### PR TITLE
Treat optional dependency with an empty file as an error

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -6,6 +6,13 @@ package com.jetbrains.plugin.structure.base.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 
+/**
+ * Indicates an issue with plugin descriptor (`plugin.xml`).
+ *
+ * Such kinds of errors are treated in a special way.
+ * Although they are indicated as [errors][com.jetbrains.plugin.structure.base.plugin.PluginProblem.Level.ERROR],
+ * they do not prevent successful creation of plugin by [com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager].
+ */
 abstract class InvalidDescriptorProblem(private val descriptorPath: String?) : PluginProblem() {
   abstract val detailedMessage: String
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -172,20 +172,21 @@ class IdePluginManager private constructor(
     val possibleResults = results.stream()
       .filter { r: PluginCreator -> r.isSuccess || hasOnlyInvalidDescriptorErrors(r) }
       .collect(Collectors.toList())
-    if (possibleResults.size > 1) {
-      val first = possibleResults[0]
-      val second = possibleResults[1]
-      val multipleDescriptorsProblem: PluginProblem = MultiplePluginDescriptors(
-        first.descriptorPath,
-        first.pluginFileName,
-        second.descriptorPath,
-        second.pluginFileName
-      )
-      return createInvalidPlugin(root, descriptorPath, multipleDescriptorsProblem)
+    return when(possibleResults.size) {
+      0 -> createInvalidPlugin(root, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
+      1 -> possibleResults[0]
+      else -> {
+        val first = possibleResults[0]
+        val second = possibleResults[1]
+        val multipleDescriptorsProblem: PluginProblem = MultiplePluginDescriptors(
+                first.descriptorPath,
+                first.pluginFileName,
+                second.descriptorPath,
+                second.pluginFileName
+        )
+        createInvalidPlugin(root, descriptorPath, multipleDescriptorsProblem)
+      }
     }
-    return if (possibleResults.size == 1) {
-      possibleResults[0]
-    } else createInvalidPlugin(root, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
   }
 
   private fun loadPluginInfoFromJarOrDirectory(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -507,8 +507,12 @@ internal class PluginCreator private constructor(
     for (dependencyBean in dependencies) {
       if (dependencyBean.dependencyId.isNullOrBlank() || dependencyBean.dependencyId.contains("\n")) {
         registerProblem(InvalidDependencyId(descriptorPath, dependencyBean.dependencyId))
-      } else if (dependencyBean.optional == true && dependencyBean.configFile == null) {
-        registerProblem(OptionalDependencyConfigFileNotSpecified(dependencyBean.dependencyId))
+      } else if (dependencyBean.optional == true) {
+        if (dependencyBean.configFile == null) {
+          registerProblem(OptionalDependencyConfigFileNotSpecified(dependencyBean.dependencyId))
+        } else if (dependencyBean.configFile.isBlank()) {
+          registerProblem(OptionalDependencyConfigFileIsEmpty(dependencyBean.dependencyId, descriptorPath))
+        }
       } else if (dependencyBean.optional == false) {
         registerProblem(SuperfluousNonOptionalDependencyDeclaration(dependencyBean.dependencyId))
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -181,3 +181,22 @@ class OptionalDependencyDescriptorCycleProblem(descriptorPath: String, private v
   override val detailedMessage: String
     get() = "optional dependencies configuration files contain cycle: " + cyclicPath.joinToString(separator = " -> ")
 }
+
+/**
+ * Indicates optional dependency with empty config file.
+ *
+ * Example violation:
+ * ```
+ * <depends optional="true" config-file="">
+ *   com.intellij.optional.plugin.id
+ * </depends>
+ * ```
+ *
+ */
+class OptionalDependencyConfigFileIsEmpty(private val optionalDependencyId: String, descriptorPath: String) : InvalidDescriptorProblem(descriptorPath) {
+  override val level
+    get() = Level.ERROR
+
+  override val detailedMessage: String
+    get() = "Optional dependency declaration on '$optionalDependencyId' cannot have empty \"config-file\""
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -15,15 +15,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
-class PluginXmlValidationTest {
-
-  @Rule
-  @JvmField
-  val temporaryFolder = TemporaryFolder()
-
-  companion object {
-
-    private const val HEADER = """
+private const val HEADER = """
       <id>someId</id>
       <name>someName</name>
       <version>someVersion</version>
@@ -33,7 +25,11 @@ class PluginXmlValidationTest {
       <idea-version since-build="131.1"/>
     """
 
-  }
+class PluginXmlValidationTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
 
   @Test
   fun `plugin declaring optional dependency but missing config-file`() {
@@ -54,7 +50,7 @@ class PluginXmlValidationTest {
     val warnings = pluginCreationSuccess.warnings
     assertEquals(1, warnings.size)
     val warning = warnings.filterIsInstance<OptionalDependencyConfigFileNotSpecified>()
-            .firstOrNull()
+            .singleOrNull()
     if (warning == null) {
       fail("Expected 'Optional Dependency Config File Not Specified' plugin warning")
     }
@@ -78,7 +74,7 @@ class PluginXmlValidationTest {
 
     assertEquals(1, pluginCreationFail.errorsAndWarnings.size)
     val warning = pluginCreationFail.errorsAndWarnings.filterIsInstance<OptionalDependencyConfigFileIsEmpty>()
-            .firstOrNull()
+            .singleOrNull()
     if (warning == null) {
       fail("Expected 'Optional Dependency Config File Is Empty' plugin warning")
     }
@@ -87,7 +83,8 @@ class PluginXmlValidationTest {
   private fun buildMalformedPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationFail<IdePlugin> {
     val pluginCreationResult = buildIdePlugin(pluginContentBuilder)
     if (pluginCreationResult !is PluginCreationFail) {
-      fail("This plugin should not be created, but is correct.")
+      fail("This plugin was expected to fail during creation, but the creation process was successful." +
+              " Please ensure that this is the intended behavior in the unit test.")
     }
     return pluginCreationResult as PluginCreationFail
   }
@@ -103,14 +100,5 @@ class PluginXmlValidationTest {
   private fun buildIdePlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
     return IdePluginManager.createManager().createPlugin(pluginFile)
-  }
-
-  class PluginCreationHandler {
-    fun onSuccess(result: PluginCreationSuccess<IdePlugin>): PluginCreationSuccess<IdePlugin> {
-      return result
-    }
-    fun onFailure(result: PluginCreationFail<IdePlugin>): PluginCreationFail<IdePlugin> {
-      return result
-    }
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -1,0 +1,116 @@
+package com.jetbrains.plugin.structure.intellij
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileIsEmpty
+import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileNotSpecified
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PluginXmlValidationTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  companion object {
+
+    private const val HEADER = """
+      <id>someId</id>
+      <name>someName</name>
+      <version>someVersion</version>
+      ""<vendor email="vendor.com" url="url">vendor</vendor>""
+      <description>this description is looooooooooong enough</description>
+      <change-notes>these change-notes are looooooooooong enough</change-notes>
+      <idea-version since-build="131.1"/>
+    """
+
+  }
+
+  @Test
+  fun `plugin declaring optional dependency but missing config-file`() {
+    val pluginCreationSuccess = buildCorrectPlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $HEADER
+              <depends>com.intellij.modules.platform</depends>
+              <depends optional="true">com.intellij.bundled.plugin.id</depends>
+            </idea-plugin>
+          """
+        }
+      }
+    }
+
+    val warnings = pluginCreationSuccess.warnings
+    assertEquals(1, warnings.size)
+    val warning = warnings.filterIsInstance<OptionalDependencyConfigFileNotSpecified>()
+            .firstOrNull()
+    if (warning == null) {
+      fail("Expected 'Optional Dependency Config File Not Specified' plugin warning")
+    }
+  }
+
+  @Test
+  fun `plugin declaring optional dependency but empty config-file is a creation error`() {
+    val pluginCreationFail = buildMalformedPlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $HEADER
+              <depends>com.intellij.modules.platform</depends>
+              <depends optional="true" config-file="">com.intellij.optional.plugin.id</depends>
+            </idea-plugin>
+          """
+        }
+      }
+    }
+
+    assertEquals(1, pluginCreationFail.errorsAndWarnings.size)
+    val warning = pluginCreationFail.errorsAndWarnings.filterIsInstance<OptionalDependencyConfigFileIsEmpty>()
+            .firstOrNull()
+    if (warning == null) {
+      fail("Expected 'Optional Dependency Config File Is Empty' plugin warning")
+    }
+  }
+
+  private fun buildMalformedPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationFail<IdePlugin> {
+    val pluginCreationResult = buildIdePlugin(pluginContentBuilder)
+    if (pluginCreationResult !is PluginCreationFail) {
+      fail("This plugin should not be created, but is correct.")
+    }
+    return pluginCreationResult as PluginCreationFail
+  }
+
+  private fun buildCorrectPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationSuccess<IdePlugin> {
+    val pluginCreationResult = buildIdePlugin(pluginContentBuilder)
+    if (pluginCreationResult !is PluginCreationSuccess) {
+      fail("This plugin has not been created. Creation failed with error(s).")
+    }
+    return pluginCreationResult as PluginCreationSuccess
+  }
+
+  private fun buildIdePlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
+    return IdePluginManager.createManager().createPlugin(pluginFile)
+  }
+
+  class PluginCreationHandler {
+    fun onSuccess(result: PluginCreationSuccess<IdePlugin>): PluginCreationSuccess<IdePlugin> {
+      return result
+    }
+    fun onFailure(result: PluginCreationFail<IdePlugin>): PluginCreationFail<IdePlugin> {
+      return result
+    }
+  }
+}


### PR DESCRIPTION
Optional dependency in plugin descriptor with an empty `config-file` is treated as an error.