### PR TITLE
Support Markdown output format for verification reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ Here is the full syntax of the command:
     The path to the directory where verification reports will be saved.
     By default, it is equal to `<current working dir>/verification-<timestamp>`.
 
+* `-verification-reports-formats (-vrf)`
+
+    The output format of the verification reports. 
+    Supported formats are: `plain` (console output), `html` and `markdown`
+    By default `plain` and `html` output formats are enabled. 
+
 * `-runtime-dir (-r)`
 
     The path to the directory containing Java runtime jar.

--- a/README.md
+++ b/README.md
@@ -256,9 +256,10 @@ Here is the full syntax of the command:
     Output format that starts with a `-` (dash) will be suppressed: either from the default 
     set of output formats or from the specified output formats.
 
-    For example, `plain,markdown` will enable console output and the Markdown verification reports.
+    Examples:
 
-    Setting the `-plain` will disable console output but retain the default HTML output.
+    * `plain,markdown` will enable console output and the Markdown verification reports.
+    * `-plain` will disable console output, but retain the default HTML output.
 
 * `-runtime-dir (-r)`
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,15 @@ Here is the full syntax of the command:
 
     The output format of the verification reports. 
     Supported formats are: `plain` (console output), `html` and `markdown`
-    By default `plain` and `html` output formats are enabled. 
+    By default, `plain` and `html` output formats are enabled.
+    Multiple output formats are supported, separated by a comma.
+
+    Output format that starts with a `-` (dash) will be suppressed: either from the default 
+    set of output formats or from the specified output formats.
+
+    For example, `plain,markdown` will enable console output and the Markdown verification reports.
+
+    Setting the `-plain` will disable console output but retain the default HTML output.
 
 * `-runtime-dir (-r)`
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -11,7 +11,7 @@ open class CmdOpts(
   @set:Argument("verification-reports-dir", alias = "vrd", description = "The directory where the verification report files will reside")
   var verificationReportsDir: String? = null,
 
-  @set:Argument("output-formats", alias="f", description = "Output format of the verification report files. Supported formats are 'stream' (stdout), 'html' and 'markdown'")
+  @set:Argument("verification-reports-formats", alias="vrf", description = "Output format of the verification report files. Supported formats are 'stream' (stdout), 'html' and 'markdown'")
   var outputFormats: Array<String> = arrayOf(OutputFormat.STREAM.code(), OutputFormat.HTML.code()),
 
   @set:Argument("ignored-problems", alias = "ip", description = "The problems specified in this file will be ignored. The file must contain lines in form <plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>")

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -12,7 +12,7 @@ open class CmdOpts(
   var verificationReportsDir: String? = null,
 
   @set:Argument("verification-reports-formats", alias="vrf", description = "Output format of the verification report files. Supported formats are 'stream' (stdout), 'html' and 'markdown'")
-  var outputFormats: Array<String> = arrayOf(OutputFormat.STREAM.code(), OutputFormat.HTML.code()),
+  var outputFormats: Array<String> = arrayOf(OutputFormat.PLAIN.code(), OutputFormat.HTML.code()),
 
   @set:Argument("ignored-problems", alias = "ip", description = "The problems specified in this file will be ignored. The file must contain lines in form <plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>")
   var ignoreProblemsFile: String? = null,

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -11,7 +11,7 @@ open class CmdOpts(
   @set:Argument("verification-reports-dir", alias = "vrd", description = "The directory where the verification report files will reside")
   var verificationReportsDir: String? = null,
 
-  @set:Argument("verification-reports-formats", alias="vrf", description = "Output format of the verification report files. Supported formats are 'stream' (stdout), 'html' and 'markdown'")
+  @set:Argument("verification-reports-formats", alias="vrf", description = "Output format of the verification report files. Supported formats are 'plain' (console output in stdout), 'html' and 'markdown'")
   var outputFormats: Array<String> = arrayOf(OutputFormat.PLAIN.code(), OutputFormat.HTML.code()),
 
   @set:Argument("ignored-problems", alias = "ip", description = "The problems specified in this file will be ignored. The file must contain lines in form <plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>")

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -4,11 +4,15 @@
 
 package com.jetbrains.pluginverifier.options
 
+import com.jetbrains.pluginverifier.output.OutputFormat
 import com.sampullara.cli.Argument
 
 open class CmdOpts(
   @set:Argument("verification-reports-dir", alias = "vrd", description = "The directory where the verification report files will reside")
   var verificationReportsDir: String? = null,
+
+  @set:Argument("output-formats", alias="f", description = "Output format of the verification report files. Supported formats are 'stream' (stdout), 'html' and 'markdown'")
+  var outputFormats: Array<String> = arrayOf(OutputFormat.STREAM.code(), OutputFormat.HTML.code()),
 
   @set:Argument("ignored-problems", alias = "ip", description = "The problems specified in this file will be ignored. The file must contain lines in form <plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>")
   var ignoreProblemsFile: String? = null,

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -74,7 +74,7 @@ object OptionsParser {
       try {
         OutputFormat.valueOf(it.uppercase())
       } catch (e: IllegalArgumentException) {
-        LOG.warn("Unsupported verification report output format '$it'. Skipping")
+        LOG.warn("Unsupported verification report output format '$it'. Skipping this output format.")
         null
       }
     }.ifEmpty { DEFAULT_OUTPUT_FORMATS }
@@ -84,7 +84,7 @@ object OptionsParser {
         try {
           OutputFormat.valueOf(it.uppercase())
         } catch (e: IllegalArgumentException) {
-          LOG.warn("Unsupported verification report output format '$it' specified for exclusion.")
+          LOG.warn("Unsupported verification report output format '$it' specified for exclusion. Ignoring this output format.")
           null
         }
       }.toSet()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputFormat.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputFormat.kt
@@ -1,11 +1,11 @@
 package com.jetbrains.pluginverifier.output
 
 enum class OutputFormat {
-  STREAM,
+  PLAIN,
   HTML,
   MARKDOWN;
 
   fun code() = this.name.lowercase()
 }
 
-val DEFAULT_OUTPUT_FORMATS = listOf(OutputFormat.STREAM, OutputFormat.HTML)
+val DEFAULT_OUTPUT_FORMATS = listOf(OutputFormat.PLAIN, OutputFormat.HTML)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputFormat.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputFormat.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.pluginverifier.output
+
+enum class OutputFormat {
+  STREAM,
+  HTML,
+  MARKDOWN;
+
+  fun code() = this.name.lowercase()
+}
+
+val DEFAULT_OUTPUT_FORMATS = listOf(OutputFormat.STREAM, OutputFormat.HTML)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputOptions.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputOptions.kt
@@ -37,3 +37,8 @@ data class OutputOptions(
   }
 
 }
+
+fun OutputOptions.usePlainOutput() = this.outputFormats.contains(OutputFormat.PLAIN)
+fun OutputOptions.useHtml() = this.outputFormats.contains(OutputFormat.HTML)
+fun OutputOptions.useMarkdown() = this.outputFormats.contains(OutputFormat.MARKDOWN)
+

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputOptions.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/OutputOptions.kt
@@ -15,7 +15,8 @@ data class OutputOptions(
   private val verificationReportsDirectory: Path,
   val teamCityLog: TeamCityLog?,
   val teamCityGroupType: TeamCityResultPrinter.GroupBy,
-  val previousTcHistory: TeamCityHistory?
+  val previousTcHistory: TeamCityHistory?,
+  val outputFormats: List<OutputFormat> = DEFAULT_OUTPUT_FORMATS
 ) {
 
   fun getTargetReportDirectory(verificationTarget: PluginVerificationTarget): Path = when (verificationTarget) {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -78,43 +78,43 @@ class Markdown(private val out: PrintWriter) {
 }
 
 private operator fun Markdown.plus(result: PluginVerificationResult.Verified) {
-  result.printVerificationResult(this)
+  printVerificationResult(result)
 }
 
-private fun PluginVerificationResult.Verified.printVerificationResult(markdown: Markdown) = with(markdown) {
-  printVerificationResult(this@printVerificationResult, "Plugin structure warnings", pluginStructureWarnings) {
+private fun Markdown.printVerificationResult(result: PluginVerificationResult.Verified) = with(result) {
+  printVerificationResult("Plugin structure warnings", pluginStructureWarnings) {
     "" to it.message
   }
 
-  printVerificationResult(this@printVerificationResult, "Missing dependencies", dependenciesGraph.getDirectMissingDependencies()) {
+  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies()) {
     "" to "${it.dependency}: ${it.missingReason}"
   }
 
-  printVerificationResult(this@printVerificationResult, "Compatibility warnings", compatibilityWarnings) {
+  printVerificationResult("Compatibility warnings", compatibilityWarnings) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Compatibility problems", compatibilityProblems) {
+  printVerificationResult("Compatibility problems", compatibilityProblems) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Deprecated API usages", deprecatedUsages) {
+  printVerificationResult("Deprecated API usages", deprecatedUsages) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Experimental API usages", experimentalApiUsages) {
+  printVerificationResult("Experimental API usages", experimentalApiUsages) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Internal API usages", internalApiUsages) {
+  printVerificationResult("Internal API usages", internalApiUsages) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Override-only API usages", overrideOnlyMethodUsages) {
+  printVerificationResult("Override-only API usages", overrideOnlyMethodUsages) {
     it.shortDescription to it.fullDescription
   }
 
-  printVerificationResult(this@printVerificationResult, "Non-extendable API usages", nonExtendableApiUsages) {
+  printVerificationResult("Non-extendable API usages", nonExtendableApiUsages) {
     it.shortDescription to it.fullDescription
   }
 
@@ -126,9 +126,8 @@ private fun PluginVerificationResult.Verified.printVerificationResult(markdown: 
   }
 }
 
-private fun <T> Markdown.printVerificationResult(verificationResult: PluginVerificationResult.Verified,
-                                                                        title: String, items: Set<T>,
-                                                                        descriptionPropertyExtractor: (T) -> Pair<String, String>) {
+private fun <T> Markdown.printVerificationResult(title: String,
+                                                 items: Set<T>, descriptionPropertyExtractor: (T) -> Pair<String, String>) {
   if (items.isNotEmpty()) {
     h2("$title (${items.size}): ")
     val shortToFullDescriptions = items.map(descriptionPropertyExtractor)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -1,8 +1,11 @@
 package com.jetbrains.pluginverifier.output.markdown
 
+import com.jetbrains.plugin.structure.base.utils.create
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
+import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.usages.deprecated.DeprecatedApiUsage
@@ -13,8 +16,17 @@ import com.jetbrains.pluginverifier.usages.overrideOnly.OverrideOnlyMethodUsage
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import com.jetbrains.pluginverifier.warnings.PluginStructureWarning
 import java.io.PrintWriter
+import java.nio.file.Files
 
-class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter {
+class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter, AutoCloseable {
+
+  companion object {
+    fun create(verificationTarget: PluginVerificationTarget, outputOptions: OutputOptions): MarkdownResultPrinter {
+      val reportHtmlFile = outputOptions.getTargetReportDirectory(verificationTarget).resolve("report.markdown")
+      val writer = PrintWriter(Files.newBufferedWriter(reportHtmlFile.create()))
+      return MarkdownResultPrinter(writer)
+    }
+  }
 
   override fun printResults(results: List<PluginVerificationResult>) {
     markdown(out) {
@@ -32,6 +44,10 @@ class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter {
         markdown + this
       }
     }
+  }
+
+  override fun close() {
+    out.close()
   }
 
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -17,7 +17,8 @@ class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter {
 
   private fun printResult(pluginVerificationResult: PluginVerificationResult, markdown: Markdown) {
     with(pluginVerificationResult) {
-      markdown.h1("Plugin $plugin against $verificationTarget: $verificationVerdict")
+      markdown.h1("Plugin $plugin against $verificationTarget")
+      markdown.paragraph(verificationVerdict)
       if (this is PluginVerificationResult.Verified) {
         markdown + this
       }
@@ -45,12 +46,16 @@ class Markdown(private val out: PrintWriter) {
   }
 
   fun h3(header: String) {
-    out.println("## $header")
+    out.println("### $header")
     out.println()
   }
 
   fun unorderedListItem(content: String) {
     out.println("* $content")
+  }
+
+  fun unorderedListEnd() {
+    out.println()
   }
 
   fun paragraph(content: String): Markdown {
@@ -82,6 +87,7 @@ private fun PluginVerificationResult.Verified.printVerificationResult(markdown: 
     for (warning in pluginStructureWarnings) {
       unorderedListItem(warning.message)
     }
+    unorderedListEnd()
   }
 
   val directMissingDependencies = dependenciesGraph.getDirectMissingDependencies()
@@ -145,6 +151,7 @@ private fun Markdown.appendShortAndFullDescriptions(shortToFullDescriptions: Map
         unorderedListItem(line)
       }
     }
+    unorderedListEnd()
   }
 }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -1,8 +1,17 @@
 package com.jetbrains.pluginverifier.output.markdown
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.output.ResultPrinter
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.usages.deprecated.DeprecatedApiUsage
+import com.jetbrains.pluginverifier.usages.experimental.ExperimentalApiUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
+import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableApiUsage
+import com.jetbrains.pluginverifier.usages.overrideOnly.OverrideOnlyMethodUsage
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
+import com.jetbrains.pluginverifier.warnings.PluginStructureWarning
 import java.io.PrintWriter
 
 class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter {
@@ -82,41 +91,15 @@ private operator fun Markdown.plus(result: PluginVerificationResult.Verified) {
 }
 
 private fun Markdown.printVerificationResult(result: PluginVerificationResult.Verified) = with(result) {
-  printVerificationResult("Plugin structure warnings", pluginStructureWarnings) {
-    "" to it.message
-  }
-
-  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies()) {
-    "" to "${it.dependency}: ${it.missingReason}"
-  }
-
-  printVerificationResult("Compatibility warnings", compatibilityWarnings) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Compatibility problems", compatibilityProblems) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Deprecated API usages", deprecatedUsages) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Experimental API usages", experimentalApiUsages) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Internal API usages", internalApiUsages) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Override-only API usages", overrideOnlyMethodUsages) {
-    it.shortDescription to it.fullDescription
-  }
-
-  printVerificationResult("Non-extendable API usages", nonExtendableApiUsages) {
-    it.shortDescription to it.fullDescription
-  }
+  printVerificationResult("Plugin structure warnings", pluginStructureWarnings, PluginStructureWarning::describe)
+  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies(), MissingDependency::describe)
+  printVerificationResult("Compatibility warnings", compatibilityWarnings, CompatibilityWarning::describe)
+  printVerificationResult("Compatibility problems", compatibilityProblems, CompatibilityProblem::describe)
+  printVerificationResult("Deprecated API usages", deprecatedUsages, DeprecatedApiUsage::describe)
+  printVerificationResult("Experimental API usages", experimentalApiUsages, ExperimentalApiUsage::describe)
+  printVerificationResult("Internal API usages", internalApiUsages, InternalApiUsage::describe)
+  printVerificationResult("Override-only API usages", overrideOnlyMethodUsages, OverrideOnlyMethodUsage::describe)
+  printVerificationResult("Non-extendable API usages", nonExtendableApiUsages, NonExtendableApiUsage::describe)
 
   val dynaStatus = "Dynamic Plugin Status"
   when (val dynamicPluginStatus = dynamicPluginStatus) {
@@ -150,3 +133,12 @@ private fun Markdown.appendShortAndFullDescriptions(shortToFullDescriptions: Map
   }
 }
 
+fun PluginStructureWarning.describe() = "" to message
+fun MissingDependency.describe() = "" to "$dependency: $missingReason"
+fun CompatibilityWarning.describe() = shortDescription to fullDescription
+fun CompatibilityProblem.describe() = shortDescription to fullDescription
+fun DeprecatedApiUsage.describe() = shortDescription to fullDescription
+fun ExperimentalApiUsage.describe() = shortDescription to fullDescription
+fun InternalApiUsage.describe() = shortDescription to fullDescription
+fun OverrideOnlyMethodUsage.describe() = shortDescription to fullDescription
+fun NonExtendableApiUsage.describe() = shortDescription to fullDescription

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -8,6 +8,7 @@ import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.tasks.InvalidPluginFile
 import com.jetbrains.pluginverifier.usages.deprecated.DeprecatedApiUsage
 import com.jetbrains.pluginverifier.usages.experimental.ExperimentalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
@@ -32,6 +33,34 @@ class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter, AutoC
     markdown(out) {
       results.forEach {
         printResult(it, this)
+      }
+    }
+  }
+
+  fun printInvalidPluginFiles(invalidPluginFiles: List<InvalidPluginFile>) {
+    markdown(out) {
+      when (invalidPluginFiles.size) {
+        0 -> return@markdown
+        1 -> {
+          h1("Invalid plugin")
+          paragraph("The following file specified for the verification is not a valid plugin.")
+        }
+        else -> {
+          h1("Invalid plugins")
+          out.println("The following files specified for the verification are not valid plugins.")
+        }
+      }
+      if (invalidPluginFiles.isNotEmpty()) {
+        for ((pluginFile, pluginErrors) in invalidPluginFiles) {
+          h2("${pluginFile.fileName}")
+          paragraph("Full path: `$pluginFile`")
+          if (pluginErrors.isNotEmpty()) {
+            for (pluginError in pluginErrors) {
+              unorderedListItem("$pluginError")
+            }
+            unorderedListEnd()
+          }
+        }
       }
     }
   }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -128,7 +128,7 @@ private fun Markdown.printVerificationResult(result: PluginVerificationResult.Ve
 private fun <T> Markdown.printVerificationResult(title: String,
                                                  items: Set<T>, descriptionPropertyExtractor: (T) -> Pair<String, String>) {
   if (items.isNotEmpty()) {
-    h2("$title (${items.size}): ")
+    h2("$title (${items.size})")
     val shortToFullDescriptions = items.map(descriptionPropertyExtractor)
       .groupBy({ it.first }, { it.second })
     appendShortAndFullDescriptions(shortToFullDescriptions)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -1,0 +1,150 @@
+package com.jetbrains.pluginverifier.output.markdown
+
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
+import com.jetbrains.pluginverifier.output.ResultPrinter
+import java.io.PrintWriter
+
+class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter {
+
+  override fun printResults(results: List<PluginVerificationResult>) {
+    markdown(out) {
+      results.forEach {
+        printResult(it, this)
+      }
+    }
+  }
+
+  private fun printResult(pluginVerificationResult: PluginVerificationResult, markdown: Markdown) {
+    with(pluginVerificationResult) {
+      markdown.h1("Plugin $plugin against $verificationTarget: $verificationVerdict")
+      if (this is PluginVerificationResult.Verified) {
+        markdown + this
+      }
+    }
+  }
+
+}
+
+fun markdown(out: PrintWriter, init: Markdown.() -> Unit): Markdown {
+  val markdown = Markdown(out)
+  markdown.init()
+  return markdown
+}
+
+class Markdown(private val out: PrintWriter) {
+  fun h1(header: String) {
+    out.println("# $header")
+    out.println()
+  }
+
+  fun h2(header: String): Markdown {
+    out.println("## $header")
+    out.println()
+    return this
+  }
+
+  fun h3(header: String) {
+    out.println("## $header")
+    out.println()
+  }
+
+  fun unorderedListItem(content: String) {
+    out.println("* $content")
+  }
+
+  fun paragraph(content: String): Markdown {
+    out.println(content)
+    out.appendLine()
+    return this
+  }
+
+  operator fun String.unaryPlus() {
+    out.println(this)
+  }
+
+  operator fun plus(value: String) {
+    out.println(value)
+  }
+
+  operator fun plus(@Suppress("UNUSED_PARAMETER") markdown: Markdown) {
+    // no-op. Concatenating two Markdown instances is equivalent to concatenating their Writers
+  }
+}
+
+private operator fun Markdown.plus(result: PluginVerificationResult.Verified) {
+  result.printVerificationResult(this)
+}
+
+private fun PluginVerificationResult.Verified.printVerificationResult(markdown: Markdown) = with(markdown) {
+  if (pluginStructureWarnings.isNotEmpty()) {
+    h2("Plugin structure warnings (${pluginStructureWarnings.size}): ")
+    for (warning in pluginStructureWarnings) {
+      unorderedListItem(warning.message)
+    }
+  }
+
+  val directMissingDependencies = dependenciesGraph.getDirectMissingDependencies()
+  if (directMissingDependencies.isNotEmpty()) {
+    h2("Missing dependencies: ")
+    for (missingDependency in directMissingDependencies) {
+      unorderedListItem("${missingDependency.dependency}: ${missingDependency.missingReason}")
+    }
+  }
+
+  if (compatibilityWarnings.isNotEmpty()) {
+    h2("Compatibility warnings (${compatibilityWarnings.size}): ")
+    appendShortAndFullDescriptions(compatibilityWarnings.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (compatibilityProblems.isNotEmpty()) {
+    h2("Compatibility problems (${compatibilityProblems.size}): ")
+    appendShortAndFullDescriptions(compatibilityProblems.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (deprecatedUsages.isNotEmpty()) {
+    h2("Deprecated API usages (${deprecatedUsages.size}): ")
+    appendShortAndFullDescriptions(deprecatedUsages.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (experimentalApiUsages.isNotEmpty()) {
+    h2("Experimental API usages (${experimentalApiUsages.size}): ")
+    appendShortAndFullDescriptions(experimentalApiUsages.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (internalApiUsages.isNotEmpty()) {
+    h2("Internal API usages (${internalApiUsages.size}): ")
+    appendShortAndFullDescriptions(internalApiUsages.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (overrideOnlyMethodUsages.isNotEmpty()) {
+    h2("Override-only API usages (${overrideOnlyMethodUsages.size}): ")
+    appendShortAndFullDescriptions(overrideOnlyMethodUsages.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+  if (nonExtendableApiUsages.isNotEmpty()) {
+    h2("Non-extendable API usages (${nonExtendableApiUsages.size}): ")
+    appendShortAndFullDescriptions(nonExtendableApiUsages.groupBy({ it.shortDescription }, { it.fullDescription }))
+  }
+
+
+  val dynaStatus = "Dynamic Plugin Status"
+  when (val dynamicPluginStatus = dynamicPluginStatus) {
+    is DynamicPluginStatus.MaybeDynamic -> h2(dynaStatus) + paragraph("Plugin can probably be enabled or disabled without IDE restart")
+    is DynamicPluginStatus.NotDynamic -> h2(dynaStatus) + paragraph("Plugin probably cannot be enabled or disabled without IDE restart: " + dynamicPluginStatus.reasonsNotToLoadUnloadWithoutRestart.joinToString())
+    null -> Unit
+  }
+
+}
+
+private fun Markdown.appendShortAndFullDescriptions(shortToFullDescriptions: Map<String, List<String>>) {
+  shortToFullDescriptions.forEach { (shortDescription, fullDescriptions) ->
+    h3(shortDescription)
+    for (fullDescription in fullDescriptions) {
+      fullDescription.lines().forEach { line ->
+        unorderedListItem(line)
+      }
+    }
+  }
+}
+

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeResultPrinter.kt
@@ -6,14 +6,16 @@ package com.jetbrains.pluginverifier.tasks.checkIde
 
 import com.jetbrains.plugin.structure.base.utils.pluralizeWithNumber
 import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.output.OutputFormat
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
 import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
+import com.jetbrains.pluginverifier.output.useHtml
+import com.jetbrains.pluginverifier.output.useMarkdown
 import com.jetbrains.pluginverifier.output.stream.WriterResultPrinter
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityHistory
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityLog
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityResultPrinter
+import com.jetbrains.pluginverifier.output.usePlainOutput
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -29,11 +31,15 @@ class CheckIdeResultPrinter(val pluginRepository: PluginRepository) : TaskResult
         val teamCityHistory = printTcLog(outputOptions.teamCityGroupType, this, outputOptions.teamCityLog)
         outputOptions.postProcessTeamCityTests(teamCityHistory)
       } else {
-        printOnStdOut(this)
+        if (outputOptions.usePlainOutput()) {
+          printOnStdOut(this)
+        }
       }
 
-      HtmlResultPrinter(ide, outputOptions).printResults(results)
-      if (outputOptions.outputFormats.contains(OutputFormat.MARKDOWN)) {
+      if (outputOptions.useHtml()) {
+        HtmlResultPrinter(ide, outputOptions).printResults(results)
+      }
+      if (outputOptions.useMarkdown()) {
         MarkdownResultPrinter.create(ide, outputOptions).use {
           it.printResults(results)
         }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeResultPrinter.kt
@@ -6,8 +6,10 @@ package com.jetbrains.pluginverifier.tasks.checkIde
 
 import com.jetbrains.plugin.structure.base.utils.pluralizeWithNumber
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.output.OutputFormat
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
+import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
 import com.jetbrains.pluginverifier.output.stream.WriterResultPrinter
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityHistory
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityLog
@@ -31,6 +33,11 @@ class CheckIdeResultPrinter(val pluginRepository: PluginRepository) : TaskResult
       }
 
       HtmlResultPrinter(ide, outputOptions).printResults(results)
+      if (outputOptions.outputFormats.contains(OutputFormat.MARKDOWN)) {
+        MarkdownResultPrinter.create(ide, outputOptions).use {
+          it.printResults(results)
+        }
+      }
     }
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
@@ -12,7 +12,7 @@ import com.jetbrains.pluginverifier.tasks.InvalidPluginFile
 import com.jetbrains.pluginverifier.tasks.TaskParameters
 
 class CheckPluginParams(
-  private val ideDescriptors: List<IdeDescriptor>,
+  internal val ideDescriptors: List<IdeDescriptor>,
   val problemsFilters: List<ProblemsFilter>,
   val verificationDescriptors: List<PluginVerificationDescriptor>,
   val invalidPluginFiles: List<InvalidPluginFile>,

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResult.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResult.kt
@@ -5,13 +5,25 @@
 package com.jetbrains.pluginverifier.tasks.checkPlugin
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.tasks.InvalidPluginFile
 import com.jetbrains.pluginverifier.tasks.TaskResult
 
+/**
+ * Result of the `check-plugin` task
+ *
+ * @param invalidPluginFiles list of plugins with structural problems or descriptor validation problems
+ * @param results list of nonstructural problems of plugins
+ * @param ideDescriptorsWithInvalidPlugins between specific IDE and corresponding list of plugins with structural problems.
+ * This is used to map the verification target IDE to list of plugins that did not even enter the actual verification
+ * stage due to the structural problems.
+ *
+ */
 class CheckPluginResult(
   val invalidPluginFiles: List<InvalidPluginFile>,
-  val results: List<PluginVerificationResult>
+  val results: List<PluginVerificationResult>,
+  val ideDescriptorsWithInvalidPlugins: Map<IdeDescriptor, List<InvalidPluginFile>> = emptyMap()
 ) : TaskResult {
   override fun createTaskResultsPrinter(pluginRepository: PluginRepository) =
     CheckPluginResultPrinter(pluginRepository)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -5,8 +5,7 @@
 package com.jetbrains.pluginverifier.tasks.checkPlugin
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.output.OutputFormat
-import com.jetbrains.pluginverifier.output.OutputOptions
+import com.jetbrains.pluginverifier.output.*
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
 import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
 import com.jetbrains.pluginverifier.output.stream.WriterResultPrinter
@@ -26,12 +25,16 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
         val teamCityHistory = printTcLog(true, outputOptions.teamCityLog, outputOptions.teamCityGroupType)
         outputOptions.postProcessTeamCityTests(teamCityHistory)
       } else {
-        printOnStdout(this)
+        if (outputOptions.usePlainOutput()) {
+          printOnStdout (this)
+        }
       }
 
       results.groupBy { it.verificationTarget }.forEach { (verificationTarget, resultsOfIde) ->
-        HtmlResultPrinter(verificationTarget, outputOptions).printResults(resultsOfIde)
-        if (outputOptions.outputFormats.contains(OutputFormat.MARKDOWN)) {
+        if(outputOptions.useHtml()) {
+          HtmlResultPrinter(verificationTarget, outputOptions).printResults(resultsOfIde)
+        }
+        if (outputOptions.useMarkdown()) {
           MarkdownResultPrinter.create(verificationTarget, outputOptions).use {
             it.printResults(resultsOfIde)
           }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -34,7 +34,7 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
 
       if (hasOnlyPluginsWithInvalidFiles()) {
         for ((ideDescriptor, invalidPlugins) in ideDescriptorsWithInvalidPlugins) {
-          if(outputOptions.useMarkdown()) {
+          if (outputOptions.useMarkdown()) {
             MarkdownResultPrinter.create(ideDescriptor.toVerificationTarget(), outputOptions).use {
               it.printInvalidPluginFiles(invalidPlugins)
             }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -31,7 +31,7 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
       }
 
       results.groupBy { it.verificationTarget }.forEach { (verificationTarget, resultsOfIde) ->
-        if(outputOptions.useHtml()) {
+        if (outputOptions.useHtml()) {
           HtmlResultPrinter(verificationTarget, outputOptions).printResults(resultsOfIde)
         }
         if (outputOptions.useMarkdown()) {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -93,6 +93,11 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
     }
   }
 
+  /**
+   * Indicates that there is at least one plugin with structural plugin problems.
+   * In that case, the verification will not take place at all and only structural
+   * problems will be reported.
+   */
   private fun CheckPluginResult.hasOnlyPluginsWithInvalidFiles() =
     results.isEmpty() && invalidPluginFiles.isNotEmpty()
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -64,7 +64,7 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
       }
     }.distinct().size
     if (totalProblemsNumber > 0) {
-      tcLog.buildStatusFailure("$totalProblemsNumber problem${if (totalProblemsNumber > 0) "s" else ""} found")
+      tcLog.buildStatusFailure("$totalProblemsNumber problem${if (totalProblemsNumber > 1) "s" else ""} found")
     }
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -34,8 +34,10 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
 
       if (hasOnlyPluginsWithInvalidFiles()) {
         for ((ideDescriptor, invalidPlugins) in ideDescriptorsWithInvalidPlugins) {
-          MarkdownResultPrinter.create(ideDescriptor.toVerificationTarget(), outputOptions).use {
-            it.printInvalidPluginFiles(invalidPlugins)
+          if(outputOptions.useMarkdown()) {
+            MarkdownResultPrinter.create(ideDescriptor.toVerificationTarget(), outputOptions).use {
+              it.printInvalidPluginFiles(invalidPlugins)
+            }
           }
         }
       }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -5,6 +5,8 @@
 package com.jetbrains.pluginverifier.tasks.checkPlugin
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
+import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.output.*
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
 import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
@@ -27,6 +29,14 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
       } else {
         if (outputOptions.usePlainOutput()) {
           printOnStdout (this)
+        }
+      }
+
+      if (hasOnlyPluginsWithInvalidFiles()) {
+        for ((ideDescriptor, invalidPlugins) in ideDescriptorsWithInvalidPlugins) {
+          MarkdownResultPrinter.create(ideDescriptor.toVerificationTarget(), outputOptions).use {
+            it.printInvalidPluginFiles(invalidPlugins)
+          }
         }
       }
 
@@ -80,5 +90,10 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
       printWriter.flush()
     }
   }
+
+  private fun CheckPluginResult.hasOnlyPluginsWithInvalidFiles() =
+    results.isEmpty() && invalidPluginFiles.isNotEmpty()
+
+  private fun IdeDescriptor.toVerificationTarget() = PluginVerificationTarget.IDE(ideVersion, jdkVersion)
 
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginResultPrinter.kt
@@ -5,8 +5,10 @@
 package com.jetbrains.pluginverifier.tasks.checkPlugin
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.output.OutputFormat
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
+import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
 import com.jetbrains.pluginverifier.output.stream.WriterResultPrinter
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityHistory
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityLog
@@ -29,6 +31,11 @@ class CheckPluginResultPrinter(private val pluginRepository: PluginRepository) :
 
       results.groupBy { it.verificationTarget }.forEach { (verificationTarget, resultsOfIde) ->
         HtmlResultPrinter(verificationTarget, outputOptions).printResults(resultsOfIde)
+        if (outputOptions.outputFormats.contains(OutputFormat.MARKDOWN)) {
+          MarkdownResultPrinter.create(verificationTarget, outputOptions).use {
+            it.printResults(resultsOfIde)
+          }
+        }
       }
     }
   }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
@@ -38,7 +38,8 @@ class CheckPluginTask(private val parameters: CheckPluginParams) : Task {
       }
 
       val results = runSeveralVerifiers(reportage, verifiers)
-      return CheckPluginResult(invalidPluginFiles, results)
+      val ideDescriptorsWithInvalidPluginFiles = ideDescriptors.associateWith { invalidPluginFiles }
+      return CheckPluginResult(invalidPluginFiles, results, ideDescriptorsWithInvalidPluginFiles)
     }
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
@@ -12,10 +12,13 @@ import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
+import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityHistory
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityLog
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityResultPrinter
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityTest
+import com.jetbrains.pluginverifier.output.useHtml
+import com.jetbrains.pluginverifier.output.useMarkdown
 import com.jetbrains.pluginverifier.repository.Browseable
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.marketplace.UpdateInfo
@@ -40,8 +43,14 @@ class TwoTargetsResultPrinter : TaskResultPrinter {
         println("Enable TeamCity results printing option (-team-city or -tc) to see the results in TeamCity builds format.")
       }
 
-      HtmlResultPrinter(baseTarget, outputOptions).printResults(baseResults)
-      HtmlResultPrinter(newTarget, outputOptions).printResults(newResults)
+      if(outputOptions.useHtml()) {
+        HtmlResultPrinter(baseTarget, outputOptions).printResults(baseResults)
+        HtmlResultPrinter(newTarget, outputOptions).printResults(newResults)
+      }
+      if (outputOptions.useMarkdown()) {
+        MarkdownResultPrinter.create(baseTarget, outputOptions).printResults(baseResults)
+        MarkdownResultPrinter.create(newTarget, outputOptions).printResults(newResults)
+      }
     }
   }
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
@@ -43,7 +43,7 @@ class TwoTargetsResultPrinter : TaskResultPrinter {
         println("Enable TeamCity results printing option (-team-city or -tc) to see the results in TeamCity builds format.")
       }
 
-      if(outputOptions.useHtml()) {
+      if (outputOptions.useHtml()) {
         HtmlResultPrinter(baseTarget, outputOptions).printResults(baseResults)
         HtmlResultPrinter(newTarget, outputOptions).printResults(newResults)
       }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/nonExtendable/NonExtendableTypeInherited.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/nonExtendable/NonExtendableTypeInherited.kt
@@ -14,14 +14,6 @@ import com.jetbrains.pluginverifier.results.presentation.formatClassLocation
 import com.jetbrains.pluginverifier.usages.formatUsageLocation
 import java.util.*
 
-/**
- *  Indicates a type that is not supposed to be extended, usually due to the
- *  `org.jetbrains.annotations.ApiStatus.NonExtendable` annotation being present.
- *
- *  @see NonExtendableTypeInheritedProcessor
- *  @param apiElement A type that is not supposed to be extended, inherited or implemented
- *  @param usageLocation location which is extending, inheriting or implemented the discouraged type.
- */
 class NonExtendableTypeInherited(
   override val apiElement: ClassLocation,
   override val usageLocation: ClassLocation

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/nonExtendable/NonExtendableTypeInherited.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/nonExtendable/NonExtendableTypeInherited.kt
@@ -14,6 +14,14 @@ import com.jetbrains.pluginverifier.results.presentation.formatClassLocation
 import com.jetbrains.pluginverifier.usages.formatUsageLocation
 import java.util.*
 
+/**
+ *  Indicates a type that is not supposed to be extended, usually due to the
+ *  `org.jetbrains.annotations.ApiStatus.NonExtendable` annotation being present.
+ *
+ *  @see NonExtendableTypeInheritedProcessor
+ *  @param apiElement A type that is not supposed to be extended, inherited or implemented
+ *  @param usageLocation location which is extending, inheriting or implemented the discouraged type.
+ */
 class NonExtendableTypeInherited(
   override val apiElement: ClassLocation,
   override val usageLocation: ClassLocation

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -1,0 +1,46 @@
+package com.jetbrains.pluginverifier.output.markdown
+
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
+import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.DependencyNode
+import com.jetbrains.pluginverifier.jdk.JdkVersion
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.PrintWriter
+import java.io.StringWriter
+
+private const val PLUGIN_ID = "pluginId"
+private const val PLUGIN_VERSION = "1.0"
+
+class MarkdownOutputTest {
+  private val pluginInfo = mockPluginInfo(PLUGIN_ID, PLUGIN_VERSION)
+  private val verificationTarget = PluginVerificationTarget.IDE(IdeVersion.createIdeVersion("232"), JdkVersion("11", null))
+
+  @Test
+  fun `plugin is compatible`() {
+    val dependenciesGraph = DependenciesGraph(
+      verifiedPlugin = DependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+      vertices = emptyList(),
+      edges = emptyList(),
+      missingDependencies = emptyMap()
+      )
+    val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
+
+    val out = StringWriter()
+    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
+    resultPrinter.printResults(listOf(verificationResult))
+
+    val expected = """
+      # Plugin pluginId $PLUGIN_VERSION against 232.0: Compatible
+      
+      
+      """.trimIndent()
+    assertEquals(expected, out.buffer.toString())
+  }
+}
+
+fun mockPluginInfo(pluginId: String, version: String): PluginInfo =
+  object : PluginInfo(pluginId, pluginId, version, null, null, null) {}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -90,7 +90,7 @@ class MarkdownOutputTest {
       
       4 compatibility problems
       
-      ## Compatibility problems (4): 
+      ## Compatibility problems (4)
       
       ### Incompatible change of super interface com.jetbrains.plugin.Parent to class
       
@@ -132,7 +132,7 @@ class MarkdownOutputTest {
           
           Compatible. 1 plugin configuration defect
           
-          ## Plugin structure warnings (1): 
+          ## Plugin structure warnings (1)
           
           * Plugin descriptor plugin.xml does not include any module dependency tags. The plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html
 
@@ -163,7 +163,7 @@ class MarkdownOutputTest {
         
         Compatible. 1 usage of internal API
         
-        ## Internal API usages (1): 
+        ## Internal API usages (1)
         
         ### Internal class InternalApiRegistrar reference
         
@@ -199,7 +199,7 @@ class MarkdownOutputTest {
         
         Compatible. 1 non-extendable API usage violation
         
-        ## Non-extendable API usages (1): 
+        ## Non-extendable API usages (1)
         
         ### Non-extendable class NonExtendableClass is extended
         
@@ -243,7 +243,7 @@ class MarkdownOutputTest {
           
           Compatible. 1 usage of experimental API
           
-          ## Experimental API usages (1): 
+          ## Experimental API usages (1)
           
           ### Experimental API class ExperimentalClass reference
           
@@ -275,7 +275,7 @@ class MarkdownOutputTest {
         
         Compatible
         
-        ## Missing dependencies (1): 
+        ## Missing dependencies (1)
         
         * MissingPlugin (optional): Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
         

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -314,27 +314,26 @@ class MarkdownOutputTest {
   private fun output() = out.buffer.toString()
 }
 
-fun mockPluginInfo(pluginId: String, version: String): PluginInfo =
+private fun mockPluginInfo(pluginId: String, version: String): PluginInfo =
   object : PluginInfo(pluginId, pluginId, version, null, null, null) {}
 
-fun mockCompatibilityProblems(): Set<CompatibilityProblem> =
+private fun mockCompatibilityProblems(): Set<CompatibilityProblem> =
   setOf(superInterfaceBecameClassProblem(), superInterfaceBecameClassProblemInOtherLocation(), methodNotFoundProblem(), methodNotFoundProblemInSampleStuffFactoryClass())
 
-fun superInterfaceBecameClassProblem(): SuperInterfaceBecameClassProblem {
+private fun superInterfaceBecameClassProblem(): SuperInterfaceBecameClassProblem {
   val child = ClassLocation("com.jetbrains.plugin.Child", null, Modifiers.of(PUBLIC), SomeFileOrigin)
   val clazz = ClassLocation("com.jetbrains.plugin.Parent", null, Modifiers.of(PUBLIC), SomeFileOrigin)
   return SuperInterfaceBecameClassProblem(child, clazz)
 }
 
-fun superInterfaceBecameClassProblemInOtherLocation(): SuperInterfaceBecameClassProblem {
+private fun superInterfaceBecameClassProblemInOtherLocation(): SuperInterfaceBecameClassProblem {
   val child = ClassLocation("com.jetbrains.plugin.pkg.Child", null, Modifiers.of(PUBLIC), SomeFileOrigin)
   val clazz = ClassLocation("com.jetbrains.plugin.pkg.Parent", null, Modifiers.of(PUBLIC), SomeFileOrigin)
   return SuperInterfaceBecameClassProblem(child, clazz)
 }
 
-
 //FIXME consolidate with DocumentedProblemsReportingTest
-val mockMethodLocation = MethodLocation(
+private val mockMethodLocation = MethodLocation(
   ClassLocation("SomeClass", null, Modifiers.of(PUBLIC), SomeFileOrigin),
   "someMethod",
   "()V",
@@ -346,7 +345,7 @@ val mockMethodLocation = MethodLocation(
 private val sampleStuffFactoryLocation = ClassLocation("SampleStuffFactory", null, Modifiers.of(PUBLIC), SomeFileOrigin)
 private val internalApiClassLocation = ClassLocation("InternalApiRegistrar", null, Modifiers.of(PUBLIC), SomeFileOrigin)
 
-val mockMethodLocationInSampleStuffFactory = MethodLocation(
+private val mockMethodLocationInSampleStuffFactory = MethodLocation(
   sampleStuffFactoryLocation,
   "produceStuff",
   "()V",
@@ -355,7 +354,7 @@ val mockMethodLocationInSampleStuffFactory = MethodLocation(
   Modifiers.of(PUBLIC)
 )
 
-fun methodNotFoundProblem(): MethodNotFoundProblem {
+private fun methodNotFoundProblem(): MethodNotFoundProblem {
   //FIXME consolidate with DocumentedProblemsReportingTest
   val JAVA_LANG_OBJECT_HIERARCHY = ClassHierarchy(
     "java/lang/Object",
@@ -373,7 +372,7 @@ fun methodNotFoundProblem(): MethodNotFoundProblem {
   )
 }
 
-fun methodNotFoundProblemInSampleStuffFactoryClass(): MethodNotFoundProblem {
+private fun methodNotFoundProblemInSampleStuffFactoryClass(): MethodNotFoundProblem {
   //FIXME consolidate with DocumentedProblemsReportingTest
   val JAVA_LANG_OBJECT_HIERARCHY = ClassHierarchy(
     "java/lang/Object",
@@ -390,7 +389,6 @@ fun methodNotFoundProblemInSampleStuffFactoryClass(): MethodNotFoundProblem {
     JAVA_LANG_OBJECT_HIERARCHY
   )
 }
-
 
 private object SomeFileOrigin : FileOrigin {
   override val parent: FileOrigin? = null

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -35,7 +35,6 @@ import org.junit.Before
 import org.junit.Test
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.io.Writer
 
 private const val PLUGIN_ID = "pluginId"
 private const val PLUGIN_VERSION = "1.0"

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -103,7 +103,7 @@ class MarkdownOutputTest {
       ### Invocation of unresolved method org.some.deleted.Class.foo() : void
       
       * Method SomeClass.someMethod() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
-      * Method VioletClass.produceViolet() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
+      * Method SampleStuffFactory.produceStuff() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
 
 
       """.trimIndent()
@@ -151,7 +151,7 @@ class MarkdownOutputTest {
     )
 
     val internalApiUsages = setOf(
-      InternalClassUsage(ClassReference("com.jetbrains.InternalClass"), internalApiClassLocation, mockMethodLocationInVioletClass)
+      InternalClassUsage(ClassReference("com.jetbrains.InternalClass"), internalApiClassLocation, mockMethodLocationInSampleStuffFactory)
     )
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, internalApiUsages = internalApiUsages)
@@ -167,7 +167,7 @@ class MarkdownOutputTest {
         
         ### Internal class InternalApiRegistrar reference
         
-        * Internal class InternalApiRegistrar is referenced in VioletClass.produceViolet() : void. This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the class is not supposed to be used in client code.
+        * Internal class InternalApiRegistrar is referenced in SampleStuffFactory.produceStuff() : void. This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the class is not supposed to be used in client code.
 
 
       """.trimIndent()
@@ -318,7 +318,7 @@ fun mockPluginInfo(pluginId: String, version: String): PluginInfo =
   object : PluginInfo(pluginId, pluginId, version, null, null, null) {}
 
 fun mockCompatibilityProblems(): Set<CompatibilityProblem> =
-  setOf(superInterfaceBecameClassProblem(), superInterfaceBecameClassProblemInOtherLocation(), methodNotFoundProblem(), methodNotFoundProblemInVioletClass())
+  setOf(superInterfaceBecameClassProblem(), superInterfaceBecameClassProblemInOtherLocation(), methodNotFoundProblem(), methodNotFoundProblemInSampleStuffFactoryClass())
 
 fun superInterfaceBecameClassProblem(): SuperInterfaceBecameClassProblem {
   val child = ClassLocation("com.jetbrains.plugin.Child", null, Modifiers.of(PUBLIC), SomeFileOrigin)
@@ -343,12 +343,12 @@ val mockMethodLocation = MethodLocation(
   Modifiers.of(PUBLIC)
 )
 
-private val violetClassLocation = ClassLocation("VioletClass", null, Modifiers.of(PUBLIC), SomeFileOrigin)
+private val sampleStuffFactoryLocation = ClassLocation("SampleStuffFactory", null, Modifiers.of(PUBLIC), SomeFileOrigin)
 private val internalApiClassLocation = ClassLocation("InternalApiRegistrar", null, Modifiers.of(PUBLIC), SomeFileOrigin)
 
-val mockMethodLocationInVioletClass = MethodLocation(
-  violetClassLocation,
-  "produceViolet",
+val mockMethodLocationInSampleStuffFactory = MethodLocation(
+  sampleStuffFactoryLocation,
+  "produceStuff",
   "()V",
   emptyList(),
   null,
@@ -373,7 +373,7 @@ fun methodNotFoundProblem(): MethodNotFoundProblem {
   )
 }
 
-fun methodNotFoundProblemInVioletClass(): MethodNotFoundProblem {
+fun methodNotFoundProblemInSampleStuffFactoryClass(): MethodNotFoundProblem {
   //FIXME consolidate with DocumentedProblemsReportingTest
   val JAVA_LANG_OBJECT_HIERARCHY = ClassHierarchy(
     "java/lang/Object",
@@ -385,7 +385,7 @@ fun methodNotFoundProblemInVioletClass(): MethodNotFoundProblem {
   val deletedClassRef = ClassReference("org/some/deleted/Class")
   return MethodNotFoundProblem(
     MethodReference(deletedClassRef, "foo", "()V"),
-    mockMethodLocationInVioletClass,
+    mockMethodLocationInSampleStuffFactory,
     Instruction.INVOKE_VIRTUAL,
     JAVA_LANG_OBJECT_HIERARCHY
   )

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.pluginverifier.output.markdown
 
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
@@ -7,6 +8,17 @@ import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
 import com.jetbrains.pluginverifier.dependencies.DependencyNode
 import com.jetbrains.pluginverifier.jdk.JdkVersion
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.results.hierarchy.ClassHierarchy
+import com.jetbrains.pluginverifier.results.instruction.Instruction
+import com.jetbrains.pluginverifier.results.location.ClassLocation
+import com.jetbrains.pluginverifier.results.location.MethodLocation
+import com.jetbrains.pluginverifier.results.modifiers.Modifiers
+import com.jetbrains.pluginverifier.results.modifiers.Modifiers.Modifier.PUBLIC
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.results.problems.MethodNotFoundProblem
+import com.jetbrains.pluginverifier.results.problems.SuperInterfaceBecameClassProblem
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.results.reference.MethodReference
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.PrintWriter
@@ -34,9 +46,45 @@ class MarkdownOutputTest {
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
-      # Plugin pluginId $PLUGIN_VERSION against 232.0: Compatible
+      # Plugin pluginId $PLUGIN_VERSION against 232.0
+      
+      Compatible
       
       
+      """.trimIndent()
+    assertEquals(expected, out.buffer.toString())
+  }
+
+  @Test
+  fun `plugin has compatibility warnings`() {
+    val dependenciesGraph = DependenciesGraph(
+      verifiedPlugin = DependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+      vertices = emptyList(),
+      edges = emptyList(),
+      missingDependencies = emptyMap()
+    )
+    val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, mockCompatibilityProblems())
+
+    val out = StringWriter()
+    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
+    resultPrinter.printResults(listOf(verificationResult))
+
+    val expected = """
+      # Plugin pluginId 1.0 against 232.0
+      
+      2 compatibility problems
+      
+      ## Compatibility problems (2): 
+      
+      ### Incompatible change of super interface com.jetbrains.plugin.Parent to class
+      
+      * Class com.jetbrains.plugin.Child has a *super interface* com.jetbrains.plugin.Parent which is actually a *class*. This can lead to **IncompatibleClassChangeError** exception at runtime.
+      
+      ### Invocation of unresolved method org.some.deleted.Class.foo() : void
+      
+      * Method SomeClass.someMethod() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
+
+
       """.trimIndent()
     assertEquals(expected, out.buffer.toString())
   }
@@ -44,3 +92,45 @@ class MarkdownOutputTest {
 
 fun mockPluginInfo(pluginId: String, version: String): PluginInfo =
   object : PluginInfo(pluginId, pluginId, version, null, null, null) {}
+
+fun mockCompatibilityProblems(): Set<CompatibilityProblem> =
+  setOf(superInterfaceBecameClassProblem(), methodNotFoundProblem())
+
+fun superInterfaceBecameClassProblem(): SuperInterfaceBecameClassProblem {
+  val child = ClassLocation("com.jetbrains.plugin.Child", null, Modifiers.of(PUBLIC), SomeFileOrigin)
+  val clazz = ClassLocation("com.jetbrains.plugin.Parent", null, Modifiers.of(PUBLIC), SomeFileOrigin)
+  return SuperInterfaceBecameClassProblem(child, clazz)
+}
+
+//FIXME consolidate with DocumentedProblemsReportingTest
+val mockMethodLocation = MethodLocation(
+  ClassLocation("SomeClass", null, Modifiers.of(PUBLIC), SomeFileOrigin),
+  "someMethod",
+  "()V",
+  emptyList(),
+  null,
+  Modifiers.of(PUBLIC)
+)
+
+fun methodNotFoundProblem(): MethodNotFoundProblem {
+  //FIXME consolidate with DocumentedProblemsReportingTest
+  val JAVA_LANG_OBJECT_HIERARCHY = ClassHierarchy(
+    "java/lang/Object",
+    false,
+    null,
+    emptyList()
+  )
+
+  val deletedClassRef = ClassReference("org/some/deleted/Class")
+  return MethodNotFoundProblem(
+    MethodReference(deletedClassRef, "foo", "()V"),
+    mockMethodLocation,
+    Instruction.INVOKE_VIRTUAL,
+    JAVA_LANG_OBJECT_HIERARCHY
+  )
+}
+
+
+private object SomeFileOrigin : FileOrigin {
+  override val parent: FileOrigin? = null
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -12,6 +12,7 @@ import com.jetbrains.pluginverifier.dependencies.DependencyNode
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus.MaybeDynamic
 import com.jetbrains.pluginverifier.jdk.JdkVersion
+import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.results.hierarchy.ClassHierarchy
 import com.jetbrains.pluginverifier.results.instruction.Instruction
@@ -30,9 +31,11 @@ import com.jetbrains.pluginverifier.usages.internal.InternalClassUsage
 import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableTypeInherited
 import com.jetbrains.pluginverifier.warnings.PluginStructureWarning
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.io.Writer
 
 private const val PLUGIN_ID = "pluginId"
 private const val PLUGIN_VERSION = "1.0"
@@ -40,6 +43,15 @@ private const val PLUGIN_VERSION = "1.0"
 class MarkdownOutputTest {
   private val pluginInfo = mockPluginInfo(PLUGIN_ID, PLUGIN_VERSION)
   private val verificationTarget = PluginVerificationTarget.IDE(IdeVersion.createIdeVersion("232"), JdkVersion("11", null))
+
+  private lateinit var out: StringWriter
+  private lateinit var resultPrinter: ResultPrinter
+
+  @Before
+  fun setUp() {
+    out = StringWriter()
+    resultPrinter = MarkdownResultPrinter(PrintWriter(out))
+  }
 
   @Test
   fun `plugin is compatible`() {
@@ -50,9 +62,6 @@ class MarkdownOutputTest {
       missingDependencies = emptyMap()
     )
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
-
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -62,7 +71,7 @@ class MarkdownOutputTest {
       
       
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -75,8 +84,6 @@ class MarkdownOutputTest {
     )
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, mockCompatibilityProblems())
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -101,7 +108,7 @@ class MarkdownOutputTest {
 
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -119,8 +126,6 @@ class MarkdownOutputTest {
     )
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, pluginStructureWarnings = structureWarnings)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -134,7 +139,7 @@ class MarkdownOutputTest {
 
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -152,8 +157,6 @@ class MarkdownOutputTest {
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, internalApiUsages = internalApiUsages)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -169,7 +172,7 @@ class MarkdownOutputTest {
 
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -190,8 +193,6 @@ class MarkdownOutputTest {
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, nonExtendableApiUsages = nonExtendableApiUsages)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -207,7 +208,7 @@ class MarkdownOutputTest {
 
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -236,8 +237,6 @@ class MarkdownOutputTest {
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, experimentalApiUsages = experimentalApiUsages)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -253,7 +252,7 @@ class MarkdownOutputTest {
           
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -270,8 +269,6 @@ class MarkdownOutputTest {
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -285,7 +282,7 @@ class MarkdownOutputTest {
         
         
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
 
   @Test
@@ -299,8 +296,6 @@ class MarkdownOutputTest {
 
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, dynamicPluginStatus = MaybeDynamic)
 
-    val out = StringWriter()
-    val resultPrinter = MarkdownResultPrinter(PrintWriter(out))
     resultPrinter.printResults(listOf(verificationResult))
 
     val expected = """
@@ -314,8 +309,10 @@ class MarkdownOutputTest {
 
 
       """.trimIndent()
-    assertEquals(expected, out.buffer.toString())
+    assertEquals(expected, output())
   }
+
+  private fun output() = out.buffer.toString()
 }
 
 fun mockPluginInfo(pluginId: String, version: String): PluginInfo =

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -1,0 +1,39 @@
+package com.jetbrains.pluginverifier.tests.cli
+
+import com.jetbrains.pluginverifier.options.CmdOpts
+import com.jetbrains.pluginverifier.options.OptionsParser
+import com.jetbrains.pluginverifier.output.OutputFormat
+import org.junit.Assert
+import org.junit.Test
+
+class OptionsParserTest {
+  @Test
+  fun `verification output format is parsed`() {
+    val opts = CmdOpts(outputFormats = arrayOf("plain", "html"))
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      Assert.assertEquals(2, outputFormats.size)
+      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+
+  @Test
+  fun `verification output format is parsed with unknown formats`() {
+    val opts = CmdOpts(outputFormats = arrayOf("plain", "html", "chocolate"))
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      Assert.assertEquals(2, outputFormats.size)
+      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+
+  @Test
+  fun `verification output format is empty, but defaults to HTML and plaintext`() {
+    val opts = CmdOpts()
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      Assert.assertEquals(2, outputFormats.size)
+      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -36,4 +36,24 @@ class OptionsParserTest {
       assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
     }
   }
+
+  @Test
+  fun `verification output format is empty and excludes plaintext`() {
+    val opts = CmdOpts(outputFormats = arrayOf("-plain"))
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      assertEquals(1, outputFormats.size)
+      assertEquals(listOf(OutputFormat.HTML), outputFormats)
+    }
+  }
+
+  @Test
+  fun `verification output format is specified and excludes plaintext`() {
+    val opts = CmdOpts(outputFormats = arrayOf("-html", "plain"))
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      assertEquals(1, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN), outputFormats)
+    }
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -18,8 +18,18 @@ class OptionsParserTest {
   }
 
   @Test
+  fun `verification output format is parsed with multiple unknown formats`() {
+    val opts = CmdOpts(outputFormats = arrayOf("unexpected-broken-format", "-another-unexpected-broken-format"))
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      assertEquals(2, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+
+  @Test
   fun `verification output format is parsed with unknown formats`() {
-    val opts = CmdOpts(outputFormats = arrayOf("plain", "html", "chocolate"))
+    val opts = CmdOpts(outputFormats = arrayOf("plain", "html", "unexpected-broken-format"))
     val options = OptionsParser.parseOutputOptions(opts)
     with(options) {
       assertEquals(2, outputFormats.size)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -3,7 +3,7 @@ package com.jetbrains.pluginverifier.tests.cli
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
 import com.jetbrains.pluginverifier.output.OutputFormat
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class OptionsParserTest {
@@ -12,8 +12,8 @@ class OptionsParserTest {
     val opts = CmdOpts(outputFormats = arrayOf("plain", "html"))
     val options = OptionsParser.parseOutputOptions(opts)
     with(options) {
-      Assert.assertEquals(2, outputFormats.size)
-      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+      assertEquals(2, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
     }
   }
 
@@ -22,8 +22,8 @@ class OptionsParserTest {
     val opts = CmdOpts(outputFormats = arrayOf("plain", "html", "chocolate"))
     val options = OptionsParser.parseOutputOptions(opts)
     with(options) {
-      Assert.assertEquals(2, outputFormats.size)
-      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+      assertEquals(2, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
     }
   }
 
@@ -32,8 +32,8 @@ class OptionsParserTest {
     val opts = CmdOpts()
     val options = OptionsParser.parseOutputOptions(opts)
     with(options) {
-      Assert.assertEquals(2, outputFormats.size)
-      Assert.assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+      assertEquals(2, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
     }
   }
 }


### PR DESCRIPTION
Support Markdown output format for verification reports.

Enable `-vrf` or `-verification-reports-formats` CLI switch that enables multiple output formats: plain, HTML and Markdown. By default, Markdown is disabled.

Reports are emitted into the same directory as HTML outputs, with `report.markdown` being the default filename.



## Out of scope

Plugin Problem messages are not in Markdown. This is out of scope of this PR.
