### PR TITLE
Remove dependency on kotlin-stdlib and kotlin-stdlib-jdk8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
-kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotson = { group = "com.github.salomonbrys.kotson", name = "kotson", version.ref = "kotson" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }

--- a/ide-diff-builder/build.gradle.kts
+++ b/ide-diff-builder/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
 
     testImplementation(sharedLibs.junit)
     testImplementation(project(":"))
-    implementation(sharedLibs.kotlin.stdlib.jdk8)
 
     val structureVersion = "dev"
     implementation(group = "org.jetbrains.intellij.plugins", name = "verifier-intellij", version = structureVersion)

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -22,10 +22,6 @@ allprojects {
     mavenLocal()
   }
 
-  dependencies {
-    implementation(rootProject.sharedLibs.kotlin.stdlib)
-  }
-
   java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -33,7 +33,6 @@ allprojects {
     mavenCentral()
   }
   dependencies {
-    implementation(rootProject.sharedLibs.kotlin.stdlib.jdk8)
     implementation(rootProject.sharedLibs.jackson.module.kotlin)
     implementation(rootProject.sharedLibs.kotlin.reflect)
   }

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -45,7 +45,6 @@ allprojects {
 
   dependencies {
 
-    implementation(rootProject.sharedLibs.kotlin.stdlib.jdk8)
     implementation(rootProject.sharedLibs.kotlin.reflect)
 
     implementation("org.jetbrains.intellij.plugins:structure-intellij:$intellijStructureVersion")

--- a/plugins-verifier-service/build.gradle.kts
+++ b/plugins-verifier-service/build.gradle.kts
@@ -70,7 +70,6 @@ allprojects {
     implementation(libs.spring.boot.devtools)
 
     testImplementation(sharedLibs.junit)
-    implementation(sharedLibs.kotlin.stdlib.jdk8)
     implementation(sharedLibs.kotson)
     implementation(sharedLibs.gson)
 


### PR DESCRIPTION
Since Kotlin 1.8, 'kotlin-stdlib-jdk8' has been merged to stdlib. See https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target

Kotlin Gradle plugin adds 'kotlin-stdlib' automatically to all source sets. See https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library