### PR TITLE
Bump commons-io to 2.12.0 while removing outdated usages

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.8.21"
 
-commons-io = "2.10.0"
+commons-io = "2.12.0"
 gson = "2.10.1"
 guava = "31.1-jre"
 jackson-module-kotlin = "2.14.2"

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
 
   implementation(sharedLibs.gson)
   implementation(sharedLibs.slf4j.api)
-  implementation(sharedLibs.commons.io)
 
   testImplementation(sharedLibs.junit)
   testImplementation(project(":test-classes"))

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -57,7 +57,6 @@ allprojects {
     implementation(rootProject.libs.bouncycastle.pkix)
 
     implementation(rootProject.sharedLibs.jetbrains.annotations)
-    implementation(rootProject.sharedLibs.commons.io)
     implementation(rootProject.sharedLibs.gson)
   }
 

--- a/plugins-verifier-service/build.gradle.kts
+++ b/plugins-verifier-service/build.gradle.kts
@@ -71,7 +71,6 @@ allprojects {
 
     testImplementation(sharedLibs.junit)
     implementation(sharedLibs.kotlin.stdlib.jdk8)
-    implementation(sharedLibs.commons.io)
     implementation(sharedLibs.kotson)
     implementation(sharedLibs.gson)
 


### PR DESCRIPTION
- Bumps `commons-io` to 2.12.0
- Removes `commons-io` as an explicit dependencies from projects that don't use this anymore