### PR TITLE
Fix: support a symbolic link for JAVA_HOME

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -23,7 +23,7 @@ fun Path.hasExtension(expected: String) =
   Files.isRegularFile(this) && expected == extension
 
 fun Path.listRecursivelyAllFilesWithExtension(extension: String) =
-  Files.walk(this).use { stream -> stream.filter { it.toString().endsWith(".${extension}") }.toList() }
+  Files.walk(this, FileVisitOption.FOLLOW_LINKS).use { stream -> stream.filter { it.toString().endsWith(".${extension}") }.toList() }
 
 fun String.withPathSeparatorOf(path: Path) = replace('\\', '/').replace("/", path.fileSystem.separator)
 fun String.withZipFsSeparator() = replace('\\', '/')


### PR DESCRIPTION
Hi :wave: I think this pull request should fix this error:

```
Exception in thread "main" java.lang.IllegalArgumentException: JDK /home/rachel/tools/jdk misses mandatory jars: rt.jar
        at com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator.createPreJava9(JdkDescriptorCreator.kt:97)
        at com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator.createJdkDescriptor(JdkDescriptorCreator.kt:45)
        at com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator.createJdkDescriptor(JdkDescriptorCreator.kt:29)
        at com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator.createJdkDescriptor$default(JdkDescriptorCreator.kt:28)
        at com.jetbrains.pluginverifier.ide.IdeDescriptor$Companion.create(IdeDescriptor.kt:59)
        at com.jetbrains.pluginverifier.options.OptionsParser.createIdeDescriptor(OptionsParser.kt:66)
        at com.jetbrains.pluginverifier.tasks.checkPlugin.CheckPluginParamsBuilder.build(CheckPluginParamsBuilder.kt:38)
        at com.jetbrains.pluginverifier.tasks.checkPlugin.CheckPluginParamsBuilder.build(CheckPluginParamsBuilder.kt:23)
        at com.jetbrains.pluginverifier.PluginVerifierMain.main(PluginVerifierMain.kt:124)

(...)

> Process 'command '/home/rachel/tools/jdk1.8.0_221/bin/java'' finished with non-zero exit value 1
```

because of having a symbolic link for `JAVA_HOME`:

```
lrwxrwxrwx  1 rachel rachel        12 sep 26  2019 jdk -> jdk1.8.0_221
```

I had to change `JAVA_HOME` value by `/home/rachel/tools/jdk1.8.0_221` to make it work:

Source: https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileVisitOption.html#FOLLOW_LINKS