### PR TITLE
MP-4620: Add check to internal API usage if method call is invoking a public API but implemented in internal class

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsageProcessor.kt
@@ -5,14 +5,20 @@
 package com.jetbrains.pluginverifier.usages.internal
 
 import com.jetbrains.pluginverifier.PluginVerificationDescriptor
+import com.jetbrains.pluginverifier.results.instruction.Instruction
 import com.jetbrains.pluginverifier.results.location.Location
+import com.jetbrains.pluginverifier.results.location.toReference
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.results.reference.ClassReference
 import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.ApiUsageProcessor
 import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+import com.jetbrains.pluginverifier.verifiers.ProblemRegistrar
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.*
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
+import com.jetbrains.pluginverifier.warnings.WarningRegistrar
 import org.objectweb.asm.tree.AbstractInsnNode
 
 class InternalApiUsageProcessor(private val pluginVerificationContext: PluginVerificationContext) : ApiUsageProcessor {
@@ -21,7 +27,7 @@ class InternalApiUsageProcessor(private val pluginVerificationContext: PluginVer
     resolvedMember: ClassFileMember,
     context: VerificationContext,
     usageLocation: Location
-  ) = resolvedMember.isInternalApi(context.classResolver)
+  ): Boolean = resolvedMember.isInternalApi(context.classResolver)
     && resolvedMember.containingClassFile.classFileOrigin != usageLocation.containingClass.classFileOrigin
 
   override fun processClassReference(
@@ -46,7 +52,44 @@ class InternalApiUsageProcessor(private val pluginVerificationContext: PluginVer
   ) {
     val usageLocation = callerMethod.location
     if (isInternal(resolvedMethod, context, usageLocation)) {
-      registerInternalApiUsage(InternalMethodUsage(methodReference, resolvedMethod.location, usageLocation))
+      // Check if the method is an override, and if so check top declaration
+      val canBeOverridden = !resolvedMethod.isStatic && !resolvedMethod.isPrivate
+        && resolvedMethod.name != "<init>" && resolvedMethod.name != "<clinit>"
+
+      // Taken from MethodOverridingVerifier
+      val overriddenMethod = if(canBeOverridden) {
+        MethodResolver().resolveMethod(
+          ClassFileWithNoMethodsWrapper(resolvedMethod.containingClassFile),
+          resolvedMethod.location.toReference(),
+          if (resolvedMethod.containingClassFile.isInterface) Instruction.INVOKE_INTERFACE else Instruction.INVOKE_VIRTUAL,
+          resolvedMethod,
+          VerificationContextWithSilentProblemRegistrar(context)
+        )
+      } else {
+        null
+      }
+
+      if (overriddenMethod == null || isInternal(overriddenMethod, context, usageLocation)) {
+        registerInternalApiUsage(InternalMethodUsage(methodReference, resolvedMethod.location, usageLocation))
+      }
+    }
+  }
+
+  private class ClassFileWithNoMethodsWrapper(
+    private val classFile: ClassFile
+  ) : ClassFile by classFile {
+    override val methods: Sequence<Method> get() = emptySequence()
+  }
+
+  private class VerificationContextWithSilentProblemRegistrar(
+    private val delegate: VerificationContext
+  ) : VerificationContext by delegate {
+    override val problemRegistrar: ProblemRegistrar = object : ProblemRegistrar {
+      override fun registerProblem(problem: CompatibilityProblem) = Unit
+    }
+
+    override val warningRegistrar: WarningRegistrar = object : WarningRegistrar {
+      override fun registerCompatibilityWarning(warning: CompatibilityWarning) = Unit
     }
   }
 

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/IntermediateInternalClass.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/IntermediateInternalClass.java
@@ -1,0 +1,10 @@
+package internal.hierarchy;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public abstract class IntermediateInternalClass implements PublicInterface {
+  @Override
+  public void doWork() {
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/PublicConcreteClass.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/PublicConcreteClass.java
@@ -1,0 +1,4 @@
+package internal.hierarchy;
+
+public class PublicConcreteClass extends IntermediateInternalClass {
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/PublicInterface.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/internal/hierarchy/PublicInterface.java
@@ -1,0 +1,5 @@
+package internal.hierarchy;
+
+public interface PublicInterface {
+  void doWork();
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/IntermediateInternalClass.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/IntermediateInternalClass.java
@@ -1,0 +1,10 @@
+package internal.hierarchy;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public abstract class IntermediateInternalClass implements PublicInterface {
+  @Override
+  public void doWork() {
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/PublicConcreteClass.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/PublicConcreteClass.java
@@ -1,0 +1,4 @@
+package internal.hierarchy;
+
+public class PublicConcreteClass extends IntermediateInternalClass {
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/PublicInterface.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/internal/hierarchy/PublicInterface.java
@@ -1,0 +1,5 @@
+package internal.hierarchy;
+
+public interface PublicInterface {
+  void doWork();
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/internal/noWarning/NoWarnings.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/internal/noWarning/NoWarnings.java
@@ -1,5 +1,7 @@
 package mock.plugin.internal.noWarning;
 
+import internal.hierarchy.PublicConcreteClass;
+import internal.hierarchy.PublicInterface;
 import internal.noWarning.NonInternalOverridden;
 
 public class NoWarnings extends NonInternalOverridden {
@@ -19,6 +21,16 @@ public class NoWarnings extends NonInternalOverridden {
   public static void foo() {
     // No warning here because the someMethod() is not internal itself.
     new NonInternalOverridden().someMethod();
+  }
+
+  public static void bar() {
+    // No warning here because the doWork() is not internal itself.
+    new PublicConcreteClass().doWork();
+  }
+
+  public static void baz() {
+    // No warning here because the doWork() is not internal itself.
+    ((PublicInterface) new PublicConcreteClass()).doWork();
   }
 }
 


### PR DESCRIPTION
Proof of concept fix for https://youtrack.jetbrains.com/issue/MP-4620

The factoring is not great, but does contain a test case to show the issue