### PR TITLE
fleet plugins: pass descriptor file name instead of content, it's now…

### DIFF
--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPlugin.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPlugin.kt
@@ -17,7 +17,7 @@ data class FleetPlugin(
   override val description: String? = null,
   override val vendor: String? = null,
 
-  val descriptorContent: String,
+  val descriptorFileName: String,
   val files: List<PluginFile>
 ) : Plugin {
   override val changeNotes: String? = null

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginManager.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginManager.kt
@@ -102,7 +102,7 @@ class FleetPluginManager private constructor(private val extractDirectory: Path)
           description = description,
           icons = icons,
           vendor = vendor,
-          descriptorContent = serializedDescriptor,
+          descriptorFileName = DESCRIPTOR_NAME,
           files = files
         )
       }


### PR DESCRIPTION
… between files passed and only needs to be identified for signing