### PR TITLE
MP-3298: support running in offline mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ Here is the full syntax of the command:
     The verifier will not verify such updates even if they are compatible with the IDE.
     File with list of excluded plugin builds (e.g. '<IDE-home>/lib/resources.jar/brokenPlugins.txt').
 
+* `-offline`
+
+    Specify this flag if the Plugin Verifier must use only locally downloaded dependencies of plugins and must avoid making HTTP requests. 
+
 * `-dump-broken-plugin-list (-d)`
 
     File to dump broken plugin ids.

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -22,6 +22,7 @@ import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
 import com.jetbrains.pluginverifier.repository.cleanup.DiskSpaceSetting
 import com.jetbrains.pluginverifier.repository.cleanup.SpaceAmount
 import com.jetbrains.pluginverifier.repository.cleanup.SpaceUnit
+import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
 import com.jetbrains.pluginverifier.repository.repositories.marketplace.MarketplaceRepository
 import com.jetbrains.pluginverifier.tasks.CommandRunner
 import com.jetbrains.pluginverifier.tasks.checkIde.CheckIdeRunner
@@ -104,7 +105,12 @@ object PluginVerifierMain {
     val runner = findTaskRunner(command)
     val outputOptions = OptionsParser.parseOutputOptions(opts)
 
-    val pluginRepository = MarketplaceRepository(URL(pluginRepositoryUrl))
+    val pluginRepository = if (opts.offlineMode) {
+      LocalPluginRepositoryFactory.createLocalPluginRepository(downloadDirectory)
+    } else {
+      MarketplaceRepository(URL(pluginRepositoryUrl))
+    }
+
     val pluginDownloadDirDiskSpaceSetting = getDiskSpaceSetting("plugin.verifier.cache.dir.max.space", 5 * 1024)
     val pluginFilesBank = PluginFilesBank.create(pluginRepository, downloadDirectory, pluginDownloadDirDiskSpaceSetting)
     val pluginDetailsProvider = PluginDetailsProviderImpl(getPluginsExtractDirectory())

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -22,6 +22,9 @@ open class CmdOpts(
   @set:Argument("team-city", alias = "tc", description = "Specify this flag if you want to print the TeamCity compatible output on stdout.")
   var needTeamCityLog: Boolean = false,
 
+  @set:Argument("offline", alias = "offline", description = "Specify this flag if the Plugin Verifier must use only locally downloaded dependencies of plugins")
+  var offlineMode: Boolean = false,
+
   @set:Argument("tc-grouping", alias = "g", description = "How to group the TeamCity presentation of the problems: either 'plugin' to group by each plugin or 'problem_type' to group by problem type")
   var teamCityGroupType: String? = null,
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -121,7 +121,7 @@ object OptionsParser {
   fun getProblemsFilters(opts: CmdOpts): List<ProblemsFilter> {
     val ignoredProblemsFilter = createIgnoredProblemsFilter(opts)
     val documentedProblemsFilter = try {
-      createDocumentedProblemsFilter()
+      if (opts.offlineMode) null else createDocumentedProblemsFilter()
     } catch (e: Exception) {
       LOG.error("Unable to read documented IntelliJ API incompatible changes. Corresponding API problems won't be ignored.", e)
       null


### PR DESCRIPTION
Added `-offline` CLI property that allows to run Plugin Verifier without internet