### PR TITLE
Ignore internal API usages from internal plugins

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.intellij.plugin

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
@@ -4,23 +4,16 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
-
 /**
  * Plugin Vendors that identify JetBrains-related plugins.
  *
  * @see com.intellij.ide.plugins.PluginManagerCore#isDeveloperByJetBrains
  */
 object PluginVendors {
-  private const val CORE_PLUGIN_ID = "com.intellij"
-  private const val SPECIAL_IDEA_PLUGIN_ID = "IDEA CORE"
   private const val VENDOR_JETBRAINS = "JetBrains"
   private const val VENDOR_JETBRAINS_SRO = "JetBrains s.r.o."
 
-  fun isDevelopedByJetBrains(plugin: IdePlugin): Boolean {
-    return CORE_PLUGIN_ID == plugin.pluginId ||
-      SPECIAL_IDEA_PLUGIN_ID == plugin.pluginId ||
-      isDevelopedByJetBrains(plugin.vendor)
-  }
+  fun isDevelopedByJetBrains(plugin: IdePlugin) = isDevelopedByJetBrains(plugin.vendor)
 
   private fun isDevelopedByJetBrains(vendorString: String?): Boolean {
     if (vendorString == null) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.intellij.plugin
 
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -4,7 +4,8 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
-import org.junit.Assert
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PluginVendorsTest {
@@ -14,8 +15,8 @@ class PluginVendorsTest {
       pluginId = "com.example.thirdparty"
       vendor = "PluginIndustries s.r.o."
     }
-    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
-    Assert.assertFalse(isInternalPlugin)
+    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    assertFalse(isJetBrainsPlugin)
   }
 
   @Test
@@ -24,8 +25,8 @@ class PluginVendorsTest {
       pluginId = "com.intellij.internal"
       vendor = "JetBrains s.r.o."
     }
-    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
-    Assert.assertTrue(isInternalPlugin)
+    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    assertTrue(isJetBrainsPlugin)
   }
 
   @Test
@@ -34,8 +35,8 @@ class PluginVendorsTest {
       pluginId = "com.intellij"
       vendor = "JetBrains s.r.o., PluginIndustries s.r.o."
     }
-    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
-    Assert.assertTrue(isInternalPlugin)
+    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    assertTrue(isJetBrainsPlugin)
   }
 
   @Test
@@ -44,8 +45,8 @@ class PluginVendorsTest {
       pluginId = "com.intellij.someplugin"
       vendor = "PluginIndustries s.r.o., PluginFactory s.r.o."
     }
-    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
-    Assert.assertFalse(isInternalPlugin)
+    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    assertFalse(isJetBrainsPlugin)
   }
 
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -29,10 +29,10 @@ class PluginVendorsTest {
   }
 
   @Test
-  fun `has multiple vendors and one is JetBrains`() {
+  fun `has multiple vendors and one of them is JetBrains`() {
     val idePlugin = IdePluginImpl().apply {
       pluginId = "com.intellij"
-      vendor = "JetBrains s.r.o., JetBrains"
+      vendor = "JetBrains s.r.o., PluginIndustries s.r.o."
     }
     val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
     Assert.assertTrue(isInternalPlugin)
@@ -42,7 +42,7 @@ class PluginVendorsTest {
   fun `has multiple vendors and none of those is JetBrains`() {
     val idePlugin = IdePluginImpl().apply {
       pluginId = "com.intellij.someplugin"
-      vendor = "PluginIndustries s.r.o."
+      vendor = "PluginIndustries s.r.o., PluginFactory s.r.o."
     }
     val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
     Assert.assertFalse(isInternalPlugin)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.intellij.plugin

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.intellij.plugin
 
 import org.junit.Assert

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -10,6 +10,16 @@ import org.junit.Test
 
 class PluginVendorsTest {
   @Test
+  fun `is a JetBrains plugin by plugin ID`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.intellij"
+      vendor = "JetBrains Department"
+    }
+    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    assertTrue(isJetBrainsPlugin)
+  }
+
+  @Test
   fun `has single vendor which is 3rd party`() {
     val idePlugin = IdePluginImpl().apply {
       pluginId = "com.example.thirdparty"

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -10,16 +10,6 @@ import org.junit.Test
 
 class PluginVendorsTest {
   @Test
-  fun `is a JetBrains plugin by plugin ID`() {
-    val idePlugin = IdePluginImpl().apply {
-      pluginId = "com.intellij"
-      vendor = "JetBrains Department"
-    }
-    val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
-    assertTrue(isJetBrainsPlugin)
-  }
-
-  @Test
   fun `has single vendor which is 3rd party`() {
     val idePlugin = IdePluginImpl().apply {
       pluginId = "com.example.thirdparty"
@@ -58,5 +48,4 @@ class PluginVendorsTest {
     val isJetBrainsPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
     assertFalse(isJetBrainsPlugin)
   }
-
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
@@ -38,6 +38,7 @@ sealed class PluginVerificationResult(
     val deprecatedUsages: Set<DeprecatedApiUsage> = emptySet(),
     val experimentalApiUsages: Set<ExperimentalApiUsage> = emptySet(),
     val internalApiUsages: Set<InternalApiUsage> = emptySet(),
+    val ignoredInternalApiUsages: Map<InternalApiUsage, String> = emptyMap(),
     val nonExtendableApiUsages: Set<NonExtendableApiUsage> = emptySet(),
     val overrideOnlyMethodUsages: Set<OverrideOnlyMethodUsage> = emptySet(),
     val pluginStructureWarnings: Set<PluginStructureWarning> = emptySet(),

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -14,6 +14,7 @@ import com.jetbrains.pluginverifier.analysis.ReachabilityGraph
 import com.jetbrains.pluginverifier.analysis.buildClassReachabilityGraph
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
 import com.jetbrains.pluginverifier.dymamic.DynamicPlugins
+import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
 import com.jetbrains.pluginverifier.filtering.ExternalBuildClassesSelector
 import com.jetbrains.pluginverifier.filtering.MainClassesSelector
 import com.jetbrains.pluginverifier.filtering.ProblemsFilter
@@ -24,6 +25,7 @@ import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.results.problems.PackageNotFoundProblem
 import com.jetbrains.pluginverifier.usages.deprecated.DeprecatedMethodOverridingProcessor
 import com.jetbrains.pluginverifier.usages.experimental.ExperimentalMethodOverridingProcessor
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalMethodOverridingProcessor
 import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableMethodOverridingProcessor
 import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableTypeInheritedProcessor
@@ -45,7 +47,8 @@ class PluginVerifier(
   private val problemFilters: List<ProblemsFilter>,
   private val pluginDetailsCache: PluginDetailsCache,
   private val classFilters: List<ClassFilter>,
-  private val excludeExternalBuildClassesSelector: Boolean
+  private val excludeExternalBuildClassesSelector: Boolean,
+  private val apiUsageFilters: List<ApiUsageFilter> = emptyList(),
 ) {
 
   fun loadPluginAndVerify(): PluginVerificationResult {
@@ -120,6 +123,8 @@ class PluginVerifier(
       groupMissingClassesToMissingPackages(context.compatibilityProblems, context.classResolver)
       val (reportProblems, ignoredProblems) = partitionReportAndIgnoredProblems(context.compatibilityProblems, context)
 
+      val (reportedInternalApiUsages, ignoredInternalApiUsages) = partitionReportAndIgnoredInternalApiUsages(context.internalApiUsages, context)
+
       return with(context) {
         PluginVerificationResult.Verified(
           verificationDescriptor.checkedPlugin,
@@ -130,7 +135,8 @@ class PluginVerifier(
           compatibilityWarnings,
           deprecatedUsages,
           experimentalApiUsages,
-          internalApiUsages,
+          reportedInternalApiUsages,
+          ignoredInternalApiUsages,
           nonExtendableApiUsages,
           overrideOnlyMethodUsages,
           pluginStructureWarnings,
@@ -163,6 +169,25 @@ class PluginVerifier(
 
     return reportProblems to ignoredProblems
   }
+
+  private fun partitionReportAndIgnoredInternalApiUsages(allInternalApiUsages: Set<InternalApiUsage>, context: PluginVerificationContext): Pair<Set<InternalApiUsage>, Map<InternalApiUsage, String>> {
+    val reportedUsages = mutableSetOf<InternalApiUsage>()
+    val ignoredUsages = mutableMapOf<InternalApiUsage, String>()
+    for (usage in allInternalApiUsages) {
+      for (apiUsageFilter in apiUsageFilters) {
+        val shouldReport = apiUsageFilter.shouldReport(usage, context)
+        if (shouldReport is ApiUsageFilter.Result.Ignore) {
+          ignoredUsages[usage] = shouldReport.reason
+          break
+        } else {
+          reportedUsages += usage
+        }
+      }
+    }
+    return reportedUsages to ignoredUsages
+  }
+
+
 
   /**
    * Returns the top-most package of the given [className] that is not available in this [Resolver].

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -174,13 +174,17 @@ class PluginVerifier(
     val reportedUsages = mutableSetOf<InternalApiUsage>()
     val ignoredUsages = mutableMapOf<InternalApiUsage, String>()
     for (usage in allInternalApiUsages) {
-      for (apiUsageFilter in apiUsageFilters) {
-        val shouldReport = apiUsageFilter.shouldReport(usage, context)
-        if (shouldReport is ApiUsageFilter.Result.Ignore) {
-          ignoredUsages[usage] = shouldReport.reason
-          break
-        } else {
-          reportedUsages += usage
+      if (apiUsageFilters.isEmpty()) {
+        reportedUsages += usage
+      } else {
+        for (apiUsageFilter in apiUsageFilters) {
+          val shouldReport = apiUsageFilter.shouldReport(usage, context)
+          if (shouldReport is ApiUsageFilter.Result.Ignore) {
+            ignoredUsages[usage] = shouldReport.reason
+            break
+          } else {
+            reportedUsages += usage
+          }
         }
       }
     }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
@@ -1,0 +1,18 @@
+package com.jetbrains.pluginverifier.filtering
+
+import com.jetbrains.pluginverifier.usages.ApiUsage
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+
+/**
+ * Classifies API usages to reported and ignored. This can be used to filter out
+ * unrelated, irrelevant or unnecessary API usages from verification results.
+ */
+interface ApiUsageFilter {
+  fun shouldReport(apiUsage: ApiUsage, context: VerificationContext): Result
+
+  sealed class Result {
+    object Report : Result()
+
+    data class Ignore(val reason: String) : Result()
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.pluginverifier.filtering
 
 import com.jetbrains.pluginverifier.usages.ApiUsage

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ApiUsageFilter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.filtering

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.pluginverifier.filtering
 
 import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
@@ -16,7 +16,7 @@ class InternalApiUsageFilter : ApiUsageFilter {
       apiUsage is InternalApiUsage
         && context is PluginVerificationContext
         && PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
-        ApiUsageFilter.Result.Ignore("Internal API usage from internal plugins is allowed.")
+        ApiUsageFilter.Result.Ignore("Internal API usage from JetBrains plugins is allowed.")
       else -> ApiUsageFilter.Result.Report
     }
   }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
@@ -1,0 +1,19 @@
+package com.jetbrains.pluginverifier.filtering
+
+import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors
+import com.jetbrains.pluginverifier.usages.ApiUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
+import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+
+class InternalApiUsageFilter : ApiUsageFilter {
+  override fun shouldReport(apiUsage: ApiUsage, context: VerificationContext): ApiUsageFilter.Result {
+    return when {
+      apiUsage is InternalApiUsage
+        && context is PluginVerificationContext
+        && PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
+        ApiUsageFilter.Result.Ignore("Internal API usage from internal plugins is allowed.")
+      else -> ApiUsageFilter.Result.Report
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -120,7 +120,7 @@ class InternalApiUsagePluginTest {
     assertEquals(internalClassUsageMsg, relevantInternalClassUsages[0].fullDescription)
   }
 
-  private fun buildIdePlugin(
+  private fun buildIdePlugin(ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij"),
     pluginClassesContentBuilder: (ContentBuilder).() -> Unit
   ): IdePlugin {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
@@ -131,7 +131,7 @@ class InternalApiUsagePluginTest {
           """
             <idea-plugin>
               <id>someId</id>
-              <name>someName</name>
+              <name>${ideaPluginSpec.id}</name>
               <version>someVersion</version>
               ""<vendor email="vendor.com" url="url">vendor</vendor>""
               <description>this description is looooooooooong enough</description>
@@ -227,6 +227,7 @@ class InternalApiUsagePluginTest {
     return ide
   }
 
+  data class IdeaPluginSpec(val id: String)
 
   object IntellijInternalApiDump : Opcodes {
     @Throws(Exception::class)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -11,6 +11,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
+import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.usages.ApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
@@ -81,17 +82,7 @@ class InternalApiUsagePluginTest {
   fun `internal plugin class uses an internal API`() {
     val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.intellij"))
 
-    val apiUsageFilter = object : ApiUsageFilter {
-      override fun shouldReport(apiUsage: ApiUsage, context: VerificationContext): ApiUsageFilter.Result {
-        return when {
-          apiUsage is InternalApiUsage
-            && context is PluginVerificationContext
-            && PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
-            ApiUsageFilter.Result.Ignore("Internal API usage from internal plugins is allowed.")
-          else -> ApiUsageFilter.Result.Report
-        }
-      }
-    }
+    val apiUsageFilter = InternalApiUsageFilter()
 
     // Run verification
     val verificationResult = VerificationRunner().runPluginVerification(ide, idePlugin,

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -38,6 +38,18 @@ class InternalApiUsagePluginTest {
   @JvmField
   val temporaryFolder = TemporaryFolder()
 
+  private val internalMethodUsageMsg = "Internal method com.intellij.openapi.InternalApiService.fortyTwo() : " +
+    "int is invoked in usage.Usage.delegateFortyTwo() : int. " +
+    "This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
+    "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
+    "and indicates that the method is not supposed to be used in client code."
+
+  private val internalClassUsageMsg = "Internal class com.intellij.openapi.InternalApiService " +
+    "is referenced in usage.Usage.delegateFortyTwo() : int. " +
+    "This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
+    "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
+    "and indicates that the class is not supposed to be used in client code."
+
   @Test
   fun `plugin class uses an internal API`() {
     val (idePlugin, ide) = prepareIde(IdeaPluginSpec("some.plugin"))
@@ -52,11 +64,6 @@ class InternalApiUsagePluginTest {
     assertEquals(3, verificationResult.internalApiUsages.size)
     val internalMethodUsages = verificationResult.internalApiUsages.filterIsInstance<InternalMethodUsage>()
     assertEquals(1, internalMethodUsages.size)
-    val internalMethodUsageMsg = "Internal method com.intellij.openapi.InternalApiService.fortyTwo() : " +
-      "int is invoked in usage.Usage.delegateFortyTwo() : int. " +
-      "This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
-      "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
-      "and indicates that the method is not supposed to be used in client code."
     assertEquals(internalMethodUsageMsg, internalMethodUsages[0].fullDescription)
 
     val internalClassUsages = verificationResult.internalApiUsages.filterIsInstance<InternalClassUsage>()
@@ -64,11 +71,6 @@ class InternalApiUsagePluginTest {
     // ignore internal ByteBuddy delegates due to MethodDelegations
     val relevantInternalClassUsages = internalClassUsages.filterNot { u -> u.fullDescription.contains("usage.Usage.delegate$") }
     assertEquals(1, relevantInternalClassUsages.size)
-    val internalClassUsageMsg = "Internal class com.intellij.openapi.InternalApiService " +
-      "is referenced in usage.Usage.delegateFortyTwo() : int. " +
-      "This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
-      "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
-      "and indicates that the class is not supposed to be used in client code."
     assertEquals(internalClassUsageMsg, relevantInternalClassUsages[0].fullDescription)
   }
 
@@ -100,11 +102,6 @@ class InternalApiUsagePluginTest {
     val ignoredUsages = verificationResult.ignoredInternalApiUsages.keys
     assertEquals(3, ignoredUsages.size)
     val internalMethodUsages = ignoredUsages.filterIsInstance<InternalMethodUsage>()
-    val internalMethodUsageMsg = "Internal method com.intellij.openapi.InternalApiService.fortyTwo() : " +
-            "int is invoked in usage.Usage.delegateFortyTwo() : int. " +
-            "This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
-            "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
-            "and indicates that the method is not supposed to be used in client code."
     assertEquals(internalMethodUsageMsg, internalMethodUsages[0].fullDescription)
 
     val internalClassUsages = ignoredUsages.filterIsInstance<InternalClassUsage>()
@@ -112,11 +109,6 @@ class InternalApiUsagePluginTest {
     // ignore internal ByteBuddy delegates due to MethodDelegations
     val relevantInternalClassUsages = internalClassUsages.filterNot { u -> u.fullDescription.contains("usage.Usage.delegate$") }
     assertEquals(1, relevantInternalClassUsages.size)
-    val internalClassUsageMsg = "Internal class com.intellij.openapi.InternalApiService " +
-            "is referenced in usage.Usage.delegateFortyTwo() : int. " +
-            "This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
-            "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
-            "and indicates that the class is not supposed to be used in client code."
     assertEquals(internalClassUsageMsg, relevantInternalClassUsages[0].fullDescription)
   }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.pluginverifier.tests
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -8,17 +8,11 @@ import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
-import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors
 import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
 import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
-import com.jetbrains.pluginverifier.usages.ApiUsage
-import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalClassUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalMethodUsage
-import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
-import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.description.annotation.AnnotationDescription
@@ -33,7 +27,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.lang.IllegalStateException
 import java.lang.reflect.Modifier
 
 class InternalApiUsagePluginTest {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -8,6 +8,7 @@ import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -85,7 +86,7 @@ class InternalApiUsagePluginTest {
         return when {
           apiUsage is InternalApiUsage
             && context is PluginVerificationContext
-            && context.idePlugin.pluginId == "com.intellij" ->
+            && PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
             ApiUsageFilter.Result.Ignore("Internal API usage from internal plugins is allowed.")
           else -> ApiUsageFilter.Result.Report
         }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -53,7 +53,7 @@ class InternalApiUsagePluginTest {
 
   @Test
   fun `plugin class uses an internal API`() {
-    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("some.plugin"))
+    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("some.plugin", "Plugin Factory Inc."))
 
     // Run verification
     val verificationResult = VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
@@ -77,7 +77,7 @@ class InternalApiUsagePluginTest {
 
   @Test
   fun `JetBrains plugin class uses an internal API`() {
-    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.intellij"))
+    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o."))
 
     val apiUsageFilter = InternalApiUsageFilter()
 
@@ -173,7 +173,7 @@ class InternalApiUsagePluginTest {
     }
   }
 
-  private fun buildIdePlugin(ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij"),
+  private fun buildIdePlugin(ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij", "JetBrains s.r.o."),
     pluginClassesContentBuilder: (ContentBuilder).() -> Unit
   ): IdePlugin {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
@@ -186,7 +186,7 @@ class InternalApiUsagePluginTest {
               <id>${ideaPluginSpec.id}</id>
               <name>someName</name>
               <version>someVersion</version>
-              ""<vendor email="vendor.com" url="url">vendor</vendor>""
+              ""<vendor email="vendor.com" url="url">${ideaPluginSpec.vendor}</vendor>""
               <description>this description is looooooooooong enough</description>
               <change-notes>these change-notes are looooooooooong enough</change-notes>
               <idea-version since-build="131.1"/>
@@ -280,7 +280,7 @@ class InternalApiUsagePluginTest {
     return ide
   }
 
-  data class IdeaPluginSpec(val id: String)
+  data class IdeaPluginSpec(val id: String, val vendor: String)
 
   object IntellijInternalApiDump : Opcodes {
     @Throws(Exception::class)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -76,7 +76,7 @@ class InternalApiUsagePluginTest {
   }
 
   @Test
-  fun `internal plugin class uses an internal API`() {
+  fun `JetBrains plugin class uses an internal API`() {
     val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.intellij"))
 
     val apiUsageFilter = InternalApiUsageFilter()
@@ -88,7 +88,7 @@ class InternalApiUsagePluginTest {
     // No warnings should be produced
     assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
     assertEquals(emptySet<CompatibilityWarning>(), verificationResult.compatibilityWarnings)
-    // Internal Plugins is not reporting internal usages. These are in the ignored usages
+    // JetBrains Plugin should not report internal usages. These are in the ignored usages
     assertEquals(0, verificationResult.internalApiUsages.size)
     val ignoredUsages = verificationResult.ignoredInternalApiUsages.keys
     assertEquals(3, ignoredUsages.size)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -1,0 +1,248 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.IdeManager
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.usages.internal.InternalClassUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalMethodUsage
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.annotation.AnnotationDescription
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.FixedValue
+import net.bytebuddy.implementation.MethodDelegation
+import net.bytebuddy.jar.asm.*
+import net.bytebuddy.jar.asm.Opcodes.*
+import net.bytebuddy.matcher.ElementMatchers.named
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.lang.reflect.Modifier
+
+class InternalApiUsagePluginTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `plugin class uses an internal API`() {
+    val classLoader = this::class.java.classLoader
+    val byteBuddy = ByteBuddy()
+
+    @Suppress("UNCHECKED_CAST") val intellijInternalApiClass = Class
+            .forName("com.intellij.openapi.util.IntellijInternalApi") as Class<Annotation>
+    val intellijInternalApiAnnDesc = AnnotationDescription.Builder
+            .ofType(intellijInternalApiClass)
+            .build()
+
+    val internalApiServiceClassUdt = byteBuddy
+            .subclass(Object::class.java)
+            .name("com.intellij.openapi.InternalApiService")
+            .annotateType(intellijInternalApiAnnDesc)
+            .defineMethod("fortyTwo", Integer.TYPE, Modifier.PUBLIC).intercept(FixedValue.value(42))
+            .make()
+
+    val internalApiClazz = internalApiServiceClassUdt.load(classLoader, ClassLoadingStrategy.Default.INJECTION).loaded
+    val internalApiService = internalApiClazz.getDeclaredConstructor().newInstance()
+
+    val usageClassUdt = byteBuddy
+            .subclass(Object::class.java)
+            .name("usage.Usage")
+            .defineMethod("delegateFortyTwo", Integer.TYPE, Modifier.PUBLIC).intercept(
+                    MethodDelegation
+                            .withDefaultConfiguration()
+                            .filter(named("fortyTwo")).to(internalApiService))
+            .make()
+
+    val usageClass = usageClassUdt.load(classLoader, ClassLoadingStrategy.Default.INJECTION).loaded
+    val usage = usageClass.getDeclaredConstructor().newInstance()
+
+    val result = usageClass.getMethod("delegateFortyTwo").invoke(usage)
+    assertEquals(42, result)
+
+
+    val idePlugin = buildIdePlugin {
+      dir("usage") {
+        file("Usage.class", usageClassUdt.bytes)
+      }
+    }
+
+    val ide = buildIdeWithBundledPlugins(javaPluginClassesBuilder = {
+        dir("com") {
+          dir("intellij") {
+            dir("openapi") {
+              dir("util") {
+                file("IntellijInternalApi.class", IntellijInternalApiDump.dump())
+              }
+              file("InternalApiService.class", internalApiServiceClassUdt.bytes)
+            }
+          }
+
+        }
+    }, groovyPluginClassesBuilder = {})
+
+    // Run verification
+    val verificationResult = VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+
+    // No warnings should be produced
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(emptySet<CompatibilityWarning>(), verificationResult.compatibilityWarnings)
+    // Internal API usages should be gathered
+    assertEquals(3, verificationResult.internalApiUsages.size)
+    val internalMethodUsages = verificationResult.internalApiUsages.filterIsInstance<InternalMethodUsage>()
+    assertEquals(1, internalMethodUsages.size)
+    val internalMethodUsageMsg = "Internal method com.intellij.openapi.InternalApiService.fortyTwo() : " +
+            "int is invoked in usage.Usage.delegateFortyTwo() : int. " +
+            "This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
+            "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
+            "and indicates that the method is not supposed to be used in client code."
+    assertEquals(internalMethodUsageMsg, internalMethodUsages[0].fullDescription)
+
+    val internalClassUsages = verificationResult.internalApiUsages.filterIsInstance<InternalClassUsage>()
+    assertEquals(2, internalClassUsages.size)
+    // ignore internal ByteBuddy delegates due to MethodDelegations
+    val relevantInternalClassUsages = internalClassUsages.filterNot { u -> u.fullDescription.contains("usage.Usage.delegate$") }
+    assertEquals(1, relevantInternalClassUsages.size)
+    val internalClassUsageMsg = "Internal class com.intellij.openapi.InternalApiService " +
+            "is referenced in usage.Usage.delegateFortyTwo() : int. " +
+            "This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation " +
+            "or @com.intellij.openapi.util.IntellijInternalApi annotation " +
+            "and indicates that the class is not supposed to be used in client code."
+    assertEquals(internalClassUsageMsg, relevantInternalClassUsages[0].fullDescription)
+  }
+
+  private fun buildIdePlugin(
+    pluginClassesContentBuilder: (ContentBuilder).() -> Unit
+  ): IdePlugin {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
+      this.pluginClassesContentBuilder()
+
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              <id>someId</id>
+              <name>someName</name>
+              <version>someVersion</version>
+              ""<vendor email="vendor.com" url="url">vendor</vendor>""
+              <description>this description is looooooooooong enough</description>
+              <change-notes>these change-notes are looooooooooong enough</change-notes>
+              <idea-version since-build="131.1"/>
+              <depends>org.intellij.groovy</depends>
+              <depends>com.intellij.modules.java</depends>
+            </idea-plugin>
+            """.trimIndent()
+        }
+      }
+    }
+
+    return (IdePluginManager.createManager().createPlugin(pluginFile) as PluginCreationSuccess).plugin
+  }
+
+  private fun buildIdeWithBundledPlugins(
+          javaPluginClassesBuilder: (ContentBuilder).() -> Unit,
+          groovyPluginClassesBuilder: (ContentBuilder).() -> Unit
+  ): Ide {
+    val ideaDirectory = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
+      file("build.txt", "IU-192.1")
+      dir("lib") {
+        zip("idea.jar") {
+          dir("META-INF") {
+            file("plugin.xml") {
+              """
+                <idea-plugin>
+                  <id>com.intellij</id>
+                  <name>IDEA CORE</name>
+                  <version>1.0</version>
+                  <module value="com.intellij.modules.all"/>                
+                </idea-plugin>
+                """.trimIndent()
+            }
+          }
+        }
+      }
+      dir("plugins") {
+        dir("java") {
+          dir("lib") {
+            zip("java.jar") {
+              dir("META-INF") {
+                file("plugin.xml") {
+                  """
+                    <idea-plugin>
+                      <id>com.intellij.java</id>
+                      <module value="com.intellij.modules.java"/>
+                    </idea-plugin>
+                    """.trimIndent()
+                }
+              }
+
+              //Generate content of Java plugin.
+              this.javaPluginClassesBuilder()
+            }
+          }
+        }
+        dir("groovy") {
+          dir("lib") {
+            zip("groovy.jar") {
+              dir("META-INF") {
+                file("plugin.xml") {
+                  """
+                    <idea-plugin>
+                      <id>org.intellij.groovy</id>
+                      <depends>com.intellij.modules.java</depends>
+                    </idea-plugin>
+                  """
+                }
+              }
+
+              //Generate content of Groovy plugin.
+              this.groovyPluginClassesBuilder()
+            }
+          }
+        }
+      }
+    }
+
+    // Fast assert IDE is fine
+
+    val ide = IdeManager.createManager().createIde(ideaDirectory)
+    assertEquals("IU-192.1", ide.version.asString())
+
+    val javaPlugin = ide.bundledPlugins.find { it.pluginId == "com.intellij.java" }!!
+    assertEquals("com.intellij.java", javaPlugin.pluginId)
+    assertEquals(setOf("com.intellij.modules.java"), javaPlugin.definedModules)
+
+    val groovyPlugin = ide.bundledPlugins.find { it.pluginId == "org.intellij.groovy" }!!
+    assertEquals("org.intellij.groovy", groovyPlugin.pluginId)
+
+    return ide
+  }
+
+
+  object IntellijInternalApiDump : Opcodes {
+    @Throws(Exception::class)
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      var annotationVisitor: AnnotationVisitor
+      classWriter.visit(V1_8, ACC_PUBLIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE, "com/intellij/openapi/util/IntellijInternalApi", null, "java/lang/Object", arrayOf<String>("java/lang/annotation/Annotation"))
+      classWriter.visitSource("IntellijInternalApi.java", null)
+      run {
+        annotationVisitor = classWriter.visitAnnotation("Ljava/lang/annotation/Retention;", true)
+        annotationVisitor.visitEnum("value", "Ljava/lang/annotation/RetentionPolicy;", "RUNTIME")
+        annotationVisitor.visitEnd()
+      }
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.tests

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
@@ -6,6 +6,7 @@ import com.jetbrains.pluginverifier.PluginVerificationDescriptor
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerifier
 import com.jetbrains.pluginverifier.dependencies.resolution.BundledPluginDependencyFinder
+import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
 import com.jetbrains.pluginverifier.filtering.ProblemsFilter
 import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.options.CmdOpts
@@ -26,7 +27,7 @@ import kotlin.io.path.createTempDirectory
 
 class VerificationRunner {
 
-  fun runPluginVerification(ide: Ide, idePlugin: IdePlugin, problemsFilters: List<ProblemsFilter> = emptyList()): PluginVerificationResult {
+  fun runPluginVerification(ide: Ide, idePlugin: IdePlugin, problemsFilters: List<ProblemsFilter> = emptyList(), apiUsageFilters: List<ApiUsageFilter> = emptyList()): PluginVerificationResult {
     val tempDownloadDir = createTempDirectory().toFile().apply { deleteOnExit() }.toPath()
     val pluginFilesBank = PluginFilesBank.create(MarketplaceRepository(URL("https://unused.com")), tempDownloadDir, DiskSpaceSetting(SpaceAmount.ZERO_SPACE))
 
@@ -51,7 +52,8 @@ class VerificationRunner {
         problemsFilters,
         pluginDetailsCache,
         listOf(DynamicallyLoadedFilter()),
-          false
+          false,
+        apiUsageFilters
       )
       pluginVerifier.loadPluginAndVerify()
     }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.pluginverifier.tests
 
 import com.jetbrains.plugin.structure.ide.Ide


### PR DESCRIPTION
See [MP-3282](https://youtrack.jetbrains.com/issue/MP-3282)

- introduce `ApiUsageFilter` to classify API usages to relevant and irrelevant. This is in the same vein as `ProblemsFilter`
- `PluginVerifier` may be provided with list of `ApiUsageFilter`-s.
- a `InternalApiUsageFilter` for JetBrains-related plugins is introduced. This is not enabled by default. It allows to ignore internal API usages from internal plugins.
- a new field -- `ignoredInternalApiUsages` is introduced in the `PluginVerificationResult`. This contains internal API usages that have been filtered out by any of the `ApiUsageFilter`-s.
- a parametric test that uses ByteBuddy to create multiple variants of API usages has been introduced in `InternalApiUsagePluginTest`.