### PR TITLE
Increase severity for "does not declare explicit dependency on Java plugin" to an error

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependencyBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependencyBean.java
@@ -7,6 +7,11 @@ package com.jetbrains.plugin.structure.intellij.beans;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlValue;
 
+/**
+ * Plugin dependency mapped to {@code <depends>} element in <code>plugin.xml</code>.
+ *
+ * @see <a href="https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#3-dependency-declaration-in-pluginxml">Dependency Declaration in plugin.xml</a>
+ */
 public class PluginDependencyBean {
   @XmlAttribute(name = "optional") public Boolean optional;
   @XmlAttribute(name = "config-file") public String configFile;

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/JavaPluginApiCompatibilityIssueAnalyzer.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/JavaPluginApiCompatibilityIssueAnalyzer.kt
@@ -1,0 +1,23 @@
+package com.jetbrains.pluginverifier.usages.javaPlugin
+
+import com.jetbrains.pluginverifier.verifiers.CompatibilityIssueAnalyzer
+import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+
+/**
+ * Requires explicit dependency on the Java plugin via `<depends>com.intellij.modules.java</depends>`.
+ *
+ * See [Java Functionality extracted as a plugin](https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin).
+ */
+class JavaPluginApiCompatibilityIssueAnalyzer : CompatibilityIssueAnalyzer<JavaPluginClassUsage> {
+  override fun analyze(context: PluginVerificationContext, usage: JavaPluginClassUsage) {
+    val idePlugin = context.idePlugin
+    if (idePlugin.dependencies.none { it.id == "com.intellij.modules.java" || it.id == "com.intellij.java" }) {
+      val undeclaredJavaPluginDependencyProblem = context.compatibilityProblems
+              .filterIsInstance<UndeclaredDependencyOnJavaPluginProblem>()
+              .firstOrNull() ?: UndeclaredDependencyOnJavaPluginProblem().also {
+                  context.compatibilityProblems += it
+              }
+      undeclaredJavaPluginDependencyProblem.javaPluginClassUsages += usage
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/UndeclaredDependencyOnJavaPluginProblem.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/UndeclaredDependencyOnJavaPluginProblem.kt
@@ -1,26 +1,22 @@
-/*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
- */
-
-package com.jetbrains.pluginverifier.warnings
+package com.jetbrains.pluginverifier.usages.javaPlugin
 
 import com.jetbrains.pluginverifier.results.presentation.ClassGenericsSignatureOption
 import com.jetbrains.pluginverifier.results.presentation.ClassOption
 import com.jetbrains.pluginverifier.results.presentation.formatClassLocation
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.usages.formatUsageLocation
-import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginClassUsage
+import java.util.*
 
-data class NoExplicitDependencyOnJavaPluginWarning(
+class UndeclaredDependencyOnJavaPluginProblem(
   val javaPluginClassUsages: MutableSet<JavaPluginClassUsage> = hashSetOf()
-) : CompatibilityWarning() {
-
+) : CompatibilityProblem() {
   override val problemType: String
     get() = shortDescription
 
-  override val shortDescription
+  override val shortDescription: String
     get() = "Dependency on Java plugin is not specified"
 
-  override val fullDescription
+  override val fullDescription: String
     get() = buildString {
       appendLine("Plugin uses classes of Java plugin, for example")
       val deterministicUsages = javaPluginClassUsages.sortedWith(compareBy<JavaPluginClassUsage> { it.usedClass.className }.thenBy { it.usageLocation.presentableLocation })
@@ -34,4 +30,9 @@ data class NoExplicitDependencyOnJavaPluginWarning(
       appendLine("Java functionality was extracted from the IntelliJ Platform to a separate plugin in IDEA 2019.2. ")
       appendLine("For more info refer to https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin")
     }
+
+  override fun equals(other: Any?) = other is UndeclaredDependencyOnJavaPluginProblem
+          && javaPluginClassUsages == other.javaPluginClassUsages
+
+  override fun hashCode() = Objects.hash(javaPluginClassUsages)
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/CompatibilityIssueAnalyzer.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/CompatibilityIssueAnalyzer.kt
@@ -1,0 +1,9 @@
+package com.jetbrains.pluginverifier.verifiers
+
+/**
+ * Analyze possible compatibility issues (problems or warnings) in the verification context for a particular usage.
+ */
+interface CompatibilityIssueAnalyzer<in U> {
+  fun analyze(context: PluginVerificationContext, usage: U)
+}
+

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/PluginVerificationContext.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/PluginVerificationContext.kt
@@ -29,6 +29,7 @@ import com.jetbrains.pluginverifier.usages.internal.InternalApiUsageRegistrar
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginApiUsageRegistrar
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginClassUsage
+import com.jetbrains.pluginverifier.usages.javaPlugin.UndeclaredDependencyOnJavaPluginProblem
 import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableApiRegistrar
 import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableApiUsage
 import com.jetbrains.pluginverifier.usages.overrideOnly.OverrideOnlyMethodUsage
@@ -37,7 +38,6 @@ import com.jetbrains.pluginverifier.usages.overrideOnly.OverrideOnlyRegistrar
 import com.jetbrains.pluginverifier.usages.properties.PropertyUsageProcessor
 import com.jetbrains.pluginverifier.verifiers.packages.PackageFilter
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
-import com.jetbrains.pluginverifier.warnings.NoExplicitDependencyOnJavaPluginWarning
 import com.jetbrains.pluginverifier.warnings.PluginStructureWarning
 import com.jetbrains.pluginverifier.warnings.WarningRegistrar
 
@@ -121,9 +121,10 @@ data class PluginVerificationContext(
 
   override fun registerJavaPluginClassUsage(javaPluginClassUsage: JavaPluginClassUsage) {
     if (idePlugin.dependencies.none { it.id == "com.intellij.modules.java" || it.id == "com.intellij.java" }) {
-      val noJavaDependencyWarning = compatibilityWarnings.filterIsInstance<NoExplicitDependencyOnJavaPluginWarning>().firstOrNull()
-        ?: NoExplicitDependencyOnJavaPluginWarning().also { compatibilityWarnings += it }
-      noJavaDependencyWarning.javaPluginClassUsages += javaPluginClassUsage
+
+      val undeclaredJavaPluginDependencyProblem = compatibilityProblems.filterIsInstance<UndeclaredDependencyOnJavaPluginProblem>().firstOrNull()
+              ?: UndeclaredDependencyOnJavaPluginProblem().also { compatibilityProblems += it }
+      undeclaredJavaPluginDependencyProblem.javaPluginClassUsages += javaPluginClassUsage
     }
   }
 


### PR DESCRIPTION
- Migrate warning to error
- Move verification logic to a separate class. This decouples the verification context from verification business logic.

https://youtrack.jetbrains.com/issue/MP-5434