### PR TITLE
Add additional checks for ij updates

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -41,12 +41,12 @@ internal class PluginCreator private constructor(
 
     private const val INTELLIJ_THEME_EXTENSION = "com.intellij.themeProvider"
 
-    private val DEFAULT_TEMPLATE_NAMES = listOf("Plugin display name here", "My Framework Support", "Template", "Demo")
-    private val PLUGIN_NAME_RESTRICTED_WORDS = listOf(
+    private val DEFAULT_TEMPLATE_NAMES = setOf("Plugin display name here", "My Framework Support", "Template", "Demo")
+    private val PLUGIN_NAME_RESTRICTED_WORDS = setOf(
       "plugin", "JetBrains", "IDEA", "PyCharm", "CLion", "AppCode", "DataGrip", "Fleet", "GoLand", "PhpStorm",
       "WebStorm", "Rider", "ReSharper", "TeamCity", "YouTrack", "RubyMine", "IntelliJ"
     )
-    private val DEFAULT_TEMPLATE_DESCRIPTIONS = listOf(
+    private val DEFAULT_TEMPLATE_DESCRIPTIONS = setOf(
       "Enter short description for your plugin here", "most HTML tags may be used", "example.com/my-framework"
     )
 
@@ -734,8 +734,8 @@ internal class PluginCreator private constructor(
       return
     }
 
-    val latinDescriptionPartLength = latinSymbolsRegex.find(textDescription)?.value?.length ?: 0
-    if (latinDescriptionPartLength < 40) {
+    val latinDescriptionPart = latinSymbolsRegex.find(textDescription)?.value
+    if (latinDescriptionPart == null) {
       registerProblem(NonLatinDescription())
     }
     val links = html.select("[href],img[src]")

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -10,19 +10,21 @@ import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 class PropertyWithDefaultValue(
   descriptorPath: String,
-  private val defaultProperty: DefaultProperty
+  private val property: DefaultProperty,
+  private val value: String
 ) : InvalidDescriptorProblem(descriptorPath) {
 
-  enum class DefaultProperty(val propertyName: String, val defaultValue: String) {
-    ID("<id>", "com.your.company.unique.plugin.id"),
-    NAME("<name>", "Plugin display name here"),
-    VENDOR("<vendor>", "YourCompany"),
-    VENDOR_URL("<vendor url>", "https://www.yourcompany.com"),
-    VENDOR_EMAIL("<vendor email>", "support@yourcompany.com")
+  enum class DefaultProperty(val propertyName: String) {
+    ID("<id>"),
+    NAME("<name>"),
+    VENDOR("<vendor>"),
+    VENDOR_URL("<vendor url>"),
+    VENDOR_EMAIL("<vendor email>"),
+    DESCRIPTION("<description>")
   }
 
   override val detailedMessage: String
-    get() = "${defaultProperty.propertyName} must not be equal to default value '${defaultProperty.defaultValue}'"
+    get() = "${property.propertyName} must not be equal to default value: '$value'"
 
   override val level
     get() = Level.ERROR
@@ -178,4 +180,31 @@ class OptionalDependencyDescriptorCycleProblem(descriptorPath: String, private v
 
   override val detailedMessage: String
     get() = "optional dependencies configuration files contain cycle: " + cyclicPath.joinToString(separator = " -> ")
+}
+
+class ShortDescription : PluginProblem() {
+
+  override val level
+    get() = Level.ERROR
+
+  override val message
+    get() = "Description is too short"
+}
+
+class NonLatinDescription : PluginProblem() {
+
+  override val level
+    get() = Level.ERROR
+
+  override val message
+    get() = "Please make sure to provide the description in English"
+}
+
+class HttpLinkInDescription(private val link: String) : PluginProblem() {
+
+  override val level
+    get() = Level.ERROR
+
+  override val message
+    get() = "All links in description should be HTTPS: $link"
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -18,25 +18,6 @@ class NoModuleDependencies(private val descriptorPath: String) : PluginProblem()
       "See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html"
 }
 
-class NonLatinDescription : PluginProblem() {
-
-  override val level
-    get() = Level.WARNING
-
-  override val message
-    get() = "Please make sure to provide the description in English"
-}
-
-class ShortDescription : PluginProblem() {
-
-  override val level
-    get() = Level.WARNING
-
-  override val message
-    get() = "Description is too short"
-}
-
-
 class DefaultChangeNotes(private val descriptorPath: String) : PluginProblem() {
 
   override val level

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdeTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdeTest.kt
@@ -274,7 +274,7 @@ class IdeTest {
                       name = "<name>Bundled</name>"
                       id = "<id>Bundled</id>"
                       vendor = "<vendor>JetBrains</vendor>"
-                      description = "<description>Short</description>"
+                      description = "<description>Long enough test description for bundled plugin without version</description>"
                       changeNotes = "<change-notes>Short</change-notes>"
                     }
                   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -387,7 +387,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
         $linksString
       ]]>
     """.trimIndent()
-    val plugin = `test invalid plugin xml`(
+    `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         description = "<description>$desc</description>"
       },

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -19,12 +19,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
-  private val DEFAULT_TEMPLATE_NAMES = listOf("Plugin display name here", "My Framework Support", "Template", "Demo")
-  private val PLUGIN_NAME_RESTRICTED_WORDS = listOf(
+  private val DEFAULT_TEMPLATE_NAMES = setOf("Plugin display name here", "My Framework Support", "Template", "Demo")
+  private val PLUGIN_NAME_RESTRICTED_WORDS = setOf(
     "plugin", "JetBrains", "IDEA", "PyCharm", "CLion", "AppCode", "DataGrip", "Fleet", "GoLand", "PhpStorm", "WebStorm",
     "Rider", "ReSharper", "TeamCity", "YouTrack", "RubyMine", "IntelliJ"
   )
-  private val DEFAULT_TEMPLATE_DESCRIPTIONS = listOf(
+  private val DEFAULT_TEMPLATE_DESCRIPTIONS = setOf(
     "Enter short description for your plugin here", "most HTML tags may be used", "example.com/my-framework"
   )
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/MP-3644

To prevent uploading a plugin with some mistakes on the uploading stage

Ideas what we can check in the library. Done in this branch:

1. The plugin name is present and different from the default value;
2. Plugin description is present and differs from the default value in both Plugin template and DevKit;
3. Plugin name does not include the word "plugin" (except those who already have it — for new plugins only);
4. Description in English is present;
5. Plugin name doesn't include: JetBrains, IDEA, PyCharm, CLion, AppCode, DataGrip, Fleet, GoLand, PhpStorm, WebStorm, Rider, ReSharper, TeamCity, YouTrack, RubyMine, IntelliJ (except those who already have it — for new plugins only);
8. Links to images in the plugin description must be with HTTPS, not HTTP;
10. And [MP-4275](https://youtrack.jetbrains.com/issue/MP-4275).

To do next:
6. Do not use the [default logo](https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/src/main/resources/META-INF/pluginIcon.svg) of the [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template) or [IntelliJ SDK Code Samples](https://github.com/JetBrains/intellij-sdk-code-samples) (if it is possible to check it);
7. Plugin logo must be provided in one size: 40px by 40px and in SVG format;
9. Also, probably validation for the case mentioned in [MP-4193](https://youtrack.jetbrains.com/issue/MP-4193);