### PR TITLE
Validate plugin IDs for specific prefixes and product names

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IntelliJPlatformProduct.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IntelliJPlatformProduct.kt
@@ -25,7 +25,7 @@ enum class IntelliJPlatformProduct(
   PYCHARM_EDU("PE", "PyCharm Educational", "PyCharmEdu", "PCE"),
   PHP_STORM("PS", "PhpStorm", "PhpStorm"),
   WEB_STORM("WS", "WebStorm", "WebStorm"),
-  APPCODE("OC", "AppCode", "AppCode"),
+  APPCODE("OC", "AppCode", "AppCode", "AC"),
   CLION("CL", "CLion", "CLion"),
   DATA_GRIP("DB", "DataGrip", "DataGrip", "DG"),
   RIDER("RD", "Rider", "Rider"),
@@ -34,7 +34,9 @@ enum class IntelliJPlatformProduct(
   ANDROID_STUDIO("AI", "Android Studio", "AndroidStudio"),
   DATA_SPELL("DS", "DataSpell", "DataSpell"),
   JETBRAINS_CLIENT("JBC", "JetBrains Client", "JetBrainsClient"),
-  GATEWAY("GW", "Gateway", "Gateway");
+  GATEWAY("GW", "Gateway", "Gateway"),
+  FLEET("FL", "Fleet", "Fleet"),
+  AQUA("QA", "Aqua", "Aqua");
 
   companion object {
     fun fromProductCode(productCode: String): IntelliJPlatformProduct? =

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -15,6 +15,7 @@ import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
+import com.jetbrains.plugin.structure.intellij.verifiers.validateNewlines
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.xinclude.XIncluder
 import com.jetbrains.plugin.structure.intellij.xinclude.XIncluderException
@@ -726,7 +727,7 @@ internal class PluginCreator private constructor(
           registerProblem(TemplateWordInPluginName(descriptorPath, templateWord))
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
-        validateNewlines("name", name)
+        validateNewlines("name", name, descriptorPath, ::registerProblem)
       }
     }
   }
@@ -778,12 +779,6 @@ internal class PluginCreator private constructor(
     }
 
     validatePropertyLength("<change-notes>", changeNotes, MAX_LONG_PROPERTY_LENGTH)
-  }
-
-  private fun validateNewlines(propertyName: String, propertyValue: String) {
-    if (propertyValue.trim().contains("\n")) {
-      registerProblem(ContainsNewlines(propertyName, descriptorPath))
-    }
   }
 
   private fun validatePropertyLength(propertyName: String, propertyValue: String, maxLength: Int) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -711,21 +711,7 @@ internal class PluginCreator private constructor(
   private fun hasErrors() = problems.any { it.level === PluginProblem.Level.ERROR }
 
   private fun validateId(plugin: PluginBean, id: String?) {
-    if (id != null) {
-      when {
-        id.isBlank() -> {
-          registerProblem(PropertyNotSpecified("id"))
-        }
-        "com.your.company.unique.plugin.id" == id -> {
-          registerProblem(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.ID, id))
-        }
-        else -> {
-          validatePropertyLength("id", id, MAX_PROPERTY_LENGTH)
-          validateNewlines("id", id)
-          pluginIdVerifier.verify(plugin, descriptorPath, ::registerProblem)
-        }
-      }
-    }
+    pluginIdVerifier.verify(plugin, descriptorPath, ::registerProblem)
   }
 
   private fun validateName(name: String?) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -15,7 +15,7 @@ import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
-import com.jetbrains.plugin.structure.intellij.verifiers.validateNewlines
+import com.jetbrains.plugin.structure.intellij.verifiers.verifyNewlines
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.xinclude.XIncluder
 import com.jetbrains.plugin.structure.intellij.xinclude.XIncluderException
@@ -727,7 +727,7 @@ internal class PluginCreator private constructor(
           registerProblem(TemplateWordInPluginName(descriptorPath, templateWord))
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
-        validateNewlines("name", name, descriptorPath, ::registerProblem)
+        verifyNewlines("name", name, descriptorPath, ::registerProblem)
       }
     }
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -477,7 +477,7 @@ internal class PluginCreator private constructor(
       validateBeanUrl(bean.url)
     }
     if (validateDescriptor || bean.id != null) {
-      validateId(bean, bean.id)
+      validateId(bean)
     }
     if (validateDescriptor || bean.name != null) {
       validateName(bean.name)
@@ -711,7 +711,7 @@ internal class PluginCreator private constructor(
 
   private fun hasErrors() = problems.any { it.level === PluginProblem.Level.ERROR }
 
-  private fun validateId(plugin: PluginBean, id: String?) {
+  private fun validateId(plugin: PluginBean) {
     pluginIdVerifier.verify(plugin, descriptorPath, ::registerProblem)
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
@@ -1,0 +1,33 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+const val CORE_PLUGIN_ID = "com.intellij"
+const val SPECIAL_IDEA_PLUGIN_ID = "IDEA CORE"
+const val VENDOR_JETBRAINS = "JetBrains"
+const val VENDOR_JETBRAINS_SRO = "JetBrains s.r.o."
+
+/**
+ * Plugin Vendors that identify JetBrains-related plugins.
+ *
+ * @see com.intellij.ide.plugins.PluginManagerCore#isDeveloperByJetBrains
+ */
+object PluginVendors {
+  fun isDevelopedByJetBrains(plugin: IdePlugin): Boolean {
+    return CORE_PLUGIN_ID == plugin.pluginId ||
+      SPECIAL_IDEA_PLUGIN_ID == plugin.pluginId ||
+      isDevelopedByJetBrains(plugin.vendor)
+  }
+
+  private fun isDevelopedByJetBrains(vendorString: String?): Boolean {
+    if (vendorString == null) {
+      return false
+    }
+    return vendorString.split(",")
+      .map(String::trim)
+      .filter(String::isNotEmpty)
+      .any(::isVendorJetBrains)
+  }
+
+  private fun isVendorJetBrains(vendorItem: String?): Boolean {
+    return VENDOR_JETBRAINS == vendorItem || VENDOR_JETBRAINS_SRO == vendorItem
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginVendors.kt
@@ -1,9 +1,5 @@
 package com.jetbrains.plugin.structure.intellij.plugin
 
-const val CORE_PLUGIN_ID = "com.intellij"
-const val SPECIAL_IDEA_PLUGIN_ID = "IDEA CORE"
-const val VENDOR_JETBRAINS = "JetBrains"
-const val VENDOR_JETBRAINS_SRO = "JetBrains s.r.o."
 
 /**
  * Plugin Vendors that identify JetBrains-related plugins.
@@ -11,6 +7,11 @@ const val VENDOR_JETBRAINS_SRO = "JetBrains s.r.o."
  * @see com.intellij.ide.plugins.PluginManagerCore#isDeveloperByJetBrains
  */
 object PluginVendors {
+  private const val CORE_PLUGIN_ID = "com.intellij"
+  private const val SPECIAL_IDEA_PLUGIN_ID = "IDEA CORE"
+  private const val VENDOR_JETBRAINS = "JetBrains"
+  private const val VENDOR_JETBRAINS_SRO = "JetBrains s.r.o."
+
   fun isDevelopedByJetBrains(plugin: IdePlugin): Boolean {
     return CORE_PLUGIN_ID == plugin.pluginId ||
       SPECIAL_IDEA_PLUGIN_ID == plugin.pluginId ||

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -37,6 +37,16 @@ class TemplateWordInPluginName(private val descriptorPath: String, private val t
 
 }
 
+class TemplateWordInPluginId(private val descriptorPath: String, private val templateWord: String) : PluginProblem() {
+
+  override val level
+    get() = Level.WARNING
+
+  override val message
+    get() = "Plugin ID specified in $descriptorPath should not contain the word '$templateWord'"
+
+}
+
 class OptionalDependencyDescriptorResolutionProblem(
   private val dependencyId: String,
   private val configurationFile: String,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -5,6 +5,7 @@
 package com.jetbrains.plugin.structure.intellij.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionError
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
@@ -153,3 +154,18 @@ class SuspiciousUntilBuild(
   override val level
     get() = Level.WARNING
 }
+
+open class IllegalPluginId(private val illegalPluginId: String) : InvalidDescriptorProblem("id") {
+
+  override val level
+    get() = Level.WARNING
+
+  override val detailedMessage
+    get() = "Plugin ID '$illegalPluginId' is not valid. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
+}
+
+class IllegalPluginIdPrefix(private val illegalPluginId: String, private val illegalPrefix: String) : IllegalPluginId(illegalPluginId) {
+  override val detailedMessage
+    get() = "Plugin ID '$illegalPluginId' has an illegal prefix '$illegalPrefix'. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
+}
+

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -44,7 +44,7 @@ class TemplateWordInPluginId(private val descriptorPath: String, private val tem
     get() = Level.WARNING
 
   override val message
-    get() = "Plugin ID specified in $descriptorPath should not contain the word '$templateWord'"
+    get() = "Plugin ID specified in $descriptorPath should not contain '$templateWord'"
 
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
@@ -21,3 +21,18 @@ class HttpLinkInDescription(private val link: String) : InvalidDescriptorProblem
   override val detailedMessage
     get() = "All links in description must be HTTPS: $link"
 }
+
+open class IllegalPluginId(private val illegalPluginId: String) : InvalidDescriptorProblem("id") {
+
+  override val level
+    get() = Level.UNACCEPTABLE_WARNING
+
+  override val detailedMessage
+    get() = "Plugin ID '$illegalPluginId' is not valid. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
+}
+
+class IllegalPluginIdPrefix(private val illegalPluginId: String, private val illegalPrefix: String) : IllegalPluginId(illegalPluginId) {
+  override val detailedMessage
+    get() = "Plugin ID '$illegalPluginId' has an illegal prefix '$illegalPrefix'. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
+}
+

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
@@ -22,17 +22,3 @@ class HttpLinkInDescription(private val link: String) : InvalidDescriptorProblem
     get() = "All links in description must be HTTPS: $link"
 }
 
-open class IllegalPluginId(private val illegalPluginId: String) : InvalidDescriptorProblem("id") {
-
-  override val level
-    get() = Level.UNACCEPTABLE_WARNING
-
-  override val detailedMessage
-    get() = "Plugin ID '$illegalPluginId' is not valid. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
-}
-
-class IllegalPluginIdPrefix(private val illegalPluginId: String, private val illegalPrefix: String) : IllegalPluginId(illegalPluginId) {
-  override val detailedMessage
-    get() = "Plugin ID '$illegalPluginId' has an illegal prefix '$illegalPrefix'. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
-}
-

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
-import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import com.jetbrains.plugin.structure.intellij.plugin.CORE_PLUGIN_ID

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -30,7 +30,7 @@ class PluginIdVerifier {
       }
       else -> {
         validatePropertyLength("id", id, MAX_PROPERTY_LENGTH, descriptorPath, problemRegistrar)
-        validateNewlines("id", id, descriptorPath, problemRegistrar)
+        verifyNewlines("id", id, descriptorPath, problemRegistrar)
         verifyPrefix(plugin, descriptorPath, problemRegistrar)
       }
     }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -11,8 +11,9 @@ val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example
 val JETBRAINS_VENDORS = listOf("JetBrains", "JetBrains s.r.o.")
 
 val PRODUCT_ID_RESTRICTED_WORDS = listOf(
-  "clion",  "datagrip", "datalore", "dataspell", "dotcover", "dotmemory", "dotpeek", "dottrace", "fleet", "goland",
-  "intellij", "phpstorm", "pycharm", "resharper", "rider", "rubymine", "space", "webstorm", "youtrack",
+  "aqua", "clion",  "datagrip", "datalore",
+  "dataspell", "dotcover", "dotmemory", "dotpeek", "dottrace", "fleet", "goland",
+  "intellij", "qodana", "phpstorm", "pycharm", "resharper", "rider", "rubymine", "space", "webstorm", "youtrack",
 )
 
 class PluginIdVerifier {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -29,7 +29,7 @@ class PluginIdVerifier {
         problemRegistrar.registerProblem(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.ID, id))
       }
       else -> {
-        validatePropertyLength("id", id, MAX_PROPERTY_LENGTH, descriptorPath, problemRegistrar)
+        verifyPropertyLength("id", id, MAX_PROPERTY_LENGTH, descriptorPath, problemRegistrar)
         verifyNewlines("id", id, descriptorPath, problemRegistrar)
         verifyPrefix(plugin, descriptorPath, problemRegistrar)
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -1,11 +1,10 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
-import com.jetbrains.plugin.structure.intellij.plugin.*
+import com.jetbrains.plugin.structure.intellij.plugin.CORE_PLUGIN_ID
+import com.jetbrains.plugin.structure.intellij.plugin.SPECIAL_IDEA_PLUGIN_ID
 import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginIdPrefix
-import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
 
 /*
@@ -23,7 +22,6 @@ val PRODUCT_ID_RESTRICTED_WORDS = listOf(
 class PluginIdVerifier {
 
   fun verify(plugin: PluginBean, descriptorPath: String, problemConsumer: (PluginProblem) -> Unit) {
-    val id = plugin.id ?: return
     verifyPrefix(plugin, descriptorPath, problemConsumer)
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -1,0 +1,49 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+import com.jetbrains.plugin.structure.intellij.plugin.*
+import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginIdPrefix
+import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
+import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
+
+/*
+com.example.X and others which are clearly not "real"
+non-JB plugins: anything containing jetbrains other than "our" official plugin ID prefixes (com.intellij.X, org.jetbrains.X ?)
+non-JB plugins: anything containing our product names e.g. intellij
+ */
+val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example", "edu.example", "com.intellij", "org.jetbrains")
+
+val PRODUCT_ID_RESTRICTED_WORDS = listOf(
+  "clion",  "datagrip", "datalore", "dataspell", "dotcover", "dotmemory", "dotpeek", "dottrace", "fleet", "goland",
+  "intellij", "phpstorm", "pycharm", "resharper", "rider", "rubymine", "space", "webstorm", "youtrack",
+)
+
+class PluginIdVerifier {
+
+  fun verify(plugin: PluginBean, descriptorPath: String, problemConsumer: (PluginProblem) -> Unit) {
+    val id = plugin.id ?: return
+    verifyPrefix(plugin, descriptorPath, problemConsumer)
+  }
+
+  private fun verifyPrefix(plugin: PluginBean, descriptorPath: String, problemConsumer: (PluginProblem) -> Unit) {
+    if (isDevelopedByJetBrains(plugin)) {
+      return
+    }
+    val id = plugin.id
+    DEFAULT_ILLEGAL_PREFIXES
+      .filter(id::startsWith)
+      .forEach { problemConsumer(IllegalPluginIdPrefix(id, it)) }
+
+    id.split('.')
+      .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent) }
+      .forEach { idComponent -> problemConsumer(TemplateWordInPluginId(descriptorPath, idComponent)) }
+  }
+
+  private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {
+    return CORE_PLUGIN_ID == plugin.id ||
+      SPECIAL_IDEA_PLUGIN_ID == plugin.id
+  }
+
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -42,7 +42,7 @@ class PluginIdVerifier {
     }
     val id = plugin.id
     DEFAULT_ILLEGAL_PREFIXES
-      .filter { illegalPrefix -> id.startsWith(illegalPrefix) }
+      .filter(id::startsWith)
       .forEach { problemRegistrar.registerProblem(IllegalPluginIdPrefix(id, it)) }
 
     id.split('.')

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -9,11 +9,6 @@ import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginIdPrefix
 import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
 
-/*
-com.example.X and others which are clearly not "real"
-non-JB plugins: anything containing jetbrains other than "our" official plugin ID prefixes (com.intellij.X, org.jetbrains.X ?)
-non-JB plugins: anything containing our product names e.g. intellij
- */
 val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example", "edu.example", "com.intellij", "org.jetbrains")
 
 val PRODUCT_ID_RESTRICTED_WORDS = listOf(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -4,7 +4,6 @@ import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import com.jetbrains.plugin.structure.intellij.plugin.CORE_PLUGIN_ID
-import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.SPECIAL_IDEA_PLUGIN_ID
 import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginIdPrefix
 import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
@@ -24,40 +23,36 @@ val PRODUCT_ID_RESTRICTED_WORDS = listOf(
 
 class PluginIdVerifier {
 
-  fun verify(plugin: PluginBean, descriptorPath: String, problemConsumer: (PluginProblem) -> Unit) {
+  fun verify(plugin: PluginBean, descriptorPath: String, problemRegistrar: ProblemRegistrar) {
     val id = plugin.id ?: return
 
     when {
       id.isBlank() -> {
-        problemConsumer(PropertyNotSpecified("id"))
+        problemRegistrar.registerProblem(PropertyNotSpecified("id"))
       }
       "com.your.company.unique.plugin.id" == id -> {
-        problemConsumer(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.ID, id))
+        problemRegistrar.registerProblem(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.ID, id))
       }
       else -> {
-        validatePropertyLength("id", id, MAX_PROPERTY_LENGTH) {
-          problemConsumer(it)
-        }
-        validateNewlines("id", id) {
-          problemConsumer(it)
-        }
-        verifyPrefix(plugin, descriptorPath, problemConsumer)
+        validatePropertyLength("id", id, MAX_PROPERTY_LENGTH, descriptorPath, problemRegistrar)
+        validateNewlines("id", id, descriptorPath, problemRegistrar)
+        verifyPrefix(plugin, descriptorPath, problemRegistrar)
       }
     }
   }
 
-  private fun verifyPrefix(plugin: PluginBean, descriptorPath: String, problemConsumer: (PluginProblem) -> Unit) {
+  private fun verifyPrefix(plugin: PluginBean, descriptorPath: String, problemRegistrar: ProblemRegistrar) {
     if (isDevelopedByJetBrains(plugin)) {
       return
     }
     val id = plugin.id
     DEFAULT_ILLEGAL_PREFIXES
       .filter(id::startsWith)
-      .forEach { problemConsumer(IllegalPluginIdPrefix(id, it)) }
+      .forEach { problemRegistrar.registerProblem(IllegalPluginIdPrefix(id, it)) }
 
     id.split('.')
       .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent) }
-      .forEach { idComponent -> problemConsumer(TemplateWordInPluginId(descriptorPath, idComponent)) }
+      .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, idComponent)) }
   }
 
   private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -42,16 +42,16 @@ class PluginIdVerifier {
     }
     val id = plugin.id
     DEFAULT_ILLEGAL_PREFIXES
-      .filter(id::startsWith)
+      .filter { illegalPrefix -> id.startsWith(illegalPrefix) }
       .forEach { problemRegistrar.registerProblem(IllegalPluginIdPrefix(id, it)) }
 
     id.split('.')
-      .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent) }
+      .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.toLowerCase()) }
       .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, idComponent)) }
   }
 
   private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {
-    return JETBRAINS_VENDORS.contains(plugin.vendor.name)
+    return JETBRAINS_VENDORS.contains(plugin.vendor?.name)
   }
 
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -2,13 +2,13 @@ package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
-import com.jetbrains.plugin.structure.intellij.plugin.CORE_PLUGIN_ID
-import com.jetbrains.plugin.structure.intellij.plugin.SPECIAL_IDEA_PLUGIN_ID
 import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginIdPrefix
 import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
 
 val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example", "edu.example", "com.intellij", "org.jetbrains")
+
+val JETBRAINS_VENDORS = listOf("JetBrains", "JetBrains s.r.o.")
 
 val PRODUCT_ID_RESTRICTED_WORDS = listOf(
   "clion",  "datagrip", "datalore", "dataspell", "dotcover", "dotmemory", "dotpeek", "dottrace", "fleet", "goland",
@@ -50,8 +50,7 @@ class PluginIdVerifier {
   }
 
   private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {
-    return CORE_PLUGIN_ID == plugin.id ||
-      SPECIAL_IDEA_PLUGIN_ID == plugin.id
+    return JETBRAINS_VENDORS.contains(plugin.vendor.name)
   }
 
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProblemRegistrar.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProblemRegistrar.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+
+fun interface ProblemRegistrar {
+  fun registerProblem(problem: PluginProblem)
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
-import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
 import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -4,8 +4,6 @@ import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
 import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 
-typealias ProblemRegistrar = (PluginProblem) -> Unit
-
 const val DEFAULT_DESCRIPTOR_PATH = "plugin.xml"
 
 const val MAX_PROPERTY_LENGTH = 255
@@ -14,13 +12,13 @@ fun validateNewlines(propertyName: String, propertyValue: String,
                      descriptorPath: String = DEFAULT_DESCRIPTOR_PATH,
                      problemRegistrar: ProblemRegistrar) {
   if (propertyValue.trim().contains("\n")) {
-    problemRegistrar(ContainsNewlines(propertyName, descriptorPath))
+    problemRegistrar.registerProblem(ContainsNewlines(propertyName, descriptorPath))
   }
 }
 
 fun validatePropertyLength(propertyName: String, propertyValue: String, maxLength: Int,
                            descriptorPath: String = DEFAULT_DESCRIPTOR_PATH, problemRegistrar: ProblemRegistrar) {
   if (propertyValue.length > maxLength) {
-    problemRegistrar(TooLongPropertyValue(descriptorPath, propertyName, propertyValue.length, maxLength))
+    problemRegistrar.registerProblem(TooLongPropertyValue(descriptorPath, propertyName, propertyValue.length, maxLength))
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -6,9 +6,9 @@ import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 
 const val MAX_PROPERTY_LENGTH = 255
 
-fun validateNewlines(propertyName: String, propertyValue: String,
-                     descriptorPath: String = PLUGIN_XML,
-                     problemRegistrar: ProblemRegistrar) {
+fun verifyNewlines(propertyName: String, propertyValue: String,
+                   descriptorPath: String = PLUGIN_XML,
+                   problemRegistrar: ProblemRegistrar) {
   if (propertyValue.trim().contains("\n")) {
     problemRegistrar.registerProblem(ContainsNewlines(propertyName, descriptorPath))
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -1,14 +1,13 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.PLUGIN_XML
 import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
-
-const val DEFAULT_DESCRIPTOR_PATH = "plugin.xml"
 
 const val MAX_PROPERTY_LENGTH = 255
 
 fun validateNewlines(propertyName: String, propertyValue: String,
-                     descriptorPath: String = DEFAULT_DESCRIPTOR_PATH,
+                     descriptorPath: String = PLUGIN_XML,
                      problemRegistrar: ProblemRegistrar) {
   if (propertyValue.trim().contains("\n")) {
     problemRegistrar.registerProblem(ContainsNewlines(propertyName, descriptorPath))
@@ -16,7 +15,7 @@ fun validateNewlines(propertyName: String, propertyValue: String,
 }
 
 fun validatePropertyLength(propertyName: String, propertyValue: String, maxLength: Int,
-                           descriptorPath: String = DEFAULT_DESCRIPTOR_PATH, problemRegistrar: ProblemRegistrar) {
+                           descriptorPath: String = PLUGIN_XML, problemRegistrar: ProblemRegistrar) {
   if (propertyValue.length > maxLength) {
     problemRegistrar.registerProblem(TooLongPropertyValue(descriptorPath, propertyName, propertyValue.length, maxLength))
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -14,8 +14,8 @@ fun verifyNewlines(propertyName: String, propertyValue: String,
   }
 }
 
-fun validatePropertyLength(propertyName: String, propertyValue: String, maxLength: Int,
-                           descriptorPath: String = PLUGIN_XML, problemRegistrar: ProblemRegistrar) {
+fun verifyPropertyLength(propertyName: String, propertyValue: String, maxLength: Int,
+                         descriptorPath: String = PLUGIN_XML, problemRegistrar: ProblemRegistrar) {
   if (propertyValue.length > maxLength) {
     problemRegistrar.registerProblem(TooLongPropertyValue(descriptorPath, propertyName, propertyValue.length, maxLength))
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/SimpleVerifiers.kt
@@ -1,0 +1,26 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
+import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
+
+typealias ProblemRegistrar = (PluginProblem) -> Unit
+
+const val DEFAULT_DESCRIPTOR_PATH = "plugin.xml"
+
+const val MAX_PROPERTY_LENGTH = 255
+
+fun validateNewlines(propertyName: String, propertyValue: String,
+                     descriptorPath: String = DEFAULT_DESCRIPTOR_PATH,
+                     problemRegistrar: ProblemRegistrar) {
+  if (propertyValue.trim().contains("\n")) {
+    problemRegistrar(ContainsNewlines(propertyName, descriptorPath))
+  }
+}
+
+fun validatePropertyLength(propertyName: String, propertyValue: String, maxLength: Int,
+                           descriptorPath: String = DEFAULT_DESCRIPTOR_PATH, problemRegistrar: ProblemRegistrar) {
+  if (propertyValue.length > maxLength) {
+    problemRegistrar(TooLongPropertyValue(descriptorPath, propertyName, propertyValue.length, maxLength))
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginVendorsTest.kt
@@ -1,0 +1,47 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import org.junit.Assert
+import org.junit.Test
+
+class PluginVendorsTest {
+  @Test
+  fun `has single vendor which is 3rd party`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.example.thirdparty"
+      vendor = "PluginIndustries s.r.o."
+    }
+    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    Assert.assertFalse(isInternalPlugin)
+  }
+
+  @Test
+  fun `has single vendor which is JetBrains`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.intellij.internal"
+      vendor = "JetBrains s.r.o."
+    }
+    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    Assert.assertTrue(isInternalPlugin)
+  }
+
+  @Test
+  fun `has multiple vendors and one is JetBrains`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.intellij"
+      vendor = "JetBrains s.r.o., JetBrains"
+    }
+    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    Assert.assertTrue(isInternalPlugin)
+  }
+
+  @Test
+  fun `has multiple vendors and none of those is JetBrains`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.intellij.someplugin"
+      vendor = "PluginIndustries s.r.o."
+    }
+    val isInternalPlugin = PluginVendors.isDevelopedByJetBrains(idePlugin)
+    Assert.assertFalse(isInternalPlugin)
+  }
+
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -1,0 +1,123 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+private const val DESCRIPTOR_PATH = "plugin.xml"
+
+class PluginIdVerifierTest {
+  private lateinit var verifier: PluginIdVerifier
+
+  @Before
+  fun setUp() {
+    verifier = PluginIdVerifier()
+  }
+
+  @Test
+  fun `plugin by JetBrains has no issues`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    val comIntellijPlugin = PluginBean().apply {
+      id = "com.intellij"
+    }
+
+    val ideaCorePlugin = PluginBean().apply {
+      id = "IDEA CORE"
+    }
+
+    val problemConsumer: (PluginProblem) -> Unit = {
+      problems += it
+    }
+    verifier.verify(comIntellijPlugin, DESCRIPTOR_PATH, problemConsumer)
+    verifier.verify(ideaCorePlugin, DESCRIPTOR_PATH, problemConsumer)
+
+    Assert.assertTrue(problems.isEmpty())
+  }
+
+
+  @Test
+  fun `plugin by 3rd party is disallowed`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    val orgJetBrains = "org.jetbrains"
+
+    val orgJetBrainsPlugin = PluginBean().apply {
+      id = orgJetBrains
+    }
+
+    val problemConsumer: (PluginProblem) -> Unit = {
+      problems += it
+    }
+    verifier.verify(orgJetBrainsPlugin, DESCRIPTOR_PATH, problemConsumer)
+
+    Assert.assertEquals(1, problems.size)
+    val problem = problems[0]
+    Assert.assertEquals("Invalid plugin descriptor 'id': " +
+      "Plugin ID '$orgJetBrains' has an illegal prefix 'org.jetbrains'. " +
+      "See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id", problem.message)
+  }
+
+  @Test
+  fun `plugin with generic ID is disallowed`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    val genericId = "com.example.genericplugin"
+
+    val orgJetBrainsPlugin = PluginBean().apply {
+      id = genericId
+    }
+
+    val problemConsumer: (PluginProblem) -> Unit = {
+      problems += it
+    }
+    verifier.verify(orgJetBrainsPlugin, DESCRIPTOR_PATH, problemConsumer)
+
+    Assert.assertEquals(1, problems.size)
+    val problem = problems[0]
+    Assert.assertEquals("Invalid plugin descriptor 'id': " +
+      "Plugin ID '$genericId' has an illegal prefix 'com.example'. " +
+      "See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id", problem.message)
+  }
+
+  @Test
+  fun `plugin with product name in ID is disallowed`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    val genericId = "vendor.rider.quickride"
+
+    val riderPlugin = PluginBean().apply {
+      id = genericId
+    }
+
+    val problemConsumer: (PluginProblem) -> Unit = {
+      problems += it
+    }
+    verifier.verify(riderPlugin, DESCRIPTOR_PATH, problemConsumer)
+
+    Assert.assertEquals(1, problems.size)
+    val problem = problems[0]
+    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain the word 'rider'", problem.message)
+  }
+
+  @Test
+  fun `plugin with partial product name in ID is allowed`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    // contains 'space' as a product name
+    val genericId = "vendor.spacetrip"
+
+    val riderPlugin = PluginBean().apply {
+      id = genericId
+    }
+
+    val problemConsumer: (PluginProblem) -> Unit = {
+      problems += it
+    }
+    verifier.verify(riderPlugin, DESCRIPTOR_PATH, problemConsumer)
+
+    Assert.assertTrue(problems.isEmpty())
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -80,31 +80,34 @@ class PluginIdVerifierTest {
 
     val riderPlugin = newPluginBean("vendor.rider.quickride", "Third Party Inc.")
 
+    val problemRegistrar = ProblemRegistrar {
+      problems += it
+    }
+
+    verifier.verify(riderPlugin, DESCRIPTOR_PATH, problemRegistrar)
+
+    Assert.assertEquals(1, problems.size)
+    val problem = problems[0]
+    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain 'rider'", problem.message)
+  }
+
+  @Test
+  fun `plugin with multiple case-sensitive names in ID is disallowed`() {
+    val problems = mutableListOf<PluginProblem>()
+
+    val riderPlugin = newPluginBean("vendor.DataLore.DataGrip", "Third Party Inc.")
+
     val problemConsumer: (PluginProblem) -> Unit = {
       problems += it
     }
     verifier.verify(riderPlugin, DESCRIPTOR_PATH, problemConsumer)
 
-    Assert.assertEquals(1, problems.size)
-    val problem = problems[0]
-    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain the word 'rider'", problem.message)
-  }
+    Assert.assertEquals(2, problems.size)
+    val dataLoreProblem = problems[0]
+    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain 'DataLore'", dataLoreProblem.message)
 
-  @Test
-  fun `plugin with partial product name in ID is allowed`() {
-    val problems = mutableListOf<PluginProblem>()
-
-    // contains 'space' as a product name, but this is allowed
-    val genericId = "vendor.spacetrip"
-
-    val plugin = newPluginBean(genericId, "Space Trip Vendor Inc.")
-
-    val problemConsumer: (PluginProblem) -> Unit = {
-      problems += it
-    }
-    verifier.verify(plugin, DESCRIPTOR_PATH, problemConsumer)
-
-    Assert.assertTrue(problems.isEmpty())
+    val dataGripProblem = problems[1]
+    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain 'DataGrip'", dataGripProblem.message)
   }
 
   private fun newPluginBean(pluginId: String, pluginVendor: String): PluginBean {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -67,13 +67,17 @@ class PluginIdVerifierTest {
 
   @Test
   fun `plugin with product name in ID is disallowed`() {
-    val riderPlugin = plugin("vendor.rider.quickride", "Third Party Inc.")
+    PRODUCT_ID_RESTRICTED_WORDS.forEach {
+      val plugin = plugin("vendor.$it.quickride", "Third Party Inc.")
 
-    verifier.verify(riderPlugin, DESCRIPTOR_PATH, problemRegistrar)
+      verifier.verify(plugin, DESCRIPTOR_PATH, problemRegistrar)
 
-    Assert.assertEquals(1, problems.size)
-    val problem = problems[0]
-    Assert.assertEquals("Plugin ID specified in plugin.xml should not contain 'rider'", problem.message)
+      Assert.assertEquals(1, problems.size)
+      val problem = problems[0]
+      Assert.assertEquals("Plugin ID specified in plugin.xml should not contain '$it'", problem.message)
+
+      problems.clear()
+    }
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -142,7 +142,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       perfectXmlBuilder.modify {
         id = "<id>com.example.plugin</id>"
       },
-    ).unacceptableWarnings.single()
+    ).warnings.single()
     assertEquals(IllegalPluginIdPrefix("com.example.plugin", "com.example"), warning)
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
+import com.jetbrains.plugin.structure.intellij.verifiers.PRODUCT_ID_RESTRICTED_WORDS
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert
@@ -133,6 +134,28 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       }
     )
     assertEquals(pluginId, plugin.plugin.pluginId)
+  }
+
+  @Test
+  fun `plugin id has forbidden prefix`() {
+    val warning = `test valid plugin xml`(
+      perfectXmlBuilder.modify {
+        id = "<id>com.example.plugin</id>"
+      },
+    ).unacceptableWarnings.single()
+    assertEquals(IllegalPluginIdPrefix("com.example.plugin", "com.example"), warning)
+  }
+
+  @Test
+  fun `plugin id has template word prefix`() {
+    PRODUCT_ID_RESTRICTED_WORDS.forEach { product ->
+      val warning = `test valid plugin xml`(
+        perfectXmlBuilder.modify {
+          id = "<id>plugin.${product}.improved</id>"
+        }
+      ).warnings.single()
+      assertEquals(TemplateWordInPluginId("plugin.xml", product), warning)
+    }
   }
 
   @Test


### PR DESCRIPTION
See [MP-5459](https://youtrack.jetbrains.com/issue/MP-5459)

Stricter rules for plugin IDs:

- specific words in plugin IDs are discouraged and treated as _warnings_
- specific plugin prefixes are discouraged and treated as _unnaceptable warnings_, such as `com.example` or JetBrains prefixes