### PR TITLE
Create better description of empty <vendor>

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginProblem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginProblem.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.base.plugin
 
+import java.net.URL
 import java.util.*
 
 abstract class PluginProblem {
@@ -26,3 +27,10 @@ abstract class PluginProblem {
   final override fun hashCode() = Objects.hash(message, level)
 
 }
+
+/**
+ * Indicates a hint that points to the solution.
+ * @param example A code sample that shows a correct usage of the specific code or declaration.
+ * @param documentationUrl a hyperlink to the human-readable documentation describing a suggested usage.
+ */
+data class ProblemSolutionHint(val example: String?, val documentationUrl: URL?)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginProblem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginProblem.kt
@@ -4,7 +4,6 @@
 
 package com.jetbrains.plugin.structure.base.plugin
 
-import java.net.URL
 import java.util.*
 
 abstract class PluginProblem {
@@ -33,4 +32,4 @@ abstract class PluginProblem {
  * @param example A code sample that shows a correct usage of the specific code or declaration.
  * @param documentationUrl a hyperlink to the human-readable documentation describing a suggested usage.
  */
-data class ProblemSolutionHint(val example: String?, val documentationUrl: URL?)
+data class ProblemSolutionHint(val example: String?, val documentationUrl: String?)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -6,7 +6,6 @@ package com.jetbrains.plugin.structure.base.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.plugin.ProblemSolutionHint
-import java.net.URL
 
 /**
  * Indicates an issue with plugin descriptor (`plugin.xml`).
@@ -120,7 +119,7 @@ class VendorCannotBeEmpty(descriptorPath: String? = null
 
   private val solutionHint = ProblemSolutionHint(
           """<vendor email="joe@example.com">Joe Doe</vendor>""",
-          URL("https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__vendor")
+          "https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__vendor"
   )
 
   override val detailedMessage: String

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -5,6 +5,7 @@
 package com.jetbrains.plugin.structure.base.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import java.net.URL
 
 abstract class InvalidDescriptorProblem(private val descriptorPath: String?) : PluginProblem() {
   abstract val detailedMessage: String
@@ -44,8 +45,8 @@ class TooLongPropertyValue(
     get() = Level.ERROR
 }
 
-class PropertyNotSpecified(
-  private val propertyName: String,
+open class PropertyNotSpecified(
+  protected val propertyName: String,
   descriptorPath: String? = null
 ) : InvalidDescriptorProblem(descriptorPath) {
 
@@ -93,3 +94,19 @@ class ContainsNewlines(propertyName: String, descriptorPath: String? = null) : I
 
   override val level = Level.ERROR
 }
+
+class VendorCannotBeEmpty(descriptorPath: String? = null
+) : PropertyNotSpecified("vendor", descriptorPath) {
+
+  private val solutionHint = ProblemSolutionHint(
+          """<vendor email="joe@example.com">Joe Doe</vendor>""",
+          URL("https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__vendor")
+  )
+
+  override val detailedMessage: String
+    get() = "<$propertyName> element has no content. The vendor name or organization ID must be set. Example: ${solutionHint.example}"
+
+  override val level
+    get() = Level.ERROR
+}
+

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -5,6 +5,7 @@
 package com.jetbrains.plugin.structure.base.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.plugin.ProblemSolutionHint
 import java.net.URL
 
 abstract class InvalidDescriptorProblem(private val descriptorPath: String?) : PluginProblem() {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/ProblemSolutionHint.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/ProblemSolutionHint.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.plugin.structure.base.problems
+
+import java.net.URL
+
+data class ProblemSolutionHint(val example: String?, val documentationUrl: URL?)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/ProblemSolutionHint.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/ProblemSolutionHint.kt
@@ -1,5 +1,0 @@
-package com.jetbrains.plugin.structure.base.problems
-
-import java.net.URL
-
-data class ProblemSolutionHint(val example: String?, val documentationUrl: URL?)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -794,8 +794,13 @@ internal class PluginCreator private constructor(
   }
 
   private fun validateVendor(vendorBean: PluginVendorBean?) {
-    if (vendorBean == null || vendorBean.name.isNullOrBlank()) {
+    if (vendorBean == null) {
       registerProblem(PropertyNotSpecified("vendor", descriptorPath))
+      return
+    }
+
+    if (vendorBean.name.isNullOrBlank()) {
+      registerProblem(VendorCannotBeEmpty(descriptorPath))
       return
     }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -199,7 +199,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       perfectXmlBuilder.modify {
         vendor = "<vendor url=\"https://test.com\"></vendor>"
       },
-      listOf(PropertyNotSpecified("vendor", "plugin.xml"))
+      listOf(VendorCannotBeEmpty("plugin.xml"))
     )
   }
 
@@ -323,7 +323,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       perfectXmlBuilder.modify {
         vendor = """<vendor></vendor>"""
       },
-      listOf(PropertyNotSpecified("vendor", "plugin.xml"))
+      listOf(VendorCannotBeEmpty("plugin.xml"))
     )
 
     `test valid plugin xml`(


### PR DESCRIPTION
Create better description of empty <vendor> element.

Missing vendor will create an improved message:

```
Invalid plugin descriptor 'plugin.xml': <vendor> element has no content. The vendor name or organization ID must be set. Example: <vendor email="joe@example.com">Joe Doe</vendor>
```