### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/plugins-verifier-service/build.gradle
+++ b/plugins-verifier-service/build.gradle
@@ -59,11 +59,11 @@ configure(allprojects) {
   dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web") {
       dependencies {
-        implementation("org.apache.logging.log4j:log4j-to-slf4j:2.16.0") {
-          because("we need 2.16.0")
+        implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.0") {
+          because("we need 2.17.0")
         }
-        implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
-          because("we need 2.16.0")
+        implementation("org.apache.logging.log4j:log4j-api:2.17.0") {
+          because("we need 2.17.0")
         }
       }
     }


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105