### PR TITLE
Shared catalog for common cross-project dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,10 @@
+[versions]
+kotlin = "1.8.21"
+
+[libraries]
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.8.21"
 
+logback-classic = "1.4.7"
 slf4j-api = "2.0.7"
 
 [libraries]
@@ -8,6 +9,7 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 
+logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,11 +2,13 @@
 kotlin = "1.8.21"
 
 jackson-module-kotlin = "2.14.2"
+jsoup = "1.16.1"
 logback-classic = "1.4.7"
 slf4j-api = "2.0.7"
 
 [libraries]
 jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
+<jsoup> = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,14 @@
 [versions]
 kotlin = "1.8.21"
 
+slf4j-api = "2.0.7"
+
 [libraries]
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
+
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,15 @@
 [versions]
 kotlin = "1.8.21"
 
+jackson-module-kotlin = "2.14.2"
 logback-classic = "1.4.7"
 slf4j-api = "2.0.7"
 
 [libraries]
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
-
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   implementation("org.jetbrains.intellij.plugins:verifier-core:$structureVersion")
 
   implementation(libs.gson)
-  implementation(libs.slf4j.api)
+  implementation(sharedLibs.slf4j.api)
   implementation(libs.commons.io)
 
   testImplementation(libs.junit)

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  alias(sharedLibs.plugins.kotlin.jvm)
   `maven-publish`
 }
 
@@ -24,7 +24,7 @@ allprojects {
   }
 
   dependencies {
-    implementation(rootProject.libs.kotlin.stdlib)
+    implementation(rootProject.sharedLibs.kotlin.stdlib)
   }
 
   java {

--- a/intellij-feature-extractor/gradle/libs.versions.toml
+++ b/intellij-feature-extractor/gradle/libs.versions.toml
@@ -2,12 +2,10 @@
 commons-io = "2.10.0"
 gson = "2.10.1"
 junit = "4.13.2"
-slf4j-api = "2.0.7"
 
 [libraries]
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 
 [plugins]

--- a/intellij-feature-extractor/gradle/libs.versions.toml
+++ b/intellij-feature-extractor/gradle/libs.versions.toml
@@ -2,15 +2,12 @@
 commons-io = "2.10.0"
 gson = "2.10.1"
 junit = "4.13.2"
-kotlin = "1.8.21"
 slf4j-api = "2.0.7"
 
 [libraries]
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/intellij-feature-extractor/settings.gradle.kts
+++ b/intellij-feature-extractor/settings.gradle.kts
@@ -1,2 +1,10 @@
 rootProject.name = "intellij-feature-extractor"
 include("test-classes")
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("sharedLibs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -35,9 +35,9 @@ allprojects {
     mavenCentral()
   }
   dependencies {
-    implementation((rootProject.libs.kotlin.stdlib.jdk8))
-    implementation((rootProject.libs.jackson.module.kotlin))
-    implementation((rootProject.libs.kotlin.reflect))
+    implementation(rootProject.libs.kotlin.stdlib.jdk8)
+    implementation(rootProject.libs.jackson.module.kotlin)
+    implementation(rootProject.libs.kotlin.reflect)
   }
 
   val sourcesJar by tasks.registering(Jar::class) {

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -34,7 +34,7 @@ allprojects {
   }
   dependencies {
     implementation(rootProject.sharedLibs.kotlin.stdlib.jdk8)
-    implementation(rootProject.libs.jackson.module.kotlin)
+    implementation(rootProject.sharedLibs.jackson.module.kotlin)
     implementation(rootProject.sharedLibs.kotlin.reflect)
   }
 

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -3,11 +3,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   `maven-publish`
   signing
-  id("org.jetbrains.kotlin.jvm") version "1.8.21"
+  alias(sharedLibs.plugins.kotlin.jvm)
   id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
-
-val kotlin_version = "1.8.21"
 
 var intellijPluginStructureVersion = "dev"
 if (project.hasProperty("structureVersion")) {
@@ -35,9 +33,9 @@ allprojects {
     mavenCentral()
   }
   dependencies {
-    implementation(rootProject.libs.kotlin.stdlib.jdk8)
+    implementation(rootProject.sharedLibs.kotlin.stdlib.jdk8)
     implementation(rootProject.libs.jackson.module.kotlin)
-    implementation(rootProject.libs.kotlin.reflect)
+    implementation(rootProject.sharedLibs.kotlin.reflect)
   }
 
   val sourcesJar by tasks.registering(Jar::class) {

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 platform = "213.7172.25"
 jetbrains-annotations = "24.0.1"
 
-kotlin = "1.8.20"
-
 asm = "9.5"
 commons-compress = "1.23.0"
 commons-io = "2.10.0"
@@ -38,8 +36,6 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
-kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 platform-jps-model-core = { group = "com.jetbrains.intellij.platform", name = "jps-model", version.ref = "platform" }
 platform-jps-model-impl = { group = "com.jetbrains.intellij.platform", name = "jps-model-impl", version.ref = "platform" }

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ commons-compress = "1.23.0"
 commons-io = "2.10.0"
 evo-inflector = "1.3"
 guava = "31.1-jre"
-jackson-module-kotlin = "2.14.2"
 jaxb = "2.3.1"
 jdom = "2.0.6.1"
 jimfs = "1.2"
@@ -26,7 +25,6 @@ commons-compress = { group = "org.apache.commons", name = "commons-compress", ve
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 evo-inflector = { group = "org.atteo", name = "evo-inflector", version.ref = "evo-inflector" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
 jaxb-api = { group = "javax.xml.bind", name = "jaxb-api", version.ref = "jaxb" }
 jaxb-runtime = { group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb" }
 jdom = { group = "org.jdom", name = "jdom2", version.ref = "jdom" }

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ guava = "31.1-jre"
 jaxb = "2.3.1"
 jdom = "2.0.6.1"
 jimfs = "1.2"
-jsoup = "1.15.4"
 junit = "4.13.2"
 semver4j = "3.1.0"
 xz = "1.9"
@@ -30,7 +29,6 @@ jaxb-runtime = { group = "org.glassfish.jaxb", name = "jaxb-runtime", version.re
 jdom = { group = "org.jdom", name = "jdom2", version.ref = "jdom" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }
-jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 platform-jps-model-core = { group = "com.jetbrains.intellij.platform", name = "jps-model", version.ref = "platform" }
 platform-jps-model-impl = { group = "com.jetbrains.intellij.platform", name = "jps-model-impl", version.ref = "platform" }

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ jsoup = "1.15.4"
 junit = "4.13.2"
 logback-classic = "1.4.6"
 semver4j = "3.1.0"
-slf4j-api = "2.0.7"
 xz = "1.9"
 
 [libraries]
@@ -42,5 +41,4 @@ platform-jps-model-impl = { group = "com.jetbrains.intellij.platform", name = "j
 platform-jps-model-serialization = { group = "com.jetbrains.intellij.platform", name = "jps-model-serialization", version.ref = "platform" }
 platform-util = { group = "com.jetbrains.intellij.platform", name = "util", version.ref = "platform" }
 semver4j = { group = "com.vdurmont", name = "semver4j", version.ref = "semver4j" }
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ jdom = "2.0.6.1"
 jimfs = "1.2"
 jsoup = "1.15.4"
 junit = "4.13.2"
-logback-classic = "1.4.6"
 semver4j = "3.1.0"
 xz = "1.9"
 
@@ -35,7 +34,6 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 platform-jps-model-core = { group = "com.jetbrains.intellij.platform", name = "jps-model", version.ref = "platform" }
 platform-jps-model-impl = { group = "com.jetbrains.intellij.platform", name = "jps-model-impl", version.ref = "platform" }
 platform-jps-model-serialization = { group = "com.jetbrains.intellij.platform", name = "jps-model-serialization", version.ref = "platform" }

--- a/intellij-plugin-structure/settings.gradle.kts
+++ b/intellij-plugin-structure/settings.gradle.kts
@@ -12,3 +12,11 @@ include("structure-toolbox")
 include("structure-ide")
 include("structure-ide-classes")
 include("tests")
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("sharedLibs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-base/build.gradle.kts
+++ b/intellij-plugin-structure/structure-base/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
   api(libs.jetbrains.annotations)
-  api(libs.slf4j.api)
+  api(sharedLibs.slf4j.api)
 
   api(libs.commons.io)
 

--- a/intellij-plugin-structure/structure-intellij/build.gradle.kts
+++ b/intellij-plugin-structure/structure-intellij/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
   api(project(":structure-base"))
   api(libs.jdom)
 
-  implementation(libs.jsoup)
+  implementation(sharedLibs.jsoup)
   implementation(libs.jaxb.api)
   implementation(libs.jaxb.runtime)
 }

--- a/intellij-plugin-structure/tests/build.gradle.kts
+++ b/intellij-plugin-structure/tests/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   testImplementation(project(":structure-edu"))
   testImplementation(project(":structure-toolbox"))
   testImplementation(libs.junit)
-  testImplementation(libs.jackson.module.kotlin)
+  testImplementation(sharedLibs.jackson.module.kotlin)
   testImplementation(libs.jimfs)
   testRuntimeOnly(sharedLibs.logback.classic)
 }

--- a/intellij-plugin-structure/tests/build.gradle.kts
+++ b/intellij-plugin-structure/tests/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.jackson.module.kotlin)
   testImplementation(libs.jimfs)
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(sharedLibs.logback.classic)
 }

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -53,7 +53,7 @@ allprojects {
 
     testImplementation(rootProject.libs.junit)
 
-    implementation(rootProject.libs.slf4j.api)
+    implementation(rootProject.sharedLibs.slf4j.api)
     implementation(rootProject.libs.bouncycastle.pkix)
 
     implementation(rootProject.libs.jetbrains.annotations)

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   `maven-publish`
-  alias(libs.plugins.kotlin.jvm)
+  alias(sharedLibs.plugins.kotlin.jvm)
 }
 
 val projectVersion: String by extra {
@@ -45,8 +45,8 @@ allprojects {
 
   dependencies {
 
-    implementation(rootProject.libs.kotlin.stdlib.jdk8)
-    implementation(rootProject.libs.kotlin.reflect)
+    implementation(rootProject.sharedLibs.kotlin.stdlib.jdk8)
+    implementation(rootProject.sharedLibs.kotlin.reflect)
     implementation(rootProject.libs.kotson)
 
     implementation("org.jetbrains.intellij.plugins:structure-intellij:$intellijStructureVersion")

--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ jsoup = "1.16.1"
 junit = "4.13.2"
 jetbrains-pluginRepositoryRestClient = "2.0.32"
 kotson = "2.5.0"
-logback-classic = "1.4.7"
 okhttp = "4.11.0"
 okhttp-logging-interceptor = "4.11.0"
 retrofit = "2.9.0"
@@ -39,7 +38,6 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 jetbrains-pluginRepositoryRestClient = { group = "org.jetbrains.intellij", name = "plugin-repository-rest-client", version.ref = "jetbrains-pluginRepositoryRestClient" }
 kotson = { group = "com.github.salomonbrys.kotson", name = "kotson", version.ref = "kotson" }
-logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }

--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ okhttp = "4.11.0"
 okhttp-logging-interceptor = "4.11.0"
 retrofit = "2.9.0"
 retrofit-gson = "2.9.0"
-slf4j-api = "2.0.7"
 
 shadow = "7.1.2"
 xz = "1.9"
@@ -45,7 +44,6 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit-gson" }
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j-api" }
 spullara-cli-parser = { group = "com.github.spullara.cli-parser", name = "cli-parser", version.ref = "spullara-cli-parser" }
 xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
 

--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ spullara-cli-parser = "1.1.6"
 gson = "2.10.1"
 guava = "31.1-jre"
 jgrapht-core = "1.5.2"
-jsoup = "1.16.1"
 junit = "4.13.2"
 jetbrains-pluginRepositoryRestClient = "2.0.32"
 kotson = "2.5.0"
@@ -31,7 +30,6 @@ commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht-core" }
-jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 jetbrains-pluginRepositoryRestClient = { group = "org.jetbrains.intellij", name = "plugin-repository-rest-client", version.ref = "jetbrains-pluginRepositoryRestClient" }

--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -1,6 +1,4 @@
 [versions]
-kotlin = "1.8.21"
-
 jetbrains-annotations = "12.0"
 
 bcpkix-jdk15on = "1.70"
@@ -41,8 +39,6 @@ jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 jetbrains-pluginRepositoryRestClient = { group = "org.jetbrains.intellij", name = "plugin-repository-rest-client", version.ref = "jetbrains-pluginRepositoryRestClient" }
-kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotson = { group = "com.github.salomonbrys.kotson", name = "kotson", version.ref = "kotson" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
@@ -54,5 +50,4 @@ spullara-cli-parser = { group = "com.github.spullara.cli-parser", name = "cli-pa
 xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ commons-lang3 = "3.12.0"
 spullara-cli-parser = "1.1.6"
 gson = "2.10.1"
 guava = "31.1-jre"
-jackson-module-kotlin = "2.14.2"
 jgrapht-core = "1.5.2"
 jsoup = "1.16.1"
 junit = "4.13.2"
@@ -31,7 +30,6 @@ commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons
 commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commons-lang3" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
 jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht-core" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/intellij-plugin-verifier/settings.gradle.kts
+++ b/intellij-plugin-verifier/settings.gradle.kts
@@ -10,3 +10,11 @@ include("verifier-test:before-idea")
 include("verifier-test:additional-after-idea")
 include("verifier-test:additional-before-idea")
 include("verifier-test:mock-plugin")
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("sharedLibs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-cli/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-cli/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   api(project(":verifier-intellij"))
 
-  runtimeOnly(libs.logback.classic)
+  runtimeOnly(sharedLibs.logback.classic)
   implementation(libs.jackson.module.kotlin)
   implementation(libs.spullara.cli.parser)
   implementation(libs.commons.lang3)

--- a/intellij-plugin-verifier/verifier-cli/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-cli/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
   api(project(":verifier-intellij"))
 
   runtimeOnly(sharedLibs.logback.classic)
-  implementation(libs.jackson.module.kotlin)
+  implementation(sharedLibs.jackson.module.kotlin)
   implementation(libs.spullara.cli.parser)
   implementation(libs.commons.lang3)
 }

--- a/intellij-plugin-verifier/verifier-intellij/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-intellij/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
 
   api(libs.jgrapht.core)
 
-  implementation(libs.jsoup)
+  implementation(sharedLibs.jsoup)
 
   api("org.jetbrains.intellij.plugins:structure-ide-classes:$intellijStructureVersion")
 }

--- a/intellij-plugin-verifier/verifier-test/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
   implementation(project(":verifier-cli"))
 
-  testRuntimeOnly(libs.logback.classic)
+  testRuntimeOnly(sharedLibs.logback.classic)
   testRuntimeOnly(project("mock-plugin"))
 
   //bytecode generation library


### PR DESCRIPTION
Create a shared catalog for dependencies that are shared between projects in this repository.

This will enable en-masse upgrade of common libraries (_slf4j_, _logback_) in case of security issues in all projects. Also, it will prevent _dependabot_ to report duplicate depedency issues in projects.