### PR TITLE
Workaround for edu programming language

### DIFF
--- a/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/EduPlugin.kt
+++ b/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/EduPlugin.kt
@@ -22,6 +22,7 @@ data class EduPlugin(
   override val thirdPartyDependencies: List<ThirdPartyDependency> = emptyList(),
   val descriptorVersion: Int? = null,
   val language: String? = null,
+  val programmingLanguage: String? = null,
   val programmingLanguageId: String? = null,
   val programmingLanguageVersion: String? = null,
   val environment: String? = null,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/edu/mock/EduPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/edu/mock/EduPluginMockTest.kt
@@ -167,7 +167,7 @@ class EduPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTest<
   }
 
   @Test
-  fun `parse edu plugin with obsolete programming version`() {
+  fun `parse edu plugin with obsolete programming lang`() {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
       file(EduPluginManager.DESCRIPTOR_NAME) {
         getMockPluginJsonContent("course_obsolete_programming_lang")
@@ -182,7 +182,36 @@ class EduPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTest<
     assertEquals("1.1", plugin.pluginVersion)
     assertEquals("JetBrains s.r.o.", plugin.vendor)
     assertEquals("en", plugin.language)
-    assertEquals("Test", plugin.programmingLanguageId)
+    assertEquals("Test", plugin.programmingLanguage)
+    assertNull(plugin.programmingLanguageId)
+    assertNull(plugin.programmingLanguageVersion)
+    assertEquals("unittest", plugin.environment)
+    assertEquals("Python Course_JetBrains s.r.o._Test", plugin.pluginId)
+    assertEquals(1, plugin.eduStat!!.lessons.size)
+    assertEquals("lesson1", plugin.eduStat!!.lessons[0])
+    assertEquals(false, plugin.isPrivate)
+    assertEquals(iconTestContent, String(plugin.icons.single().content))
+    assertTrue(pluginCreationSuccess.warnings.isEmpty())
+  }
+
+  @Test
+  fun `parse edu plugin with obsolete programming lang and version`() {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
+      file(EduPluginManager.DESCRIPTOR_NAME) {
+        getMockPluginJsonContent("course_obsolete_programming_lang_and_version")
+      }
+      file("courseIcon.svg", iconTestContent)
+    }
+
+    val pluginCreationSuccess = createPluginSuccessfully(pluginFile)
+    val plugin = pluginCreationSuccess.plugin
+    assertEquals("Python Course", plugin.pluginName)
+    assertEquals("Python course.\nCreated: May 6, 2020, 11:21:51 AM.", plugin.description)
+    assertEquals("1.1", plugin.pluginVersion)
+    assertEquals("JetBrains s.r.o.", plugin.vendor)
+    assertEquals("en", plugin.language)
+    assertEquals("Test 12", plugin.programmingLanguage)
+    assertNull(plugin.programmingLanguageId)
     assertNull(plugin.programmingLanguageVersion)
     assertEquals("unittest", plugin.environment)
     assertEquals("Python Course_JetBrains s.r.o._Test", plugin.pluginId)

--- a/intellij-plugin-structure/tests/src/test/resources/edu/course_obsolete_programming_lang_and_version.json
+++ b/intellij-plugin-structure/tests/src/test/resources/edu/course_obsolete_programming_lang_and_version.json
@@ -1,0 +1,129 @@
+{
+  "environment" : "unittest",
+  "summary" : "Python course.\nCreated: May 6, 2020, 11:21:51 AM.",
+  "title" : "Python Course",
+  "programming_language" : "Test 12",
+  "language" : "en",
+  "course_type" : "PyCharm",
+  "edu_plugin_version": "3.7-2019.3-5266",
+  "vendor": {
+    "name": "JetBrains s.r.o.",
+    "url": "http://jetbrains.com/"
+  },
+  "items" : [
+    {
+      "title" : "lesson1",
+      "task_list" : [
+        {
+          "name" : "task1",
+          "files" : {
+            "__init__.py" : {
+              "name" : "__init__.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : ""
+            },
+            "tests/test_task.py" : {
+              "name" : "tests/test_task.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : "import unittest\n\nfrom ..task import sum\n\n\n# todo: replace this with an actual test\nclass TestCase(unittest.TestCase):\n    def test_add(self):\n        self.assertEqual(sum(1, 4), 3, msg=\"adds 1 + 2 to equal 3\")\n"
+            },
+            "tests/__init__.py" : {
+              "name" : "tests/__init__.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : ""
+            },
+            "task.py" : {
+              "name" : "task.py",
+              "placeholders" : [
+                {
+                  "offset" : 49,
+                  "length" : 9,
+                  "possible_answer" : "a",
+                  "placeholder_text" : "type here"
+                },
+                {
+                  "offset" : 75,
+                  "length" : 9,
+                  "possible_answer" : "a + b",
+                  "placeholder_text" : "type here"
+                }
+              ],
+              "is_visible" : true,
+              "text" : "# todo: replace this with an actual task\ndef sum(type here, b):\n    return type here\n"
+            }
+          },
+          "description_text" : "<html>\n<p>This is a task description file. Its content will be displayed to a learner in the <strong>Task Description</strong> window.</p>\n\n<p>It supports both Markdown and HTML.\nTo toggle the format, you can rename <strong>task.md</strong> to <strong>task.html</strong>, or vice versa.\nThe default task description format can be changed in <strong>Preferences | Tools | Education</strong>, but this will not affect any existing task description files.</p>\n\n<p>The following features are available in <strong>task.md/task.html</strong> which are specific to the EduTools plugin:</p>\n\n<ul>\n<li>Hints can be added anywhere in the task text. Type \"hint\" and press Tab. <div class=\"hint\">Text of your hint</div></li>\n\n<li>You can insert shortcuts in the task description.\nWhile <strong>task.html/task.md</strong> is open, right-click anywhere on the <strong>Editor</strong> tab and choose the <strong>Insert shortcut</strong> option from the context menu.\nFor example: &amp;shortcut:FileStructurePopup;.</li><br>\n\n<li>Insert the &percnt;<code>IDE_NAME</code>&percnt; macro, which will be replaced by the actual IDE name.\nFor example, <strong>%IDE_NAME%</strong>.</li><br>\n\n<li>Insert PSI elements, by using links like <code>&lt;a href=\"psi_element://link.to.element\"&gt;element description&lt;/a&gt;</code>.\nTo get such a link, right-click the class or method and select <strong>Copy Reference</strong>. Then press &amp;shortcut:EditorPaste; to insert the link where appropriate.\nFor example, a <a href=\"psi_element://java.lang.String#contains\">link to the \"contains\" method</a>.</li>\n</ul>\n</html>",
+          "description_format" : "HTML",
+          "feedback_link" : {
+            "link_type" : "STEPIK"
+          },
+          "task_type" : "edu"
+        },
+        {
+          "name" : "task2",
+          "files" : {
+            "tests/test_task.py" : {
+              "name" : "tests/test_task.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : "import unittest\n\nfrom ..task import sum\n\n\n# todo: replace this with an actual test\nclass TestCase(unittest.TestCase):\n    def test_add(self):\n        self.assertEqual(sum(1, 2), 3, msg=\"adds 1 + 2 to equal 3\")\n"
+            },
+            "__init__.py" : {
+              "name" : "__init__.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : ""
+            },
+            "tests/__init__.py" : {
+              "name" : "tests/__init__.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : ""
+            },
+            "task.py" : {
+              "name" : "task.py",
+              "placeholders" : [ ],
+              "is_visible" : true,
+              "text" : "# todo: replace this with an actual task\ndef sum(a, b):\n    return a + b\n#"
+            }
+          },
+          "description_text" : "This is a task description file. Its content will be displayed to a learner in the **Task Description** window.\n\nIt supports both Markdown and HTML.\nTo toggle the format, you can rename **task.md** to **task.html**, or vice versa.\nThe default task description format can be changed in **Preferences | Tools | Education**, but this will not affect any existing task description files.\n\nThe following features are available in **task.md/task.html** which are specific to the EduTools plugin:\n\n- Hints can be added anywhere in the task text. Type \"hint\" and press Tab. <div class=\"hint\">Text of your hint</div>\n\n- You can insert shortcuts in the task description.\nWhile **task.html/task.md** is open, right-click anywhere on the **Editor** tab and choose the **Insert shortcut** option from the context menu.\nFor example: &shortcut:FileStructurePopup;.\n\n- Insert the &percnt;`IDE_NAME`&percnt; macro, which will be replaced by the actual IDE name.\nFor example, **%IDE_NAME%**.\n\n- Insert PSI elements, by using links like `<a href=\"psi_element://link.to.element\">element description</a>`.\nTo get such a link, right-click the class or method and select **Copy Reference**. Then press &shortcut:EditorPaste; to insert the link where appropriate.\nFor example, a <a href=\"psi_element://java.lang.String#contains\">link to the \"contains\" method</a>.",
+          "description_format" : "MD",
+          "feedback_link" : {
+            "link_type" : "STEPIK"
+          },
+          "task_type" : "edu"
+        },
+        {
+          "name" : "task3",
+          "files" : {
+            "main.py" : {
+              "name" : "main.py",
+              "placeholders" : [ ],
+              "is_visible" : true,
+              "text" : "if __name__== \"__main__\":\n    # Write your solution here\n    pass\n"
+            },
+            "__init__.py" : {
+              "name" : "__init__.py",
+              "placeholders" : [ ],
+              "is_visible" : false,
+              "text" : ""
+            }
+          },
+          "description_text" : "This is a task description file. Its content will be displayed to a learner in the **Task Description** window.\n\nIt supports both Markdown and HTML.\nTo toggle the format, you can rename **task.md** to **task.html**, or vice versa.\nThe default task description format can be changed in **Preferences | Tools | Education**, but this will not affect any existing task description files.\n\nThe following features are available in **task.md/task.html** which are specific to the EduTools plugin:\n\n- Hints can be added anywhere in the task text. Type \"hint\" and press Tab. <div class=\"hint\">Text of your hint</div>\n\n- You can insert shortcuts in the task description.\nWhile **task.html/task.md** is open, right-click anywhere on the **Editor** tab and choose the **Insert shortcut** option from the context menu.\nFor example: &shortcut:FileStructurePopup;.\n\n- Insert the &percnt;`IDE_NAME`&percnt; macro, which will be replaced by the actual IDE name.\nFor example, **%IDE_NAME%**.\n\n- Insert PSI elements, by using links like `<a href=\"psi_element://link.to.element\">element description</a>`.\nTo get such a link, right-click the class or method and select **Copy Reference**. Then press &shortcut:EditorPaste; to insert the link where appropriate.\nFor example, a <a href=\"psi_element://java.lang.String#contains\">link to the \"contains\" method</a>.",
+          "description_format" : "MD",
+          "feedback_link" : {
+            "link_type" : "STEPIK"
+          },
+          "task_type" : "ide"
+        }
+      ],
+      "type" : "lesson"
+    }
+  ],
+  "course_version": "1.1",
+  "version" : 11
+}


### PR DESCRIPTION
This is a workaround on complex, strange and outdated logic about xml id generation. Long story short:
1. There was no xml id for edu plugins, so we need to generate it by our self. The original generation alg was 
`"${this.title}_${this.vendor?.name}_$programmingLanguage"`
2. Then, it appears that authors should be able to change the `title`. To do so, edu team introduced `generated_edu_id` field in course json. The idea is to generate it the same way as described in (1) in the edu plugin and only after that allow author to change the `title`.
3. Now, it appears that `programmingLanguage` could contain the programming language, and it's version divided by space. Edu also want to split `programmingLanguage` to `programmingLanguageId` and `programmingLanguageVersion`. Also, `programmingLanguageVersion` could be changed in future versions of the course, which means it could also affect xml id generation.

So, the plan is:
1. For older versions of the course structure (with `programmingLanguage`) we will get rid of the programming language version in xml id. I'll also remove the version from xml id in the database. From now on `programmingLanguage` is deprecated with estimated period of 6 edu plugin releases (half of a year).
2. For newer versions of the course structure (with `programmingLanguageId` and `programmingLanguageVersion`) we will use only `programmingLanguageId` in xml id.
3. We also decided to remove the part with generation xml id and to use `generated_edu_id` instead for every plugin with an estimated period of 6 edu plugin releases.