### PR TITLE
Support multiple <content> blocks in the plugin.xml

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
@@ -28,7 +28,7 @@ public class PluginBean {
   @XmlElement(name = "is-internal") public boolean isInternal = true;
   @XmlElement(name = "depends") public List<PluginDependencyBean> dependencies = new ArrayList<>();
   @XmlElement(name = "dependencies") public PluginDependenciesBean dependenciesV2;
-  @XmlElement(name = "content") public PluginContentBean contentDependencies;
+  @XmlElement(name = "content") public List<PluginContentBean> contentDependencies = new ArrayList<>();
   @XmlElement(name = "incompatible-with") public List<String> incompatibleModules = new ArrayList<>();
   @XmlElement(name = "helpset") public List<PluginHelpSetBean> helpSets = new ArrayList<>();
   @XmlElement(name = "category") public String category;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -219,7 +219,10 @@ internal class PluginCreator private constructor(
     }
 
     if (bean.contentDependencies != null) {
-      for (dependencyBeanContent in bean.contentDependencies.modules) {
+      val modules = bean.contentDependencies.flatMap { it.modules }
+      val plugins = bean.contentDependencies.flatMap { it.plugins }
+
+      for (dependencyBeanContent in modules) {
         if (dependencyBeanContent.dependencyId != null) {
           val dependency = PluginDependencyImpl(dependencyBeanContent.dependencyId, true, false)
           //TODO: get dependencies from dependency config file
@@ -228,7 +231,7 @@ internal class PluginCreator private constructor(
         }
       }
       //TODO: is this even possible?
-      for (dependencyBeanContent in bean.contentDependencies.plugins) {
+      for (dependencyBeanContent in plugins) {
         if (dependencyBeanContent.dependencyId != null) {
           val dependency = PluginDependencyImpl(dependencyBeanContent.dependencyId, true, false)
           dependencies += dependency

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
@@ -33,6 +33,10 @@
     <depends>mandatoryDependency</depends>
     <depends>com.intellij.modules.mandatoryDependency</depends>
 
+    <xi:include href="../optionalsDir/ultimate-plugin.xml" xpointer="xpointer(/idea-plugin/*)">
+        <xi:fallback/>
+    </xi:include>
+
     <content>
         <module name="intellij.v2.module"/>
     </content>

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/intellij.v2.module-ultimate.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/intellij.v2.module-ultimate.xml
@@ -1,0 +1,5 @@
+<idea-plugin package="com.intellij.kubernetes.helm.gotpl_ultimate">
+    <extensionPoints>
+        <extensionPoint name="optionalUpdaterV2Ultimate" beanClass="com.intellij.BeanClassUltimate" dynamic="true"/>
+    </extensionPoints>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/intellij.v2.module.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/intellij.v2.module.xml
@@ -1,2 +1,5 @@
 <idea-plugin package="com.intellij.kubernetes.helm.gotpl">
+    <extensionPoints>
+        <extensionPoint name="optionalUpdaterV2" beanClass="com.intellij.BeanClass" dynamic="true"/>
+    </extensionPoints>
 </idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/optionalsDir/ultimate-plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/optionalsDir/ultimate-plugin.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <content>
+        <module name="intellij.v2.module-ultimate"/>
+    </content>
+</idea-plugin>


### PR DESCRIPTION
Such functionality is needed for Kotlin plugin:
- one <content> block we have in the main plugin.xml file
- another comes from <include> block with kotlin-ultimate part.

Corresponding functionality was supported in the IDEA core by the commit:
https://github.com/JetBrains/intellij-community/commit/0f9bf52acebf3801e5a84690bfe7b5d96ad503ed