### PR TITLE
MP-5395: Skip Kotlin default methods from internal usage check

### DIFF
--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -121,7 +121,7 @@ object KotlinMethods {
       return false
     }
 
-    val actualKotlinOwner = methodInsnNode.owner.substring(0, methodInsnNode.owner.length - "\$DefaultImpls".length)
+    val actualKotlinOwner = methodInsnNode.owner.substringBeforeLast("\$DefaultImpls")
 
     // do we want to walk the whole class hierarchy?
     val isAParent = method.containingClassFile.interfaces.any {

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -7,10 +7,10 @@ import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
 
 object KotlinMethods {
-  private const val capacity = 10
-  private val cache = object : LinkedHashMap<MethodLocation, Boolean>(10) {
+  private const val CAPACITY = 10
+  private val cache = object : LinkedHashMap<MethodLocation, Boolean>(CAPACITY) {
     override fun removeEldestEntry(eldest: MutableMap.MutableEntry<MethodLocation, Boolean>?): Boolean {
-      return size > capacity
+      return size > CAPACITY
     }
   }
 
@@ -64,6 +64,12 @@ object KotlinMethods {
   private fun Method.isKotlinMethodInvokingDefaultImpls(method: Method): Boolean {
     // filter non kotlin classes
     if (!method.containingClassFile.annotations.any { it.desc == "Lkotlin/Metadata;" }) {
+      return false
+    }
+
+    // Sanity check : if the method does not have bytecode
+    // this heuristic cannot run
+    if (instructions.isEmpty()) {
       return false
     }
 

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -123,7 +123,18 @@ object KotlinMethods {
 
     val actualKotlinOwner = methodInsnNode.owner.substringBeforeLast("\$DefaultImpls")
 
-    // do we want to walk the whole class hierarchy?
+    // Walking the whole class hierarchy is not necessary because
+    // these methods always delegate to the immediate superinterface. E.g.
+    // ```
+    // interface A {
+    //    fun foo() {}
+    // }
+    //
+    // interface B : A
+    //
+    // class C : B
+    // ```
+    // `C.foo` will have a call to `B$DefaultImpls.foo`.
     val isAParent = method.containingClassFile.interfaces.any {
       it == actualKotlinOwner
     }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -1,0 +1,69 @@
+package com.jetbrains.pluginverifier.verifiers.method
+
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.MethodInsnNode
+
+object KotlinMethods {
+
+
+  /**
+   * Identify a Kotlin default method.
+   *
+   * A kotlin default method is a method that has a default implementation, but kotlin compiles
+   * in the inhertor an override that calls the default implementation (inner) class known as
+   * `DefaultImpls`.
+   *
+   * There's only 3 interesting bytecode, the rest are labels and line numbers.
+   *
+   * ```
+   * // access flags 0x1
+   * public getPlaceholderCollector()Linternal/defaultMethod/AnInternalType;
+   *     @Lorg/jetbrains/annotations/Nullable;() // invisible
+   *     L0
+   *        LINENUMBER 5 L0
+   *        ALOAD 0
+   *        INVOKESTATIC internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI$DefaultImpls.getPlaceholderCollector (Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI;)Linternal/defaultMethod/AnInternalType;
+   *        ARETURN
+   *     L1
+   *        LOCALVARIABLE this Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI; L0 L1 0
+   *        MAXSTACK = 1
+   *        MAXLOCALS = 1
+   * ```
+   */
+  fun Method.isKotlinDefaultImpl(): Boolean {
+    val method: Method = this
+    // filter non kotlin classes
+    if (!method.containingClassFile.annotations.any { it.desc == "Lkotlin/Metadata;" }) {
+      return false
+    }
+
+    // check the only 3 opcodes in this method are
+    val realOpcodes = method.instructions.filter { it.opcode != -1 } // label or line numbers don't have opcode
+    if (realOpcodes.size != 3
+      || realOpcodes[0].opcode != Opcodes.ALOAD
+      || realOpcodes[1].opcode != Opcodes.INVOKESTATIC
+      || realOpcodes[2].opcode != Opcodes.ARETURN
+    ) {
+      return false
+    }
+
+    val methodInsnNode = realOpcodes[1] as MethodInsnNode
+    if (methodInsnNode.name != method.name || !methodInsnNode.owner.endsWith("\$DefaultImpls")) {
+      return false
+    }
+
+    val actualKotlinOwner = methodInsnNode.owner.substring(0, methodInsnNode.owner.length - "\$DefaultImpls".length)
+
+    // do we want to walk the whole class hierarchy?
+    val isAParent = method.containingClassFile.interfaces.any {
+      it == actualKotlinOwner
+    }
+    if (!isAParent) {
+      return false
+    }
+
+    // The method is a kotlin default method
+    return true
+  }
+}

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -2,33 +2,47 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
 
 object KotlinMethods {
-
 
   /**
    * Identify a Kotlin default method.
    *
    * A kotlin default method is a method that has a default implementation, but kotlin compiles
-   * in the inhertor an override that calls the default implementation (inner) class known as
+   * in the inheritor an override that calls the default implementation (inner) class known as
    * `DefaultImpls`.
    *
-   * There's only 3 interesting bytecode, the rest are labels and line numbers.
+   * Ignoring labels, line numbers, and kotlin intrinsics (to check nullness), there's only a
+   * handful of interesting bytecode that invoke the static method in `{TheInterfaceType}$DefaultImpls`
+   * loading first `this`, then loading parameters if any.
+   *
+   * E.g. with
    *
    * ```
    * // access flags 0x1
-   * public getPlaceholderCollector()Linternal/defaultMethod/AnInternalType;
-   *     @Lorg/jetbrains/annotations/Nullable;() // invisible
-   *     L0
-   *        LINENUMBER 5 L0
-   *        ALOAD 0
-   *        INVOKESTATIC internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI$DefaultImpls.getPlaceholderCollector (Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI;)Linternal/defaultMethod/AnInternalType;
-   *        ARETURN
-   *     L1
-   *        LOCALVARIABLE this Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI; L0 L1 0
-   *        MAXSTACK = 1
-   *        MAXLOCALS = 1
+   * public internalArgsReturningInternal(Linternal/defaultMethod/AnInternalType;Ljava/lang/String;)Linternal/defaultMethod/AnInternalType;
+   *    L0
+   *     ALOAD 1
+   *     LDC "anInternalType"
+   *     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
+   *     ALOAD 2
+   *     LDC "s"
+   *     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
+   *    L1
+   *     LINENUMBER 5 L1
+   *     ALOAD 0
+   *     ALOAD 1
+   *     ALOAD 2
+   *     INVOKESTATIC internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI$DefaultImpls.internalArgsReturningInternal (Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI;Linternal/defaultMethod/AnInternalType;Ljava/lang/String;)Linternal/defaultMethod/AnInternalType;
+   *     ARETURN
+   *    L2
+   *     LOCALVARIABLE this Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI; L0 L2 0
+   *     LOCALVARIABLE anInternalType Linternal/defaultMethod/AnInternalType; L0 L2 1
+   *     LOCALVARIABLE s Ljava/lang/String; L0 L2 2
+   *     MAXSTACK = 3
+   *     MAXLOCALS = 3
    * ```
    */
   fun Method.isKotlinDefaultImpl(): Boolean {
@@ -38,17 +52,50 @@ object KotlinMethods {
       return false
     }
 
-    // check the only 3 opcodes in this method are
-    val realOpcodes = method.instructions.filter { it.opcode != -1 } // label or line numbers don't have opcode
-    if (realOpcodes.size != 3
-      || realOpcodes[0].opcode != Opcodes.ALOAD
-      || realOpcodes[1].opcode != Opcodes.INVOKESTATIC
-      || realOpcodes[2].opcode != Opcodes.ARETURN
+    // skip non opcodes, and kotlin intrinsics on arguments
+    val candidateOpcodes = mutableListOf<AbstractInsnNode>()
+    var i = 0
+    do {
+      val currentInsnNode = instructions[i]
+      if (currentInsnNode.opcode == -1) {
+        continue
+      }
+
+      // Drop kotlin Intrinsics
+      if (currentInsnNode.opcode == Opcodes.ALOAD
+        && currentInsnNode.next?.opcode == Opcodes.LDC
+        && (currentInsnNode.next?.next?.opcode == Opcodes.INVOKESTATIC
+          && (currentInsnNode.next?.next as MethodInsnNode).owner == "kotlin/jvm/internal/Intrinsics")) {
+        i += 2
+        continue
+      }
+
+      candidateOpcodes.add(currentInsnNode)
+    } while (++i < instructions.size)
+
+
+    val expectedOpcodes = (
+      3 // aload this + invokestatic + (return or areturn)
+        + method.methodParameters.size // aload for each parameter
+      )
+
+    if (candidateOpcodes.size != expectedOpcodes
+      || candidateOpcodes[0].opcode != Opcodes.ALOAD // aload this
+      || candidateOpcodes.slice(1..method.methodParameters.size).any() { it.opcode != Opcodes.ALOAD } // parameters
+      || candidateOpcodes[candidateOpcodes.lastIndex - 1].opcode != Opcodes.INVOKESTATIC
+      || candidateOpcodes.last().opcode !in intArrayOf(
+        Opcodes.RETURN,
+        Opcodes.ARETURN,
+        Opcodes.DRETURN,
+        Opcodes.FRETURN,
+        Opcodes.IRETURN,
+        Opcodes.LRETURN
+      )
     ) {
       return false
     }
 
-    val methodInsnNode = realOpcodes[1] as MethodInsnNode
+    val methodInsnNode = candidateOpcodes[candidateOpcodes.lastIndex - 1] as MethodInsnNode
     if (methodInsnNode.name != method.name || !methodInsnNode.owner.endsWith("\$DefaultImpls")) {
       return false
     }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
@@ -6,7 +6,7 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
-import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultMethod
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
@@ -14,7 +14,7 @@ import org.objectweb.asm.Type
 
 class MethodArgumentTypesVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
-    if (method.isKotlinDefaultImpl()) {
+    if (method.isKotlinDefaultMethod()) {
       return
     }
 

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
@@ -6,6 +6,7 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
@@ -13,6 +14,10 @@ import org.objectweb.asm.Type
 
 class MethodArgumentTypesVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
+    if (method.isKotlinDefaultImpl()) {
+      return
+    }
+
     val methodType = Type.getType(method.descriptor)
     val argumentTypes = methodType.argumentTypes
     for (type in argumentTypes) {

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
@@ -6,13 +6,13 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
-import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultMethod
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
 
 class MethodLocalVarsVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
-    if (method.isKotlinDefaultImpl()) {
+    if (method.isKotlinDefaultMethod()) {
       return
     }
 

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
@@ -6,11 +6,16 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
 
 class MethodLocalVarsVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
+    if (method.isKotlinDefaultImpl()) {
+      return
+    }
+
     for (variable in method.localVariables) {
       val className = variable.desc.extractClassNameFromDescriptor() ?: continue
       context.classResolver.resolveClassChecked(className, method, context)

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodReturnTypeVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodReturnTypeVerifier.kt
@@ -6,12 +6,17 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
 import org.objectweb.asm.Type
 
 class MethodReturnTypeVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
+    if (method.isKotlinDefaultImpl()) {
+      return
+    }
+
     val methodType = Type.getType(method.descriptor)
     val className = methodType.returnType.descriptor.extractClassNameFromDescriptor() ?: return
     context.classResolver.resolveClassChecked(className, method, context)

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodReturnTypeVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodReturnTypeVerifier.kt
@@ -6,14 +6,14 @@ package com.jetbrains.pluginverifier.verifiers.method
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.extractClassNameFromDescriptor
-import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultImpl
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultMethod
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassChecked
 import org.objectweb.asm.Type
 
 class MethodReturnTypeVerifier : MethodVerifier {
   override fun verify(method: Method, context: VerificationContext) {
-    if (method.isKotlinDefaultImpl()) {
+    if (method.isKotlinDefaultMethod()) {
       return
     }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -60,12 +60,15 @@ class PluginVerifier(
               .mapTo(hashSetOf()) { PluginStructureError(it) }
           )
         }
+
         is PluginDetailsCache.Result.FileNotFound -> {
           PluginVerificationResult.NotFound(verificationDescriptor.checkedPlugin, verificationDescriptor.toTarget(), cacheEntry.reason)
         }
+
         is PluginDetailsCache.Result.Failed -> {
           PluginVerificationResult.FailedToDownload(verificationDescriptor.checkedPlugin, verificationDescriptor.toTarget(), cacheEntry.reason)
         }
+
         is PluginDetailsCache.Result.Provided -> {
           verify(cacheEntry.pluginDetails)
         }
@@ -253,9 +256,13 @@ class PluginVerifier(
       }
     }
 
-    val packageNotFoundProblems = packageToMissingProblems.map { (packageName, missingClasses) ->
-      PackageNotFoundProblem(packageName, missingClasses)
-    }
+    // Kotlin package are supposed to be part of the platform
+    val kotlinPackage = "kotlin\\b(\\..+)?".toRegex()
+    val packageNotFoundProblems = packageToMissingProblems
+      .filter { !it.key.matches(kotlinPackage) }
+      .map { (packageName, missingClasses) ->
+        PackageNotFoundProblem(packageName, missingClasses)
+      }
 
     //Retain all individual [ClassNotFoundProblem]s.
     for (problem in classNotFoundProblems) {
@@ -286,7 +293,7 @@ class PluginVerifier(
   private fun selectClassesForCheck(pluginDetails: PluginDetails): Set<String> {
     val classesForCheck = hashSetOf<String>()
     val selectorsToUse =
-        if (excludeExternalBuildClassesSelector) classesSelectors.filterNot { it is ExternalBuildClassesSelector } else classesSelectors
+      if (excludeExternalBuildClassesSelector) classesSelectors.filterNot { it is ExternalBuildClassesSelector } else classesSelectors
     for (classesSelector in selectorsToUse) {
       classesForCheck += classesSelector.getClassesForCheck(pluginDetails.pluginClassesLocations)
     }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -257,9 +257,7 @@ class PluginVerifier(
     }
 
     // Kotlin package are supposed to be part of the platform
-    val kotlinPackage = "kotlin\\b(\\..+)?".toRegex()
     val packageNotFoundProblems = packageToMissingProblems
-      .filter { !it.key.matches(kotlinPackage) }
       .map { (packageName, missingClasses) ->
         PackageNotFoundProblem(packageName, missingClasses)
       }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/AnInternalType.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/AnInternalType.kt
@@ -1,0 +1,6 @@
+package internal.defaultMethod
+
+import org.jetbrains.annotations.ApiStatus.Internal
+
+@Internal
+interface AnInternalType

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -4,5 +4,7 @@ interface InterfaceWithDefaultMethodUsingInternalAPI {
 
   val id: String
 
-  fun getPlaceholderCollector() : AnInternalType? = null
+  fun returningInternal() : AnInternalType? = null
+  fun internalArgsReturningInternal(anInternalType: AnInternalType, s: String) : AnInternalType? = null
+  fun internalArgsReturningVoid(anInternalType: AnInternalType, s: String) {}
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,0 +1,8 @@
+package internal.defaultMethod
+
+interface InterfaceWithDefaultMethodUsingInternalAPI {
+
+  val id: String
+
+  fun getPlaceholderCollector() : AnInternalType? = null
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,6 +1,6 @@
 package internal.defaultMethod
 
-interface InterfaceWithDefaultMethodUsingInternalAPI {
+interface InterfaceWithDefaultMethodUsingInternalAPI : TopInterfaceWithDefaultMethodUsingInternalAPI {
 
   val id: String
 

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/TopInterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/internal/defaultMethod/TopInterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,0 +1,5 @@
+package internal.defaultMethod
+
+interface TopInterfaceWithDefaultMethodUsingInternalAPI {
+  fun topInternal(): AnInternalType? = object: AnInternalType {}
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/AnInternalType.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/AnInternalType.kt
@@ -1,0 +1,6 @@
+package internal.defaultMethod
+
+import org.jetbrains.annotations.ApiStatus.Internal
+
+@Internal
+interface AnInternalType

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -4,5 +4,7 @@ interface InterfaceWithDefaultMethodUsingInternalAPI {
 
   val id: String
 
-  fun getPlaceholderCollector() : AnInternalType? = null
+  fun returningInternal() : AnInternalType? = null
+  fun internalArgsReturningInternal(anInternalType: AnInternalType, s: String) : AnInternalType? = null
+  fun internalArgsReturningVoid(anInternalType: AnInternalType, s: String) {}
 }

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,0 +1,8 @@
+package internal.defaultMethod
+
+interface InterfaceWithDefaultMethodUsingInternalAPI {
+
+  val id: String
+
+  fun getPlaceholderCollector() : AnInternalType? = null
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,7 +1,6 @@
 package internal.defaultMethod
 
-interface InterfaceWithDefaultMethodUsingInternalAPI {
-
+interface InterfaceWithDefaultMethodUsingInternalAPI : TopInterfaceWithDefaultMethodUsingInternalAPI {
   val id: String
 
   fun returningInternal() : AnInternalType? = null

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/TopInterfaceWithDefaultMethodUsingInternalAPI.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/internal/defaultMethod/TopInterfaceWithDefaultMethodUsingInternalAPI.kt
@@ -1,0 +1,5 @@
+package internal.defaultMethod
+
+interface TopInterfaceWithDefaultMethodUsingInternalAPI {
+  fun topInternal(): AnInternalType? = object: AnInternalType {}
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NoInternalTypeUsage.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NoInternalTypeUsage.kt
@@ -2,7 +2,7 @@ package mock.plugin.internal.defaultMethod
 
 import internal.defaultMethod.InterfaceWithDefaultMethodUsingInternalAPI
 
-class NotInternalTypeUsage : InterfaceWithDefaultMethodUsingInternalAPI {
+class NoInternalTypeUsage : InterfaceWithDefaultMethodUsingInternalAPI {
   override val id: String = ""
 
   // as plugin developer, do not override the default implementation of getPlaceholderCollector()

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NotInternalTypeUsage.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NotInternalTypeUsage.kt
@@ -7,4 +7,6 @@ class NotInternalTypeUsage : InterfaceWithDefaultMethodUsingInternalAPI {
 
   // as plugin developer, do not override the default implementation of getPlaceholderCollector()
   // as it does use an internal type
+
+  fun zeroInstructionsMethod() {}
 }

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NotInternalTypeUsage.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/internal/defaultMethod/NotInternalTypeUsage.kt
@@ -1,0 +1,10 @@
+package mock.plugin.internal.defaultMethod
+
+import internal.defaultMethod.InterfaceWithDefaultMethodUsingInternalAPI
+
+class NotInternalTypeUsage : InterfaceWithDefaultMethodUsingInternalAPI {
+  override val id: String = ""
+
+  // as plugin developer, do not override the default implementation of getPlaceholderCollector()
+  // as it does use an internal type
+}


### PR DESCRIPTION
Kotlin default methods work differently than JVM default methods, as the compiler is generation the default implementation in an inner class `DefaultImpls`, and the kotlin compiler will generate the method in the implementor, even if the actual code doesn't use it.

This PR addresses that by identifying Kotlin default methods in implementation and skip from analyzing these methods for internal types.

Three verifiers had to be patched

- method arguments
- method local vars
- return type

Reference : [MP-5395](https://youtrack.jetbrains.com/issue/MP-5395/Reports-internal-usage-when-extending-an-interface-with-default-method-having-internal-type)

------------


### MP-5395 description :

Take this interface from IntelliJ, where `getPlaceholderCollector` uses the internal type `CodeVisionPlaceholderCollector`

```kotlin
@ApiStatus.Experimental
interface CodeVisionProvider<T> {
  fun precomputeOnUiThread(editor: Editor): T
  fun getPlaceholderCollector(editor: Editor, psiFile: PsiFile?) : CodeVisionPlaceholderCollector? = null
  @JvmDefault
  fun preparePreview(editor: Editor, file: PsiFile) {  }
  // other functions / vals
}
```

And implement other methods but not `getPlaceholderCollector` :
```kotlin
class ReproducerCodeVisionProvider : CodeVisionProvider<Unit> {
    override val defaultAnchor: CodeVisionAnchorKind = CodeVisionAnchorKind.Top
    override val id: String = "reporducer.setting.id"
    override val name: String = "Dummy"
    override val relativeOrderings: List<CodeVisionRelativeOrdering> = emptyList()

    override fun precomputeOnUiThread(editor: Editor) {
        // no-op
    }

    override fun preparePreview(editor: Editor, file: PsiFile) {
        // something useful
    }
}
```

Now the verifier is failing because it sees in the generated bytecode of `ReproducerCodeVisionProvider` a reference to `CodeVisionPlaceholderCollector`. 

```text
Internal API usages (1): 
    #Internal interface com.intellij.codeInsight.codeVision.CodeVisionPlaceholderCollector reference
        Internal interface com.intellij.codeInsight.codeVision.CodeVisionPlaceholderCollector is referenced in boom.ReproducerCodeVisionProvider.getPlaceholderCollector(Editor, PsiFile) : CodeVisionPlaceholderCollector. This interface is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the class is not supposed to be used in client code.
```


And indeed looking at the bytecode we can see how kotlin is handling the default method: 

```text
  // access flags 0x1
  public getPlaceholderCollector(Lcom/intellij/openapi/editor/Editor;Lcom/intellij/psi/PsiFile;)Lcom/intellij/codeInsight/codeVision/CodeVisionPlaceholderCollector;
  @Lorg/jetbrains/annotations/Nullable;() // invisible
```

Which turns out to be calling the default.
```text
    INVOKESTATIC com/intellij/codeInsight/codeVision/CodeVisionProvider$DefaultImpls.getPlaceholderCollector (Lcom/intellij/codeInsight/codeVision/CodeVisionProvider;Lcom/intellij/openapi/editor/Editor;Lcom/intellij/psi/PsiFile;)Lcom/intellij/codeInsight/codeVision/CodeVisionPlaceholderCollector;
```

And unfortunately implementing this interface in Java is not possible either because it's not annotated by `@JvmDefault`.

----

The project is targeting Kotlin 1.6 (IJ 222), and it is compiled using Kotlin compiler 1.8.20.

