### PR TITLE
Decrease level when several dependencies use the same descriptor

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -111,7 +111,7 @@ class ReusedDescriptorInMultipleDependencies(descriptorPath: String? = null,
     get() = "Dependencies (${dependencies.size}) reuse a config-file attribute value '$configFile': " + dependencySummary
 
   override val level: Level
-    get() = Level.ERROR
+    get() = Level.WARNING
 }
 
 class VendorCannotBeEmpty(descriptorPath: String? = null

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ReusedDescriptorVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ReusedDescriptorVerifierTest.kt
@@ -25,9 +25,11 @@ class ReusedDescriptorVerifierTest {
   @Test
   fun `config-file is reused in two dependencies`() {
     val reusedConfig = "reused-config-file"
+    val reusingDependency1 = "dep-one"
+    val reusingDependency2 = "dep-two"
     val dependencies = listOf(
-            dependency("dep-one", reusedConfig),
-            dependency("dep-two", reusedConfig),
+            dependency(reusingDependency1, reusedConfig),
+            dependency(reusingDependency2, reusedConfig),
             dependency("dep-three", "config.xml")
     )
 
@@ -37,6 +39,10 @@ class ReusedDescriptorVerifierTest {
       val p = problem as ReusedDescriptorInMultipleDependencies
       Assert.assertEquals(WARNING, p.level)
       Assert.assertEquals(2, p.dependencies.size)
+      val expectedMessage = "Invalid plugin descriptor 'plugin.xml': " +
+              "Dependencies (2) reuse a config-file attribute value 'reused-config-file': " +
+              "[$reusingDependency1, $reusingDependency2]"
+      Assert.assertEquals(expectedMessage, p.message)
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ReusedDescriptorVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ReusedDescriptorVerifierTest.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem.Level.WARNING
 import com.jetbrains.plugin.structure.base.problems.ReusedDescriptorInMultipleDependencies
 import com.jetbrains.plugin.structure.intellij.beans.PluginDependencyBean
 import org.junit.Assert
@@ -34,6 +35,7 @@ class ReusedDescriptorVerifierTest {
     verifier.verify(dependencies) { problem ->
       Assert.assertTrue(problem is ReusedDescriptorInMultipleDependencies)
       val p = problem as ReusedDescriptorInMultipleDependencies
+      Assert.assertEquals(WARNING, p.level)
       Assert.assertEquals(2, p.dependencies.size)
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -269,17 +269,13 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
 
   @Test
   fun `multiple dependencies reuse a single config-file`() {
-    `test invalid plugin xml`(
+    `test valid plugin xml`(
             perfectXmlBuilder.modify {
               depends = """
                 <depends config-file="shared.xml">com.jetbrains.module-one</depends>
                 <depends config-file="shared.xml">com.jetbrains.module-two</depends>
               """.trimIndent()
-            },
-            listOf(ReusedDescriptorInMultipleDependencies("plugin.xml", "shared.xml",
-                    listOf(
-                            "com.jetbrains.module-one", "com.jetbrains.module-two")
-            ))
+            }
     )
   }
 


### PR DESCRIPTION
Decrease level when several dependencies use the same descriptor file from _error_ to _warning_.

See [MP-5523](https://youtrack.jetbrains.com/issue/MP-5523/Verifier-decrease-level-to-Warning-when-several-dependencies-use-the-same-descriptor-file)