### PR TITLE
Establish a safety net for plugin errors that fail-fast

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginManager.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/PluginManager.kt
@@ -7,6 +7,12 @@ package com.jetbrains.plugin.structure.base.plugin
 import java.io.File
 import java.nio.file.Path
 
+/**
+ * Factory for creating product-agnostic plugins based on their artifacts stored in a [Path].
+ *
+ * Each implementation is product-specific, such as [com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager]
+ * which handles plugins for IntelliJ IDEA.
+ */
 interface PluginManager<out PluginType : Plugin> {
   @Deprecated(
     message = "Use method with java.nio.Path instead of java.io.File",

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
@@ -10,6 +10,10 @@ import org.jdom2.Document
 import org.jdom2.Element
 import java.nio.file.Path
 
+/**
+ * Represents a plugin for IntelliJ IDEA platform backed by one or more `plugin.xml`
+ * descriptors.
+ */
 interface IdePlugin : Plugin {
   val sinceBuild: IdeVersion?
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -25,6 +25,11 @@ import java.nio.file.*
 import java.util.*
 import java.util.stream.Collectors
 
+/**
+ * Factory for plugins of the IntelliJ IDEA Platform.
+ *
+ * Handles plugins provided in JARs, ZIPs and directories.
+ */
 class IdePluginManager private constructor(
   private val myResourceResolver: ResourceResolver,
   private val extractDirectory: Path

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -33,7 +33,8 @@ import java.time.format.DateTimeParseException
 internal class PluginCreator private constructor(
   val pluginFileName: String,
   val descriptorPath: String,
-  private val parentPlugin: PluginCreator?
+  private val parentPlugin: PluginCreator?,
+  private val problemResolver: IntelliJPluginCreationResultResolver = IntelliJPluginCreationResultResolver()
 ) {
 
   companion object {
@@ -123,11 +124,7 @@ internal class PluginCreator private constructor(
     get() = !hasErrors()
 
   val pluginCreationResult: PluginCreationResult<IdePlugin>
-    get() = if (hasErrors()) {
-      PluginCreationFail(problems)
-    } else {
-      PluginCreationSuccess<IdePlugin>(plugin, problems)
-    }
+    get() = problemResolver.resolve(plugin, problems)
 
   fun addOptionalDescriptor(
     pluginDependency: PluginDependency,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/BlocklistedPluginError.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/BlocklistedPluginError.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+
+class BlocklistedPluginError(val cause: PluginProblem) : PluginProblem() {
+  override val level: Level
+    get() = Level.ERROR
+  override val message: String
+    get() = "Fatal plugin problem has been detected. This problem is not registered in the list of supported of fatal plugin errors. " +
+      "Please contact developers. Error: ${cause.javaClass}, message: ${cause.message}"
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/BlocklistedPluginError.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/BlocklistedPluginError.kt
@@ -2,6 +2,12 @@ package com.jetbrains.plugin.structure.intellij.problems
 
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
 
+/**
+ * A general plugin problem with _error_ category that is not listed as a supported error
+ * in the allow-list of recognized plugin errors.
+ *
+ * This indicates an error on the programmer side that might unexpectingly stop the plugin validation process.
+ */
 class BlocklistedPluginError(val cause: PluginProblem) : PluginProblem() {
   override val level: Level
     get() = Level.ERROR

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -8,13 +8,25 @@ import com.jetbrains.plugin.structure.base.plugin.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 
+/**
+ * Resolves a collection of [plugin problems][PluginProblem] to the [result of plugin creation][PluginCreationResult],
+ * which is either a success or a failure.
+ *
+ * @see com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+ */
 interface PluginCreationResultResolver {
   fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin>
 
   fun isError(problem: PluginProblem): Boolean = problem.level == ERROR
 }
 
-
+/**
+ * Resolves a collection of [plugin problems][PluginProblem] to the [result of plugin creation][PluginCreationResult]
+ * by consulting an allow-list of supported plugin problems that are considered errors.
+ *
+ * Non-listed errors are treated as an error with fail-fast mechanism, and they are wrapped into a single
+ * [BlocklistedPluginError].
+ */
 class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
   override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
     val errors = problems.filter { it.level == ERROR }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -1,0 +1,82 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem.Level.ERROR
+import com.jetbrains.plugin.structure.base.problems.*
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+
+interface PluginCreationResultResolver {
+  fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin>
+
+  fun isError(problem: PluginProblem): Boolean = problem.level == ERROR
+}
+
+
+class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
+  override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
+    val errors = problems.filter { it.level == ERROR }
+    return if (errors.isEmpty()) {
+      PluginCreationSuccess(plugin, problems)
+    } else {
+      val unclassifiedErrors = errors.filterNot(::isError)
+      if (unclassifiedErrors.isNotEmpty()) {
+        PluginCreationFail(BlocklistedPluginError(unclassifiedErrors.first()))
+      } else {
+        PluginCreationFail(problems)
+      }
+    }
+  }
+
+  override fun isError(problem: PluginProblem): Boolean = problems.contains(problem::class)
+
+  private val problems = listOf(
+    PropertyWithDefaultValue::class,
+    InvalidDependencyId::class,
+    InvalidModuleBean::class,
+    SinceBuildNotSpecified::class,
+    InvalidSinceBuild::class,
+    InvalidUntilBuild::class,
+    SinceBuildGreaterThanUntilBuild::class,
+    ErroneousSinceBuild::class,
+    ErroneousUntilBuild::class,
+    ProductCodePrefixInBuild::class,
+    XIncludeResolutionErrors::class,
+    TooLongPropertyValue::class,
+    DefaultDescription::class,
+    ReleaseDateWrongFormat::class,
+    UnableToFindTheme::class,
+    UnableToReadTheme::class,
+    OptionalDependencyDescriptorCycleProblem::class,
+    OptionalDependencyConfigFileIsEmpty::class,
+
+    PluginLibDirectoryIsEmpty::class,
+    PluginZipContainsMultipleFiles::class,
+    PluginZipContainsSingleJarInRoot::class,
+    PluginZipContainsUnknownFile::class,
+    PluginZipIsEmpty::class,
+    UnableToReadPluginFile::class,
+    UnexpectedPluginZipStructure::class,
+
+    IncorrectPluginFile::class,
+    PluginFileSizeIsTooLarge::class,
+    UnableToExtractZip::class,
+
+    InvalidPluginIDProblem::class,
+    UnexpectedDescriptorElements::class,
+    TooLongPropertyValue::class,
+    PropertyNotSpecified::class,
+    NotBoolean::class,
+
+    NotNumber::class,
+    UnableToReadDescriptor::class,
+    ContainsNewlines::class,
+    ReusedDescriptorInMultipleDependencies::class,
+    VendorCannotBeEmpty::class,
+
+    PluginDescriptorIsNotFound::class,
+    MultiplePluginDescriptors::class,
+  )
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/MockPluginProblem.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/MockPluginProblem.kt
@@ -1,0 +1,10 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginProblem
+
+class MockPluginProblem : PluginProblem() {
+  override val level: Level
+    get() = Level.ERROR
+  override val message: String
+    get() = "Mock unclassified fatal plugin error"
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolverTest.kt
@@ -1,0 +1,26 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PluginCreationResultResolverTest {
+  @Test
+  fun `unregistered plugin problem is detected`() {
+    val plugin = IdePluginImpl()
+
+    val adapter = IntelliJPluginCreationResultResolver()
+    val pluginCreationResult = adapter.resolve(plugin, listOf(MockPluginProblem()))
+    assertTrue(pluginCreationResult is PluginCreationFail)
+    val failure = pluginCreationResult as PluginCreationFail
+    assertEquals(1, failure.errorsAndWarnings.size)
+
+    val pluginProblem = failure.errorsAndWarnings[0]
+    assertTrue(pluginProblem is BlocklistedPluginError)
+    val unsupportedPluginError = pluginProblem as BlocklistedPluginError
+
+    assertTrue(unsupportedPluginError.cause is MockPluginProblem)
+  }
+}


### PR DESCRIPTION
When parsing the `plugin.xml`, plugin problems categorized as errors will fail fast.

Due to complex semantics of the plugin problem categories and due to the fact that a wrongly categorized error might fail the validation pipeline, this change establishes an explicit allow-list of plugin errors that are allowed to fail fast the parsing process.