### PR TITLE
Keep-only-problems option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ This command is used to check IDE build against a set of plugins.
         [-tc-grouping | -g ]
         [-external-prefixes <':'-separated list>]
         [-dump-broken-plugin-list | -d]
+        [-ignored-problems | -ip <file>]
+        [-keep-only-problems | -kop <file>]
 
 `<IDE>` is either a path to local IDE installation, or an IDE pattern (see bellow in the [common options](#common-options)) 
 
@@ -292,6 +294,15 @@ Here is the full syntax of the command:
     Specifies which subsystems of IDE should be checked.
     Available options: `all` (default), `android-only`, `without-android`.
 
+* `-ignore-problems (-ip)`
+
+    A file that contains a list of problems that will be ignored in report. 
+    The file must contain lines in form `<plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>`
+
+* `-keep-only-problems (-kop)`
+
+    A file that contains patterns of problems that will be reflected in report. All other problems will be ignored.
+    The file must contain lines in form: `<problem_description_regexp_pattern>`
 
 ## Technical details
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -51,6 +51,12 @@ open class CmdOpts(
       "\tandroid-only - verify only code related to Android support.\n" +
       "\twithout-android - exclude problems related to Android support. "
   )
-  var subsystemsToCheck: String = "all"
+  var subsystemsToCheck: String = "all",
 
+  @set:Argument(
+    "keep-only-problems",
+    alias = "kop",
+    description = "Only the problems matching lines in this file will be reflected in report. The file must contain lines in form: <problem_description_regexp_pattern>"
+  )
+  var keepOnlyProblemsFile: String? = null
 )

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/KeepOnlyCondition.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/KeepOnlyCondition.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.filtering
+
+import java.util.*
+
+/**
+ * Condition to keep only matching compatibility problems:
+ * - pattern - RegExp pattern of the short description
+ */
+data class KeepOnlyCondition(
+  val pattern: Regex
+) {
+
+  companion object {
+    /**
+     * Parses [KeepOnlyCondition] from this [line], that should contain only <keep_only_pattern>
+     * Problems not matching the pattern will be ignored
+     */
+    fun parseCondition(line: String): KeepOnlyCondition {
+      val token = line.trim()
+      val parseRegexp = { s: String -> Regex(s, RegexOption.IGNORE_CASE) }
+      return KeepOnlyCondition(parseRegexp(token))
+    }
+  }
+
+  /**
+   * Serializes this [KeepOnlyCondition] to [String].
+   * It can be later deserialized via [parseCondition].
+   */
+  fun serializeCondition() = pattern.pattern
+
+  override fun equals(other: Any?) = other is KeepOnlyCondition
+    && pattern.pattern == other.pattern.pattern
+
+  override fun hashCode() = Objects.hash(pattern.pattern)
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/KeepOnlyProblemsFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/KeepOnlyProblemsFilter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.filtering
+
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+
+/**
+ * [ProblemsFilter] that keep only matched problems specified in [keepOnlyConditions]. All other problems will be ignored.
+ */
+class KeepOnlyProblemsFilter(val keepOnlyConditions: List<KeepOnlyCondition>) : ProblemsFilter {
+
+    override fun shouldReportProblem(
+        problem: CompatibilityProblem,
+        context: VerificationContext
+    ): ProblemsFilter.Result {
+        if (context !is PluginVerificationContext) {
+            return ProblemsFilter.Result.Report
+        }
+
+        val patterns = keepOnlyConditions.map { it.pattern }
+        val doKeepProblem = patterns.any {
+            problem.shortDescription.matches(it)
+        }
+        if (doKeepProblem.not()) {
+            return ProblemsFilter.Result.Ignore("the problem is ignored as " +
+                    "it's not matching any pattern for keeping problems : \"${patterns.joinToString()}\"")
+        }
+        return ProblemsFilter.Result.Report
+    }
+
+}


### PR DESCRIPTION
This option will allow to create a list of problems that we only need to report and all others will be ignored. 

This is quite useful if you only interested in finding problems related to a single plugin, class, method etc. 
E.g.: we bundling dev version of Kotlin-IDE plugin  and starting verifier versus list of plugins that depends on Kotlin. As a result, we have a ton of errors, 80% of which are not related to Kotlin. Reviewing them all requires a lot of manual work. With that option we can filter our problems by keywords right away and keep our reports clean. 
