### PR TITLE
Add exclude-external-build-classes-selector option

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -44,6 +44,11 @@ open class CmdOpts(
   var externalClassesPrefixes: Array<String> = arrayOf(),
 
   @set:Argument(
+    "exclude-external-build-classes-selector", alias = "ex-selector", description = "Specify this flag if the Plugin Verifier must exclude selector for classes " +
+    "used for the external build processes such as JPS classes bundled into the Kotlin plugin (`/lib/jps`).")
+  var excludeExternalBuildClassesSelector: Boolean = false,
+
+  @set:Argument(
     "subsystems-to-check",
     alias = "subsystems",
     description = "Specifies which subsystems of IDE should be checked. Available options: all (default), android-only, without-android.\n" +

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParams.kt
@@ -17,7 +17,8 @@ class CheckIdeParams(
   val verificationDescriptors: List<PluginVerificationDescriptor.IDE>,
   val problemsFilters: List<ProblemsFilter>,
   val missingCompatibleVersionsProblems: List<MissingCompatibleVersionProblem>,
-  private val ideDescriptor: IdeDescriptor
+  private val ideDescriptor: IdeDescriptor,
+  val excludeExternalBuildClassesSelector: Boolean
 ) : TaskParameters {
 
   override val presentableText

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParamsBuilder.kt
@@ -62,7 +62,8 @@ class CheckIdeParamsBuilder(
         verificationDescriptors,
         problemsFilters,
         missingCompatibleVersionsProblems,
-        ideDescriptor
+        ideDescriptor,
+        opts.excludeExternalBuildClassesSelector
       )
     }
   }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeTask.kt
@@ -23,7 +23,8 @@ class CheckIdeTask(private val parameters: CheckIdeParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          listOf(DynamicallyLoadedFilter())
+          listOf(DynamicallyLoadedFilter()),
+          excludeExternalBuildClassesSelector
         )
       }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
@@ -15,7 +15,8 @@ class CheckPluginParams(
   private val ideDescriptors: List<IdeDescriptor>,
   val problemsFilters: List<ProblemsFilter>,
   val verificationDescriptors: List<PluginVerificationDescriptor>,
-  val invalidPluginFiles: List<InvalidPluginFile>
+  val invalidPluginFiles: List<InvalidPluginFile>,
+  val excludeExternalBuildClassesSelector: Boolean
 ) : TaskParameters {
 
   override val presentableText

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -85,7 +85,8 @@ class CheckPluginParamsBuilder(
       ideDescriptors,
       problemsFilters,
       verificationDescriptors,
-      pluginsSet.invalidPluginFiles
+      pluginsSet.invalidPluginFiles,
+      opts.excludeExternalBuildClassesSelector
     )
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
@@ -32,7 +32,8 @@ class CheckPluginTask(private val parameters: CheckPluginParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          listOf(DynamicallyLoadedFilter())
+          listOf(DynamicallyLoadedFilter()),
+          excludeExternalBuildClassesSelector
         )
       }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiParams.kt
@@ -20,7 +20,8 @@ class CheckPluginApiParams(
   val baseVerificationDescriptors: List<PluginVerificationDescriptor.Plugin>,
   val newVerificationDescriptors: List<PluginVerificationDescriptor.Plugin>,
   val baseVerificationTarget: PluginVerificationTarget.Plugin,
-  val newVerificationTarget: PluginVerificationTarget.Plugin
+  val newVerificationTarget: PluginVerificationTarget.Plugin,
+  val excludeExternalBuildClassesSelector: Boolean
 ) : TaskParameters {
 
   override val presentableText

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiParamsBuilder.kt
@@ -94,7 +94,8 @@ Example: java -jar verifier.jar check-plugin-api Kotlin-old.zip Kotlin-new.zip k
             baseVerificationDescriptors,
             newVerificationDescriptors,
             baseVerificationTarget,
-            newVerificationTarget
+            newVerificationTarget,
+            opts.excludeExternalBuildClassesSelector
           )
         }
       }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPluginApi/CheckPluginApiTask.kt
@@ -25,7 +25,8 @@ class CheckPluginApiTask(private val parameters: CheckPluginApiParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          listOf(DynamicallyLoadedFilter())
+          listOf(DynamicallyLoadedFilter()),
+          excludeExternalBuildClassesSelector
         )
       }
 
@@ -34,7 +35,8 @@ class CheckPluginApiTask(private val parameters: CheckPluginApiParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          listOf(DynamicallyLoadedFilter())
+          listOf(DynamicallyLoadedFilter()),
+          excludeExternalBuildClassesSelector
         )
       }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParams.kt
@@ -21,7 +21,8 @@ class CheckTrunkApiParams(
   val releaseVerificationDescriptors: List<PluginVerificationDescriptor.IDE>,
   val trunkVerificationDescriptors: List<PluginVerificationDescriptor.IDE>,
   val releaseVerificationTarget: PluginVerificationTarget.IDE,
-  val trunkVerificationTarget: PluginVerificationTarget.IDE
+  val trunkVerificationTarget: PluginVerificationTarget.IDE,
+  val excludeExternalBuildClassesSelector: Boolean
 ) : TaskParameters {
   override val presentableText: String
     get() = buildString {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
@@ -180,7 +180,8 @@ class CheckTrunkApiParamsBuilder(
       releaseVerificationDescriptors,
       trunkVerificationDescriptors,
       releaseVerificationTarget,
-      trunkVerificationTarget
+      trunkVerificationTarget,
+      opts.excludeExternalBuildClassesSelector
     )
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiTask.kt
@@ -30,7 +30,8 @@ class CheckTrunkApiTask(private val parameters: CheckTrunkApiParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          classFilters
+          classFilters,
+          excludeExternalBuildClassesSelector
         )
       }
 
@@ -39,7 +40,8 @@ class CheckTrunkApiTask(private val parameters: CheckTrunkApiParams) : Task {
           it,
           problemsFilters,
           pluginDetailsCache,
-          classFilters
+          classFilters,
+          excludeExternalBuildClassesSelector
         )
       }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -44,7 +44,8 @@ class PluginVerifier(
   val verificationDescriptor: PluginVerificationDescriptor,
   private val problemFilters: List<ProblemsFilter>,
   private val pluginDetailsCache: PluginDetailsCache,
-  private val classFilters: List<ClassFilter>
+  private val classFilters: List<ClassFilter>,
+  private val excludeExternalBuildClassesSelector: Boolean
 ) {
 
   fun loadPluginAndVerify(): PluginVerificationResult {
@@ -284,7 +285,9 @@ class PluginVerifier(
 
   private fun selectClassesForCheck(pluginDetails: PluginDetails): Set<String> {
     val classesForCheck = hashSetOf<String>()
-    for (classesSelector in classesSelectors) {
+    val selectorsToUse =
+        if (excludeExternalBuildClassesSelector) classesSelectors.filterNot { it is ExternalBuildClassesSelector } else classesSelectors
+    for (classesSelector in selectorsToUse) {
       classesForCheck += classesSelector.getClassesForCheck(pluginDetails.pluginClassesLocations)
     }
     return classesForCheck

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
@@ -50,7 +50,8 @@ class VerificationRunner {
         verificationDescriptor,
         problemsFilters,
         pluginDetailsCache,
-        listOf(DynamicallyLoadedFilter())
+        listOf(DynamicallyLoadedFilter()),
+          false
       )
       pluginVerifier.loadPluginAndVerify()
     }

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifyPluginTask.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifyPluginTask.kt
@@ -66,7 +66,8 @@ class VerifyPluginTask(
       verificationDescriptor,
       problemsFilters,
       pluginDetailsCache,
-      listOf(DynamicallyLoadedFilter())
+      listOf(DynamicallyLoadedFilter()),
+      false
     ).loadPluginAndVerify()
   }
 


### PR DESCRIPTION
Add exclude-external-build-classes-selector option to have the ability to verify JetBrains plugins without checking external classes. It is useful for verifying of Kotlin plugin, because checking of JPS classes only create false-positives.