### PR TITLE
Do not accept incorrect plugin archives

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -106,6 +106,9 @@ fun Path.listFiles(): List<Path> {
   return Files.list(this).use { it.collect(Collectors.toList()) }
 }
 
+fun Path.listAllFiles() =
+  Files.walk(this).use { stream -> stream.filter { it.isFile }.map { this.relativize(it) }.toList() }
+
 fun Path.deleteQuietly(): Boolean {
   return try {
     if (this.isDirectory) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/PluginExtractor.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/PluginExtractor.kt
@@ -9,13 +9,13 @@ import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.plugin.Settings
 import com.jetbrains.plugin.structure.base.problems.PluginFileSizeIsTooLarge
 import com.jetbrains.plugin.structure.base.utils.*
-import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsMultipleFiles
-import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsUnknownFile
-import com.jetbrains.plugin.structure.intellij.problems.PluginZipIsEmpty
+import com.jetbrains.plugin.structure.intellij.problems.*
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 
 object PluginExtractor {
+  private val zipPathMatcher = FileSystems.getDefault().getPathMatcher("glob:*/lib/*.jar")
 
   fun extractPlugin(pluginFile: Path, extractDirectory: Path): ExtractorResult {
     Files.createDirectories(extractDirectory)
@@ -51,12 +51,13 @@ object PluginExtractor {
       1 -> {
         val singleFile = rootFiles[0]
         return if (singleFile.isJar()) {
-          success(singleFile, extractedPlugin)
+          fail(PluginZipContainsSingleJarInRoot(singleFile.simpleName), extractedPlugin)
         } else if (singleFile.isDirectory) {
-          if (singleFile.simpleName == "lib") {
-            success(extractedPlugin, extractedPlugin)
-          } else {
+          val allFiles = extractedPlugin.listAllFiles()
+          if (allFiles.any { zipPathMatcher.matches(it) }) {
             success(singleFile, extractedPlugin)
+          } else {
+            fail(UnexpectedPluginZipStructure(), extractedPlugin)
           }
         } else {
           fail(PluginZipContainsUnknownFile(singleFile.simpleName), extractedPlugin)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginFileErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginFileErrors.kt
@@ -27,6 +27,20 @@ class PluginZipContainsUnknownFile(private val fileName: String) : PluginFileErr
 
 }
 
+class PluginZipContainsSingleJarInRoot(private val fileName: String) : PluginFileError() {
+
+  override val message
+    get() = "Plugin zip file contains a single jar file in root '$fileName'."
+
+}
+
+class UnexpectedPluginZipStructure : PluginFileError() {
+
+  override val message
+    get() = "Unexpected plugin zip file structure. It should be <plugin_id>/lib/*.jar"
+
+}
+
 class PluginZipContainsMultipleFiles(private val fileNames: List<String>) : PluginFileError() {
 
   override val message


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/MP-4275

Right now IDE accepts only two types of plugin archives:

.jar archive
.zip archive with structure <Plugin Id>/lib/*.jar
The problem is that Marketplace accepts .zip archives that contain only .jar archive. Marketplace should only accept archives mentioned above.