### PR TITLE
MP-4313: Add support for VarHandle as well

### DIFF
--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodResolver.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodResolver.kt
@@ -319,7 +319,8 @@ private class MethodResolveImpl(
   private fun isSignaturePolymorphic(methodNode: Method): Boolean =
     ("java/lang/invoke/MethodHandle" == methodNode.containingClassFile.name
       || "java/lang/invoke/VarHandle" == methodNode.containingClassFile.name)
-      && "([Ljava/lang/Object;)Ljava/lang/Object;" == methodNode.descriptor
+      && ("([Ljava/lang/Object;)Ljava/lang/Object;" == methodNode.descriptor
+      || "([Ljava/lang/Object;)Z" == methodNode.descriptor)
       && methodNode.isVararg
       && methodNode.isNative
 

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodResolver.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodResolver.kt
@@ -309,6 +309,7 @@ private class MethodResolveImpl(
   /**
    * A method is signature polymorphic if all of the following are true:
    * - It is declared in the java.lang.invoke.MethodHandle class.
+   *   or it is declared in the java.lang.invoke.VarHandle class.
    * - It has a single formal parameter of type Object[].
    * - It has a return type of Object.
    * - It has the ACC_VARARGS and ACC_NATIVE flags set.
@@ -316,7 +317,8 @@ private class MethodResolveImpl(
    * In Java SE 8, the only signature polymorphic methods are the invoke and invokeExact methods of the class java.lang.invoke.MethodHandle.
    */
   private fun isSignaturePolymorphic(methodNode: Method): Boolean =
-    "java/lang/invoke/MethodHandle" == methodNode.containingClassFile.name
+    ("java/lang/invoke/MethodHandle" == methodNode.containingClassFile.name
+      || "java/lang/invoke/VarHandle" == methodNode.containingClassFile.name)
       && "([Ljava/lang/Object;)Ljava/lang/Object;" == methodNode.descriptor
       && methodNode.isVararg
       && methodNode.isNative

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/NoErrorOnIndy.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/NoErrorOnIndy.java
@@ -6,23 +6,39 @@ import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.util.List;
 
-class NoErrorOnIndy {
+public class NoErrorOnIndy {
+  public static void main(String... args) throws Throwable {
+    new NoErrorOnIndy().varHandle();
+    new NoErrorOnIndy().methodHandle();
+  }
 
   public void varHandle() {
     SomeClass someClass = new SomeClass();
-    // LINENUMBER 12 L1
+    // LINENUMBER 22 L2
     // GETSTATIC mock/plugin/invokeDynamic/NoErrorOnIndy.someClass_list_VH : Ljava/lang/invoke/VarHandle;
     // ALOAD 1
     // INVOKEVIRTUAL java/lang/invoke/VarHandle.get (Lmock/plugin/invokeDynamic/SomeClass;)Ljava/util/List;
     // ASTORE 2
     var list = (List<String>) someClass_list_VH.get(someClass);
 
+    List<String> newList = List.of("1", "2", "3");
+
+    // LINENUMBER 33 L3
+    // GETSTATIC mock/plugin/invokeDynamic/NoErrorOnIndy.someClass_list_VH : Ljava/lang/invoke/VarHandle;
+    // ALOAD 1
+    // ALOAD 2
+    // ALOAD 3
+    // INVOKEVIRTUAL java/lang/invoke/VarHandle.compareAndSet (Lmock/plugin/invokeDynamic/SomeClass;Ljava/util/List;Ljava/util/List;)Z
+    // ISTORE 4
+    boolean wasSet = someClass_list_VH.compareAndSet(someClass, list, newList);
+
+    System.out.println(wasSet);
     System.out.println(list);
   }
 
   public void methodHandle() throws Throwable {
     SomeClass someClass = new SomeClass();
-    // LINENUMBER 23 L0
+    // LINENUMBER 46 L0
     // GETSTATIC mock/plugin/invokeDynamic/NoErrorOnIndy.someClass_getList_MH : Ljava/lang/invoke/MethodHandle;
     // ALOAD 1
     // INVOKEVIRTUAL java/lang/invoke/MethodHandle.invokeExact (Lmock/plugin/invokeDynamic/SomeClass;)Ljava/util/List;

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/NoErrorOnIndy.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/NoErrorOnIndy.java
@@ -1,0 +1,67 @@
+package mock.plugin.invokeDynamic;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.List;
+
+class NoErrorOnIndy {
+
+  public void varHandle() {
+    SomeClass someClass = new SomeClass();
+    // LINENUMBER 12 L1
+    // GETSTATIC mock/plugin/invokeDynamic/NoErrorOnIndy.someClass_list_VH : Ljava/lang/invoke/VarHandle;
+    // ALOAD 1
+    // INVOKEVIRTUAL java/lang/invoke/VarHandle.get (Lmock/plugin/invokeDynamic/SomeClass;)Ljava/util/List;
+    // ASTORE 2
+    var list = (List<String>) someClass_list_VH.get(someClass);
+
+    System.out.println(list);
+  }
+
+  public void methodHandle() throws Throwable {
+    SomeClass someClass = new SomeClass();
+    // LINENUMBER 23 L0
+    // GETSTATIC mock/plugin/invokeDynamic/NoErrorOnIndy.someClass_getList_MH : Ljava/lang/invoke/MethodHandle;
+    // ALOAD 1
+    // INVOKEVIRTUAL java/lang/invoke/MethodHandle.invokeExact (Lmock/plugin/invokeDynamic/SomeClass;)Ljava/util/List;
+    // ASTORE 2
+    var list = (List<String>) someClass_getList_MH.invokeExact(someClass);
+
+    System.out.println(list);
+  }
+
+
+  private static final MethodHandle someClass_getList_MH;
+  static {
+    try {
+      someClass_getList_MH = MethodHandles.privateLookupIn(
+          SomeClass.class,
+          MethodHandles.lookup()
+        ).findVirtual(
+          SomeClass.class,
+          "getList",
+          MethodType.methodType(List.class)
+        );
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static final VarHandle someClass_list_VH;
+  static {
+    try {
+      someClass_list_VH = MethodHandles.privateLookupIn(
+          SomeClass.class,
+          MethodHandles.lookup()
+        ).findVarHandle(
+          SomeClass.class,
+          "list",
+          List.class
+        );
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/SomeClass.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/SomeClass.java
@@ -3,7 +3,7 @@ package mock.plugin.invokeDynamic;
 import java.util.List;
 
 public class SomeClass {
-    private final List<String> list = List.of("a", "b", "c");
+    private List<String> list = List.of("a", "b", "c");
 
     private List<String> getList() {
         return list;

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/SomeClass.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/invokeDynamic/SomeClass.java
@@ -1,0 +1,11 @@
+package mock.plugin.invokeDynamic;
+
+import java.util.List;
+
+public class SomeClass {
+    private final List<String> list = List.of("a", "b", "c");
+
+    private List<String> getList() {
+        return list;
+    }
+}


### PR DESCRIPTION
Add support for `VarHandle` which allows to access fields using

Ref: [MP-4313](https://youtrack.jetbrains.com/issue/MP-4313/False-positive-runPluginVerifier-task-report-compatibility-problem-when-using-VarHandle-This-can-lead-to-NoSuchMethodError)
Ref: https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html



----

### Excerpt of MP-4313


So my plugins targets JDK11+ based IntelliJs. For some reasons I had to access a private variable in a class that I don't own. So I just used a `VarHandle`, this works fine in reality.

However I was surprised the plugin verifier reported the `VarHandle` use as incompatible because the _`invokevirtual` bytecode references an unresolved method that could lead to **NoSuchMethodError** exception at runtime_ (see log below).

```
...
Compatibility problems (1): 
    #Invocation of unresolved method java.lang.invoke.VarHandle.get(LeftTabbedPane) : List
        Method x.x.x.LeftTabbedPane.adjustTabLabelWidth() : void contains an *invokevirtual* instruction referencing an unresolved method java.lang.invoke.VarHandle.get(x.x.x.LeftTabbedPane) : java.util.List. This can lead to **NoSuchMethodError** exception at runtime.

...

2022-02-24T16:31:22 [main] INFO  verification - Finished 1 of 2 verifications (in 9.0 s): IC-213.6777.52 against plugin:0.2.7-eap: 1 compatibility problem. 1 usage of deprecated API. 136 usages of experimental API
2022-02-24T16:31:22 [main] INFO  verification - Finished 2 of 2 verifications (in 9.3 s): IC-221.4165.146 against plugin:0.2.7-eap: 1 compatibility problem. 1 usage of scheduled for removal API and 9 usages of deprecated API. 21 usages of experimental API. 4 usages of internal API
```

It fails for both IJ 2021.3.2 and the next 221 EAP (third EAP).
This is similar to MP-4266, but this happens for both Java and Kotlin code that use the `VarHandle`.
Fortunately there's a simple workaround, just use the old reflection API instead of `VarHandle` & co.

Reproducer, just add this code in a plugin code base and run the verifier.

Somewhere in `src/main/java`

```java
public class A {
    private List<String> list = new ArrayList<>();
}
```

Somewhere in `src/main/kotlin`

```kotlin
import java.lang.invoke.MethodHandles
import java.lang.invoke.VarHandle

class ConsumerOfA {
    fun consume() {
        val a = A()

        val list1 = a_VH.get(a) as java.util.List<*>
        val list2 = a_VH.get(a) as List<*>
        println(list1)
        println(list2)
    }

    companion object {
        val a_VH: VarHandle = MethodHandles.privateLookupIn(A::class.java, MethodHandles.lookup())
            .findVarHandle(A::class.java, "list", List::class.java)
    }
}
```

Or the same variant in Java as well

```java
import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;
import java.util.List;

public class ConsumerOfA2 {
    private static VarHandle aVH;

    static {
        try {
            aVH = MethodHandles.privateLookupIn(A.class, MethodHandles.lookup())
                               .findVarHandle(A.class, "list", List.class);
        } catch (NoSuchFieldException | IllegalAccessException e) {
            throw new RuntimeException(e);
        }
    }

    public void consume() {
        List<String> list = (List<String>) aVH.get(new A());
        System.out.println(list);
    }
}
```

Both `VarHandle::get` methods will be reported as compatibility problems with this message `This can lead to **NoSuchMethodError** exception at runtime.` even though the code is wrapped within a try-catch block. Could this be due to the late resolution of class constants ([JEP-309](http://openjdk.java.net/jeps/309)) ? 