### PR TITLE
DocumentedProblemsPageVerifierMain: add repository and branch parameters

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPageVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPageVerifierMain.kt
@@ -12,7 +12,10 @@ package com.jetbrains.pluginverifier.filtering.documented
 object DocumentedProblemsPageVerifierMain {
   @JvmStatic
   fun main(args: Array<String>) {
-    val documentedPages = DocumentedProblemsPagesFetcher().fetchPages()
+    val repository = args[0].ifEmpty { "JetBrains/intellij-sdk-docs" }
+    val branch = args[1].ifEmpty { "master" }
+
+    val documentedPages = DocumentedProblemsPagesFetcher().fetchPages(repository, branch)
     val documentedProblemsParser = DocumentedProblemsParser(false)
     for (page in documentedPages) {
       val pageDescriptor = buildString {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPageVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPageVerifierMain.kt
@@ -12,8 +12,8 @@ package com.jetbrains.pluginverifier.filtering.documented
 object DocumentedProblemsPageVerifierMain {
   @JvmStatic
   fun main(args: Array<String>) {
-    val repository = args[0].ifEmpty { "JetBrains/intellij-sdk-docs" }
-    val branch = args[1].ifEmpty { "master" }
+    val repository = args.elementAtOrNull(0)
+    val branch = args.elementAtOrNull(1)
 
     val documentedPages = DocumentedProblemsPagesFetcher().fetchPages(repository, branch)
     val documentedProblemsParser = DocumentedProblemsParser(false)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPagesFetcher.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPagesFetcher.kt
@@ -13,12 +13,16 @@ class DocumentedProblemsPagesFetcher {
 
   private companion object {
     private val subPagePathRegex = Regex("(api_changes/api_changes_list_20..)\\.md")
+    const val DEFAULT_REPOSITORY = "JetBrains/intellij-sdk-docs"
+    const val DEFAULT_BRANCH = "master"
   }
 
-  fun fetchPages(repository: String, branch: String): List<DocumentedProblemsPage> {
-    val mainSourcePageUrl = "https://raw.githubusercontent.com/$repository/$branch/reference_guide/api_changes_list.md"
+  fun fetchPages(repository: String? = null, branch: String? = null): List<DocumentedProblemsPage> {
+    val repositoryName = repository.orEmpty().ifEmpty { DEFAULT_REPOSITORY }
+    val branchName = branch.orEmpty().ifEmpty { DEFAULT_BRANCH }
+    val mainSourcePageUrl = "https://raw.githubusercontent.com/$repositoryName/$branchName/reference_guide/api_changes_list.md"
     val mainWebPageUrl = "https://www.jetbrains.org/intellij/sdk/docs/reference_guide/api_changes_list.html"
-    val mainEditPageUrl = "https://github.com/$repository/edit/$branch/reference_guide/api_changes_list.md"
+    val mainEditPageUrl = "https://github.com/$repositoryName/edit/$branchName/reference_guide/api_changes_list.md"
 
     val mainPageBody = fetchPageBody(mainSourcePageUrl)
     val subPagesPaths = subPagePathRegex.findAll(mainPageBody).map { it.groups[1]!!.value }.toList()

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPagesFetcher.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/documented/DocumentedProblemsPagesFetcher.kt
@@ -13,18 +13,19 @@ class DocumentedProblemsPagesFetcher {
 
   private companion object {
     private val subPagePathRegex = Regex("(api_changes/api_changes_list_20..)\\.md")
-    const val MAIN_SOURCE_PAGE_URL = "https://raw.githubusercontent.com/JetBrains/intellij-sdk-docs/master/reference_guide/api_changes_list.md"
-    const val MAIN_WEB_PAGE_URL = "https://www.jetbrains.org/intellij/sdk/docs/reference_guide/api_changes_list.html"
-    const val MAIN_EDIT_PAGE_URL = "https://github.com/JetBrains/intellij-sdk-docs/edit/master/reference_guide/api_changes_list.md"
   }
 
-  fun fetchPages(): List<DocumentedProblemsPage> {
-    val mainPageBody = fetchPageBody(MAIN_SOURCE_PAGE_URL)
+  fun fetchPages(repository: String, branch: String): List<DocumentedProblemsPage> {
+    val mainSourcePageUrl = "https://raw.githubusercontent.com/$repository/$branch/reference_guide/api_changes_list.md"
+    val mainWebPageUrl = "https://www.jetbrains.org/intellij/sdk/docs/reference_guide/api_changes_list.html"
+    val mainEditPageUrl = "https://github.com/$repository/edit/$branch/reference_guide/api_changes_list.md"
+
+    val mainPageBody = fetchPageBody(mainSourcePageUrl)
     val subPagesPaths = subPagePathRegex.findAll(mainPageBody).map { it.groups[1]!!.value }.toList()
     return subPagesPaths.map { path ->
-      val sourcePageUrl = MAIN_SOURCE_PAGE_URL.substringBeforeLast("/") + "/" + path + ".md"
-      val webPageUrl = MAIN_WEB_PAGE_URL.substringBeforeLast("/") + "/" + path + ".html"
-      val editPageUrl = MAIN_EDIT_PAGE_URL.substringBeforeLast("/") + "/" + path + ".md"
+      val sourcePageUrl = mainSourcePageUrl.substringBeforeLast("/") + "/" + path + ".md"
+      val webPageUrl = mainWebPageUrl.substringBeforeLast("/") + "/" + path + ".html"
+      val editPageUrl = mainEditPageUrl.substringBeforeLast("/") + "/" + path + ".md"
       val pageBody = fetchPageBody(sourcePageUrl)
       DocumentedProblemsPage(URL(webPageUrl), URL(sourcePageUrl), URL(editPageUrl), pageBody)
     }


### PR DESCRIPTION
For the docs testing purposes, we'd like to parameterize `DocumentedProblemsPageVerifierMain` class to be able to provide repository and branch that will be used for the page verification, like:

    java -cp verifier-all.jar com.jetbrains.pluginverifier.filtering.documented.DocumentedProblemsPageVerifierMain hsz/intellij-sdk-docs dev-branch