### PR TITLE
Treat Service EP 'preload' attribute as an error

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -15,6 +15,7 @@ import com.jetbrains.plugin.structure.intellij.problems.TooLongPropertyValue
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
+import com.jetbrains.plugin.structure.intellij.verifiers.ServiceExtensionPointPreloadVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.verifyNewlines
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.xinclude.XIncluder
@@ -625,6 +626,8 @@ internal class PluginCreator private constructor(
         registerProblem(ElementAvailableOnlySinceNewerVersion("projectListeners", listenersAvailableSinceBuild, sinceBuild, untilBuild))
       }
     }
+
+    ServiceExtensionPointPreloadVerifier().verify(plugin, ::registerProblem)
   }
 
   private fun resolveDocumentAndValidateBean(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.intellij.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 class PropertyWithDefaultValue(
@@ -199,4 +200,20 @@ class OptionalDependencyConfigFileIsEmpty(private val optionalDependencyId: Stri
 
   override val detailedMessage: String
     get() = "Optional dependency declaration on '$optionalDependencyId' cannot have empty \"config-file\""
+}
+
+class ServiceExtensionPointPreloadNotSupported(private val serviceType: IdePluginContentDescriptor.ServiceType) : PluginProblem() {
+  private val extensionPointPrefix = "com.intellij"
+
+  override val level
+    get() = Level.ERROR
+
+  override val message
+    get() = "Service preloading is deprecated in the <${serviceType.toXmlElement()}> element. Consider removing the 'preload' attribute and migrating to the listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+
+  private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = "$extensionPointPrefix." + when (this) {
+    IdePluginContentDescriptor.ServiceType.PROJECT -> "projectService"
+    IdePluginContentDescriptor.ServiceType.APPLICATION -> "applicationService"
+    IdePluginContentDescriptor.ServiceType.MODULE -> "moduleService"
+  }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -209,7 +209,7 @@ class ServiceExtensionPointPreloadNotSupported(private val serviceType: IdePlugi
     get() = Level.ERROR
 
   override val message
-    get() = "Service preloading is deprecated in the <${serviceType.toXmlElement()}> element. Consider removing the 'preload' attribute and migrating to the listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+    get() = "Service preloading is deprecated in the <${serviceType.toXmlElement()}> element. Consider removing the 'preload' attribute and migrating to listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
 
   private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = "$extensionPointPrefix." + when (this) {
     IdePluginContentDescriptor.ServiceType.PROJECT -> "projectService"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -7,6 +7,7 @@ package com.jetbrains.plugin.structure.intellij.problems
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionError
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 class NoModuleDependencies(private val descriptorPath: String) : PluginProblem() {
@@ -169,3 +170,16 @@ class IllegalPluginIdPrefix(private val illegalPluginId: String, private val ill
     get() = "Plugin ID '$illegalPluginId' has an illegal prefix '$illegalPrefix'. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
 }
 
+class ServiceExtensionPointPreloadNotSupported(private val serviceType: IdePluginContentDescriptor.ServiceType) : PluginProblem() {
+  override val level
+    get() = Level.WARNING
+
+  override val message
+    get() = "Service preloading in the 'preload' attribute is deprecated in the <${serviceType.toXmlElement()}> element. Consider migrating to the listeners. See https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+
+  private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = when (this) {
+    IdePluginContentDescriptor.ServiceType.PROJECT -> "projectService"
+    IdePluginContentDescriptor.ServiceType.APPLICATION -> "applicationService"
+    IdePluginContentDescriptor.ServiceType.MODULE -> "moduleService"
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -171,13 +171,15 @@ class IllegalPluginIdPrefix(private val illegalPluginId: String, private val ill
 }
 
 class ServiceExtensionPointPreloadNotSupported(private val serviceType: IdePluginContentDescriptor.ServiceType) : PluginProblem() {
+  private val extensionPointPrefix = "com.intellij"
+
   override val level
     get() = Level.WARNING
 
   override val message
-    get() = "Service preloading in the 'preload' attribute is deprecated in the <${serviceType.toXmlElement()}> element. Consider migrating to the listeners. See https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+    get() = "Service preloading is deprecated in the <${serviceType.toXmlElement()}> element. Consider removing the 'preload' attribute and migrating to the listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
 
-  private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = when (this) {
+  private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = "$extensionPointPrefix." + when (this) {
     IdePluginContentDescriptor.ServiceType.PROJECT -> "projectService"
     IdePluginContentDescriptor.ServiceType.APPLICATION -> "applicationService"
     IdePluginContentDescriptor.ServiceType.MODULE -> "moduleService"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -7,7 +7,6 @@ package com.jetbrains.plugin.structure.intellij.problems
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionError
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 class NoModuleDependencies(private val descriptorPath: String) : PluginProblem() {
@@ -168,20 +167,4 @@ open class IllegalPluginId(private val illegalPluginId: String) : InvalidDescrip
 class IllegalPluginIdPrefix(private val illegalPluginId: String, private val illegalPrefix: String) : IllegalPluginId(illegalPluginId) {
   override val detailedMessage
     get() = "Plugin ID '$illegalPluginId' has an illegal prefix '$illegalPrefix'. See https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__id"
-}
-
-class ServiceExtensionPointPreloadNotSupported(private val serviceType: IdePluginContentDescriptor.ServiceType) : PluginProblem() {
-  private val extensionPointPrefix = "com.intellij"
-
-  override val level
-    get() = Level.WARNING
-
-  override val message
-    get() = "Service preloading is deprecated in the <${serviceType.toXmlElement()}> element. Consider removing the 'preload' attribute and migrating to the listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
-
-  private fun IdePluginContentDescriptor.ServiceType.toXmlElement(): String = "$extensionPointPrefix." + when (this) {
-    IdePluginContentDescriptor.ServiceType.PROJECT -> "projectService"
-    IdePluginContentDescriptor.ServiceType.APPLICATION -> "applicationService"
-    IdePluginContentDescriptor.ServiceType.MODULE -> "moduleService"
-  }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ExtensionPointVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ExtensionPointVerifiers.kt
@@ -1,0 +1,27 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor.ServiceDescriptor
+import com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported
+
+/**
+ * Rule: Service Extension Point preloading is deprecated.
+ */
+class ServiceExtensionPointPreloadVerifier {
+  fun verify(plugin: IdePlugin, problemRegistrar: ProblemRegistrar) {
+    val allDescriptors = plugin.appContainerDescriptor.services +
+      plugin.projectContainerDescriptor.services +
+      plugin.moduleContainerDescriptor.services
+
+    allDescriptors.forEach {
+      verifyDescriptor(it, problemRegistrar)
+    }
+  }
+
+  private fun verifyDescriptor(serviceDescriptor: ServiceDescriptor, problemRegistrar: ProblemRegistrar) {
+    if (serviceDescriptor.preload != IdePluginContentDescriptor.PreloadMode.FALSE) {
+      problemRegistrar.registerProblem(ServiceExtensionPointPreloadNotSupported(serviceDescriptor.type))
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -10,8 +10,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileIsEmpty
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileNotSpecified
 import com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -76,9 +75,7 @@ class PluginXmlValidationTest {
     assertEquals(1, pluginCreationFail.errorsAndWarnings.size)
     val warning = pluginCreationFail.errorsAndWarnings.filterIsInstance<OptionalDependencyConfigFileIsEmpty>()
             .singleOrNull()
-    if (warning == null) {
-      fail("Expected 'Optional Dependency Config File Is Empty' plugin warning")
-    }
+    assertNotNull("Expected 'Optional Dependency Config File Is Empty' plugin warning", warning)
   }
 
   @Test
@@ -107,9 +104,7 @@ class PluginXmlValidationTest {
     assertEquals(1, warnings.size)
     val warning = warnings.filterIsInstance<ServiceExtensionPointPreloadNotSupported>()
       .singleOrNull()
-    if (warning == null) {
-      fail("Expected 'Service Extension Point Preload Not Supported' plugin warning")
-    }
+    assertNotNull("Expected 'Service Extension Point Preload Not Supported' plugin warning", warning)
   }
 
   private fun buildMalformedPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationFail<IdePlugin> {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -3,6 +3,7 @@ package com.jetbrains.plugin.structure.intellij
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
@@ -79,8 +80,8 @@ class PluginXmlValidationTest {
   }
 
   @Test
-  fun `plugin declaring projectService with preloading should emit a warning`() {
-    val pluginCreationSuccess = buildCorrectPlugin {
+  fun `plugin declaring projectService with preloading should emit an error`() {
+    val pluginCreationFail = buildMalformedPlugin {
       dir("META-INF") {
         file("plugin.xml") {
           """
@@ -100,11 +101,11 @@ class PluginXmlValidationTest {
       }
     }
 
-    val warnings = pluginCreationSuccess.warnings
-    assertEquals(1, warnings.size)
-    val warning = warnings.filterIsInstance<ServiceExtensionPointPreloadNotSupported>()
+    assertEquals(1, pluginCreationFail.errorsAndWarnings.size)
+    val error = pluginCreationFail.errorsAndWarnings.filterIsInstance<ServiceExtensionPointPreloadNotSupported>()
       .singleOrNull()
-    assertNotNull("Expected 'Service Extension Point Preload Not Supported' plugin warning", warning)
+    assertNotNull("Expected 'Service Extension Point Preload Not Supported' plugin warning", error)
+    assertEquals(PluginProblem.Level.ERROR, error?.level)
   }
 
   private fun buildMalformedPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationFail<IdePlugin> {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -104,7 +104,7 @@ class PluginXmlValidationTest {
     assertEquals(1, pluginCreationFail.errorsAndWarnings.size)
     val error = pluginCreationFail.errorsAndWarnings.filterIsInstance<ServiceExtensionPointPreloadNotSupported>()
       .singleOrNull()
-    assertNotNull("Expected 'Service Extension Point Preload Not Supported' plugin warning", error)
+    assertNotNull("Expected 'Service Extension Point Preload Not Supported' plugin error", error)
     assertEquals(PluginProblem.Level.ERROR, error?.level)
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 private const val PLUGIN_ID = "com.example.thirdparty"
 private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
 private const val MESSAGE_TEMPLATE = "Service preloading is deprecated in the <%s> " +
-  "element. Consider removing the 'preload' attribute and migrating to the listeners, " +
+  "element. Consider removing the 'preload' attribute and migrating to listeners, " +
   "see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
 
 class ServiceExtensionPointPreloadVerifierTest {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
@@ -11,9 +11,9 @@ import org.junit.Test
 
 private const val PLUGIN_ID = "com.example.thirdparty"
 private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
-private const val MESSAGE_TEMPLATE = "Service preloading in the 'preload' attribute is deprecated in the <%s> " +
-  "element. Consider migrating to the listeners. " +
-  "See https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+private const val MESSAGE_TEMPLATE = "Service preloading is deprecated in the <%s> " +
+  "element. Consider removing the 'preload' attribute and migrating to the listeners, " +
+  "see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
 
 class ServiceExtensionPointPreloadVerifierTest {
   private lateinit var verifier: ServiceExtensionPointPreloadVerifier
@@ -41,7 +41,7 @@ class ServiceExtensionPointPreloadVerifierTest {
     verifier.verify(idePlugin, problemRegistrar)
     assertEquals(1, problems.size)
     val problem = problems[0]
-    assertEquals(MESSAGE_TEMPLATE.format("projectService"), problem.message)
+    assertEquals(MESSAGE_TEMPLATE.format("com.intellij.projectService"), problem.message)
   }
 
   @Test
@@ -66,7 +66,7 @@ class ServiceExtensionPointPreloadVerifierTest {
     verifier.verify(idePlugin, problemRegistrar)
     assertEquals(1, problems.size)
     val problem = problems[0]
-    assertEquals(MESSAGE_TEMPLATE.format("applicationService"), problem.message)
+    assertEquals(MESSAGE_TEMPLATE.format("com.intellij.applicationService"), problem.message)
   }
 
   @Test
@@ -79,7 +79,7 @@ class ServiceExtensionPointPreloadVerifierTest {
     verifier.verify(idePlugin, problemRegistrar)
     assertEquals(1, problems.size)
     val problem = problems[0]
-    assertEquals(MESSAGE_TEMPLATE.format("moduleService"), problem.message)
+    assertEquals(MESSAGE_TEMPLATE.format("com.intellij.moduleService"), problem.message)
   }
 
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
@@ -1,0 +1,91 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor.*
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+
+private const val PLUGIN_ID = "com.example.thirdparty"
+private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
+private const val MESSAGE_TEMPLATE = "Service preloading in the 'preload' attribute is deprecated in the <%s> " +
+  "element. Consider migrating to the listeners. " +
+  "See https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html"
+
+class ServiceExtensionPointPreloadVerifierTest {
+  private lateinit var verifier: ServiceExtensionPointPreloadVerifier
+
+  private lateinit var problems: MutableList<PluginProblem>
+
+  private val problemRegistrar = ProblemRegistrar {
+    problems += it
+  }
+
+  @Before
+  fun setUp() {
+    verifier = ServiceExtensionPointPreloadVerifier()
+    problems = mutableListOf()
+  }
+
+
+  @Test
+  fun `has a single project service that is preloaded`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = PLUGIN_VENDOR
+      projectContainerDescriptor.services += mockServiceDescriptor(PreloadMode.TRUE, ServiceType.PROJECT)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    assertEquals(1, problems.size)
+    val problem = problems[0]
+    assertEquals(MESSAGE_TEMPLATE.format("projectService"), problem.message)
+  }
+
+  @Test
+  fun `has a single project service that is not preloaded`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = PLUGIN_VENDOR
+      projectContainerDescriptor.services += mockServiceDescriptor(PreloadMode.FALSE, ServiceType.PROJECT)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    Assert.assertTrue(problems.isEmpty())
+  }
+
+
+  @Test
+  fun `has a single application service that is preloaded`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = PLUGIN_VENDOR
+      appContainerDescriptor.services += mockServiceDescriptor(PreloadMode.TRUE, ServiceType.APPLICATION)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    assertEquals(1, problems.size)
+    val problem = problems[0]
+    assertEquals(MESSAGE_TEMPLATE.format("applicationService"), problem.message)
+  }
+
+  @Test
+  fun `has a single module service that is preloaded`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = PLUGIN_VENDOR
+      moduleContainerDescriptor.services += mockServiceDescriptor(PreloadMode.TRUE, ServiceType.MODULE)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    assertEquals(1, problems.size)
+    val problem = problems[0]
+    assertEquals(MESSAGE_TEMPLATE.format("moduleService"), problem.message)
+  }
+
+
+  private fun mockServiceDescriptor(preload: PreloadMode, serviceType: ServiceType) =
+    ServiceDescriptor(serviceImplementation = "com.jetbrains.mock.ServiceImpl", preload = preload,
+      serviceInterface = "com.jetbrains.mock.Service", type = serviceType,
+      testServiceImplementation = null, headlessImplementation = null, overrides = false,
+      configurationSchemaKey = null, client = null, os = null)
+}


### PR DESCRIPTION
Service EP preloading is no longer supported. Add a rule to detect this and emit a warning.

See [MP-5530](https://youtrack.jetbrains.com/issue/MP-5530/Plugin-Verifier-mark-Service-EP-preload-attribute-as-warning)