### PR TITLE
Improve discovery of Java JDK for mock plugins

### DIFF
--- a/intellij-plugin-verifier/gradle/libs.versions.toml
+++ b/intellij-plugin-verifier/gradle/libs.versions.toml
@@ -4,7 +4,9 @@ byteBuddy = "1.14.5"
 commons-compress = "1.23.0"
 jgrapht-core = "1.5.2"
 jetbrains-pluginRepositoryRestClient = "2.0.32"
-okhttp-mockwebserver="4.11.0"
+okhttp-mockwebserver = "4.11.0"
+systemStubs-junit4 = "2.0.2"
+jimfs = "1.2"
 
 [libraries]
 bouncycastle-pkix = { group = "org.bouncycastle", name = "bcpkix-jdk15on", version.ref = "bcpkix-jdk15on" }
@@ -12,4 +14,7 @@ byteBuddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byteB
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress" }
 jgrapht-core = { group = "org.jgrapht", name = "jgrapht-core", version.ref = "jgrapht-core" }
 jetbrains-pluginRepositoryRestClient = { group = "org.jetbrains.intellij", name = "plugin-repository-rest-client", version.ref = "jetbrains-pluginRepositoryRestClient" }
-okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp-mockwebserver"}
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp-mockwebserver" }
+systemStubs-junit4 = { group = "uk.org.webcompere", name = "system-stubs-junit4", version.ref = "systemStubs.junit4" }
+jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }
+

--- a/intellij-plugin-verifier/verifier-test/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/build.gradle.kts
@@ -6,6 +6,10 @@ dependencies {
 
   //bytecode generation library
   implementation(libs.byteBuddy)
+
+  testImplementation("uk.org.webcompere:system-stubs-junit4:2.0.2")
+  testImplementation("uk.org.webcompere:system-stubs-junit4:2.0.2")
+  testImplementation("com.google.jimfs:jimfs:1.2")
 }
 
 val prepareMockPlugin by tasks.registering(Copy::class) {

--- a/intellij-plugin-verifier/verifier-test/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/build.gradle.kts
@@ -4,12 +4,10 @@ dependencies {
   testRuntimeOnly(sharedLibs.logback.classic)
   testRuntimeOnly(project("mock-plugin"))
 
-  //bytecode generation library
   implementation(libs.byteBuddy)
 
-  testImplementation("uk.org.webcompere:system-stubs-junit4:2.0.2")
-  testImplementation("uk.org.webcompere:system-stubs-junit4:2.0.2")
-  testImplementation("com.google.jimfs:jimfs:1.2")
+  testImplementation(libs.systemStubs.junit4)
+  testImplementation(libs.jimfs)
 }
 
 val prepareMockPlugin by tasks.registering(Copy::class) {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
@@ -11,9 +11,22 @@ object TestJdkDescriptorProvider {
   private const val JVM_HOME_DIRS = "/usr/lib/jvm"
 
   fun getJdkPathForTests(): Path {
-    val javaHome = System.getenv("JAVA_HOME")?.let { Paths.get(it) }
-    if (javaHome != null && javaHome.exists()) {
-      return javaHome
+    val javaHomeFromEnv = System.getenv("JAVA_HOME")?.let { Paths.get(it) }
+    if (javaHomeFromEnv != null && javaHomeFromEnv.exists()) {
+      return javaHomeFromEnv
+    }
+
+    val javaHomeFromProperty = System.getProperty("java.home")?.let { Paths.get(it) }
+    if (javaHomeFromProperty != null && javaHomeFromProperty.exists()) {
+      return javaHomeFromProperty
+    }
+
+    val javaHomeFromSdkMan = System.getProperty("user.home")?.let {
+      Paths.get(it, ".sdkman/candidates/java/current")
+    }
+
+    if (javaHomeFromSdkMan != null && javaHomeFromSdkMan.exists()) {
+      return javaHomeFromSdkMan
     }
 
     val jvmHomeDir = Paths.get(JVM_HOME_DIRS)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
@@ -3,7 +3,8 @@ package com.jetbrains.pluginverifier.tests.mocks
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.listFiles
-import java.lang.IllegalArgumentException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Path
@@ -11,6 +12,8 @@ import java.nio.file.Path
 const val PV_TESTJAVA_HOME_PROPERTY_NAME = "pluginverifier.testjava.home"
 
 object TestJdkDescriptorProvider {
+  private val LOG: Logger = LoggerFactory.getLogger(TestJdkDescriptorProvider::class.java)
+
   private const val JVM_HOME_DIRS = "/usr/lib/jvm"
 
   var filesystem: FileSystem = FileSystems.getDefault()
@@ -27,7 +30,7 @@ object TestJdkDescriptorProvider {
     return candidates.filterNotNull()
       .firstOrNull(Path::exists)
       .also {
-        println("Using $it as JDK in tests")
+        LOG.info("Using $it as JDK in tests")
       }
       ?: throw IllegalArgumentException("No suitable JDK is found for the test. " +
         "Set the JAVA_HOME environment variable, " +

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
@@ -8,6 +8,8 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
+const val PV_TESTJAVA_HOME_PROPERTY_NAME = "pluginverifier.testjava.home"
+
 object TestJdkDescriptorProvider {
   private const val JVM_HOME_DIRS = "/usr/lib/jvm"
 
@@ -15,6 +17,7 @@ object TestJdkDescriptorProvider {
 
   fun getJdkPathForTests(): Path {
     val candidates = mutableListOf<Path?>()
+    candidates.add(System.getProperty(PV_TESTJAVA_HOME_PROPERTY_NAME)?.let { filesystem.getPath(it) })
     candidates.add(System.getenv("JAVA_HOME")?.let { filesystem.getPath(it) })
     candidates.add(System.getProperty("user.home")?.let {
       filesystem.getPath(it, ".sdkman/candidates/java/current")

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
@@ -4,40 +4,42 @@ import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.listFiles
 import java.lang.IllegalArgumentException
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
 import java.nio.file.Path
-import java.nio.file.Paths
 
 object TestJdkDescriptorProvider {
   private const val JVM_HOME_DIRS = "/usr/lib/jvm"
 
+  var filesystem: FileSystem = FileSystems.getDefault()
+
   fun getJdkPathForTests(): Path {
-    val javaHomeFromEnv = System.getenv("JAVA_HOME")?.let { Paths.get(it) }
-    if (javaHomeFromEnv != null && javaHomeFromEnv.exists()) {
-      return javaHomeFromEnv
-    }
+    val candidates = mutableListOf<Path?>()
+    candidates.add(System.getenv("JAVA_HOME")?.let { filesystem.getPath(it) })
+    candidates.add(System.getProperty("user.home")?.let {
+      filesystem.getPath(it, ".sdkman/candidates/java/current")
+    })
+    candidates.add(fromJvmHomeDirs())
+    candidates.add(System.getProperty("java.home")?.let { filesystem.getPath(it) })
 
-    val javaHomeFromProperty = System.getProperty("java.home")?.let { Paths.get(it) }
-    if (javaHomeFromProperty != null && javaHomeFromProperty.exists()) {
-      return javaHomeFromProperty
-    }
-
-    val javaHomeFromSdkMan = System.getProperty("user.home")?.let {
-      Paths.get(it, ".sdkman/candidates/java/current")
-    }
-
-    if (javaHomeFromSdkMan != null && javaHomeFromSdkMan.exists()) {
-      return javaHomeFromSdkMan
-    }
-
-    val jvmHomeDir = Paths.get(JVM_HOME_DIRS)
-    if (jvmHomeDir.exists()) {
-      val someJdk = jvmHomeDir.listFiles().firstOrNull { it.isDirectory }
-      if (someJdk != null) {
-        println("Using $someJdk as JDK in tests")
-        return someJdk
+    return candidates.filterNotNull()
+      .firstOrNull(Path::exists)
+      .also {
+        println("Using $it as JDK in tests")
       }
-    }
+      ?: throw IllegalArgumentException("No suitable JDK is found for the test. " +
+        "Set the JAVA_HOME environment variable, " +
+        "or verify the 'java.home' property, " +
+        "or setup Java via SDKMan or install the JDK to the $JVM_HOME_DIRS directory")
+  }
 
-    throw IllegalArgumentException("No suitable JDK is found for the test. Set the JAVA_HOME environment variable or install the JDK to the $JVM_HOME_DIRS directory")
+  private fun fromJvmHomeDirs(): Path? {
+    val jvmHomeDir = filesystem.getPath(JVM_HOME_DIRS)
+    return when {
+      jvmHomeDir.exists() -> {
+        jvmHomeDir.listFiles().firstOrNull { it.isDirectory }
+      }
+      else -> null
+    }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProvider.kt
@@ -30,7 +30,7 @@ object TestJdkDescriptorProvider {
     return candidates.filterNotNull()
       .firstOrNull(Path::exists)
       .also {
-        LOG.info("Using $it as JDK in tests")
+        LOG.debug("Using {} as JDK in tests", it)
       }
       ?: throw IllegalArgumentException("No suitable JDK is found for the test. " +
         "Set the JAVA_HOME environment variable, " +

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/TestJdkDescriptorProviderTest.kt
@@ -1,0 +1,69 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.google.common.jimfs.Configuration.unix
+import com.google.common.jimfs.Jimfs
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import uk.org.webcompere.systemstubs.properties.SystemProperties
+import uk.org.webcompere.systemstubs.resource.Resources
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+private const val MOCK_PV_USER_HOME = "/home/pv"
+
+class JdkDescriptorProviderTest {
+  @Before
+  fun setUp() {
+    val fs = Jimfs.newFileSystem(unix())
+    TestJdkDescriptorProvider.filesystem = fs
+    Files.createDirectories(fs.getPath("/opt/java8"))
+    Files.createDirectories(fs.getPath("/opt/java11"))
+    Files.createDirectories(fs.getPath("$MOCK_PV_USER_HOME/.sdkman/candidates/java/current"))
+  }
+
+  @Test
+  fun `discover JDK in JAVA_HOME`() {
+    Resources.with<Unit>(EnvironmentVariables("JAVA_HOME", "/opt/java8"))
+      .execute {
+        val jdkPathForTests = TestJdkDescriptorProvider.getJdkPathForTests()
+        assertEquals(Path("/opt/java8"), jdkPathForTests)
+      }
+  }
+
+  @Test
+  fun `discover JDK in test system property`() {
+    Resources.with<Unit>(
+      SystemProperties(PV_TESTJAVA_HOME_PROPERTY_NAME, "/opt/java11").set("user.home", "/nonexistent"))
+      .execute {
+        val jdkPathForTests = TestJdkDescriptorProvider.getJdkPathForTests()
+        assertEquals(Path("/opt/java11"), jdkPathForTests)
+      }
+  }
+
+  @Test
+  fun `discover JDK in system property`() {
+    Resources.with<Unit>(EnvironmentVariables("JAVA_HOME", null),
+      SystemProperties("java.home", "/opt/java11").set("user.home", "/nonexistent"))
+      .execute {
+        val jdkPathForTests = TestJdkDescriptorProvider.getJdkPathForTests()
+        assertEquals(Path("/opt/java11"), jdkPathForTests)
+      }
+  }
+
+  @Test
+  fun `discover JDK in SDKMan property`() {
+    Resources.with<Unit>(EnvironmentVariables("JAVA_HOME", null),
+      SystemProperties("user.home", MOCK_PV_USER_HOME))
+      .execute {
+        val jdkPathForTests = TestJdkDescriptorProvider.getJdkPathForTests()
+        assertEquals(Path("$MOCK_PV_USER_HOME/.sdkman/candidates/java/current"), jdkPathForTests)
+      }
+  }
+
+  private fun assertEquals(expected: Path, actual: Path) {
+    assertEquals(expected.toString(), actual.toString())
+  }
+}


### PR DESCRIPTION
When discovering JDK for mock plugins and their descriptors, investigate

1. `pluginverifier.testjava.home` system property
2. `JAVA_HOME` environment variable
3. SDKMan common location (MacOS)
4. `java.home` system property 
5. fixed paths (Linux).