### PR TITLE
Show verification reports directory at the end of verification in CLI

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
@@ -11,15 +11,16 @@ import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.presentation.DependenciesGraphPrettyPrinter
 import com.jetbrains.pluginverifier.misc.HtmlBuilder
 import com.jetbrains.pluginverifier.output.OutputOptions
+import com.jetbrains.pluginverifier.output.ResultPrinter
 import java.io.PrintWriter
 import java.nio.file.Files
 
 class HtmlResultPrinter(
   private val verificationTarget: PluginVerificationTarget,
   private val outputOptions: OutputOptions
-) {
+): ResultPrinter {
 
-  fun printResults(results: List<PluginVerificationResult>) {
+  override fun printResults(results: List<PluginVerificationResult>) {
     val reportHtmlFile = outputOptions.getTargetReportDirectory(verificationTarget).resolve("report.html")
     PrintWriter(Files.newBufferedWriter(reportHtmlFile.create())).use {
       val htmlBuilder = HtmlBuilder(it)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregator.kt
@@ -1,0 +1,31 @@
+package com.jetbrains.pluginverifier.reporting
+
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.reporting.common.LogReporter
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+import kotlin.io.path.absolute
+
+/**
+ * Stateful aggregator verification reports and their corresponding directories.
+ * Allows aggregating such reports and logging them to a logger.
+ */
+class LoggingPluginVerificationReportageAggregator(
+  private val messageReporters: List<LogReporter<String>> = listOf(LogReporter(LoggerFactory.getLogger("verification")))
+) : PluginVerificationReportageAggregator {
+
+  private val resultsInDirectories = mutableListOf<Pair<PluginVerificationResult, Path>>()
+
+  override fun handleVerificationResult(result: PluginVerificationResult, targetDirectory: Path) {
+    resultsInDirectories.add(result to targetDirectory)
+  }
+
+  fun handleAggregatedReportage() {
+    messageReporters.forEach { reporter ->
+      for ((result, targetDirectory) in resultsInDirectories) {
+        val message = "Verification reports for " + result.plugin + " saved to ${targetDirectory.absolute()}"
+        reporter.report(message)
+      }
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/PluginVerificationReportageAggregator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/PluginVerificationReportageAggregator.kt
@@ -1,0 +1,12 @@
+package com.jetbrains.pluginverifier.reporting
+
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import java.nio.file.Path
+
+/**
+ * Maps plugin verification results to target directory in the filesystem that contains the report files.
+ */
+fun interface PluginVerificationReportageAggregator {
+  fun handleVerificationResult(result: PluginVerificationResult, targetDirectory: Path)
+}
+

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
@@ -2,7 +2,6 @@ package com.jetbrains.pluginverifier.reporting
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.DefaultDescription
-import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginId
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
@@ -11,17 +10,12 @@ import com.jetbrains.pluginverifier.dependencies.DependencyNode
 import com.jetbrains.pluginverifier.jdk.JdkVersion
 import com.jetbrains.pluginverifier.reporting.common.LogReporter
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.tests.mocks.MockLogger
 import com.jetbrains.pluginverifier.warnings.PluginStructureError
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.slf4j.Marker
-import org.slf4j.event.Level
-import org.slf4j.helpers.AbstractLogger
 import kotlin.io.path.createTempDirectory
-import kotlin.math.log
-import com.jetbrains.pluginverifier.tests.mocks.MockLogger
 
 private const val PLUGIN_ID = "pluginId"
 private const val PLUGIN_VERSION = "1.0"

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
@@ -1,0 +1,77 @@
+package com.jetbrains.pluginverifier.reporting
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.problems.DefaultDescription
+import com.jetbrains.plugin.structure.intellij.problems.IllegalPluginId
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
+import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.DependencyNode
+import com.jetbrains.pluginverifier.jdk.JdkVersion
+import com.jetbrains.pluginverifier.reporting.common.LogReporter
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.warnings.PluginStructureError
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.slf4j.Marker
+import org.slf4j.event.Level
+import org.slf4j.helpers.AbstractLogger
+import kotlin.io.path.createTempDirectory
+import kotlin.math.log
+import com.jetbrains.pluginverifier.tests.mocks.MockLogger
+
+private const val PLUGIN_ID = "pluginId"
+private const val PLUGIN_VERSION = "1.0"
+
+class LoggingPluginVerificationReportageAggregatorTest {
+  private lateinit var loggingPluginVerificationReportageAggregator: LoggingPluginVerificationReportageAggregator
+  private lateinit var mockLogger: MockLogger
+
+  private val pluginInfo = mockPluginInfo()
+  private val verificationTarget = PluginVerificationTarget.IDE(IdeVersion.createIdeVersion("232"), JdkVersion("11", null))
+
+  @Before
+  fun setUp() {
+    mockLogger = MockLogger()
+    val logReporters = listOf(LogReporter<String>(mockLogger))
+    loggingPluginVerificationReportageAggregator = LoggingPluginVerificationReportageAggregator(logReporters)
+  }
+
+  @Test
+  fun `verification results are aggregated`() {
+    val dependenciesGraph = DependenciesGraph(
+      verifiedPlugin = DependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+      vertices = emptyList(),
+      edges = emptyList(),
+      missingDependencies = emptyMap()
+    )
+    val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
+    val targetDirectory = createTempDirectory()
+    loggingPluginVerificationReportageAggregator.handleVerificationResult(verificationResult, targetDirectory)
+    loggingPluginVerificationReportageAggregator.handleAggregatedReportage()
+
+    assertEquals(1, mockLogger.loggingEvents.size)
+    val logEntry = mockLogger.loggingEvents.first()
+    assertEquals("Verification reports for $PLUGIN_ID $PLUGIN_VERSION saved to $targetDirectory", logEntry.messagePattern)
+  }
+
+  @Test
+  fun `verification results are aggregated on failed verification`() {
+    val pluginStructureErrors = setOf(PluginStructureError(DefaultDescription(IdePluginManager.PLUGIN_XML)))
+    val verificationResult = PluginVerificationResult.InvalidPlugin(pluginInfo, verificationTarget, pluginStructureErrors)
+    val targetDirectory = createTempDirectory()
+    loggingPluginVerificationReportageAggregator.handleVerificationResult(verificationResult, targetDirectory)
+    loggingPluginVerificationReportageAggregator.handleAggregatedReportage()
+
+    assertEquals(1, mockLogger.loggingEvents.size)
+    val logEntry = mockLogger.loggingEvents.first()
+    assertEquals("Verification reports for $PLUGIN_ID $PLUGIN_VERSION saved to $targetDirectory", logEntry.messagePattern)
+  }
+
+  private fun mockPluginInfo(): PluginInfo =
+    object : PluginInfo(PLUGIN_ID, PLUGIN_ID, PLUGIN_VERSION, null, null, null) {}
+
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockLogger.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockLogger.kt
@@ -1,0 +1,45 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import org.slf4j.Marker
+import org.slf4j.event.Level
+import org.slf4j.helpers.AbstractLogger
+
+/**
+ * Mock SLF4J logger that aggregates logging events into in-memory list of logging events.
+ *
+ * This is used to assert logging events in unit tests.
+ */
+class MockLogger : AbstractLogger() {
+  private val _loggingEvents = mutableListOf<LoggingEvent>()
+
+  val loggingEvents: List<LoggingEvent>
+    get() = _loggingEvents
+
+  override fun handleNormalizedLoggingCall(level: Level?, marker: Marker?, messagePattern: String?, arguments: Array<out Any>?, throwable: Throwable?) {
+    _loggingEvents.add(LoggingEvent(level, marker, messagePattern, arguments, throwable))
+  }
+
+  override fun isTraceEnabled() = true
+
+  override fun isTraceEnabled(marker: Marker?) = true
+
+  override fun isDebugEnabled() = true
+
+  override fun isDebugEnabled(marker: Marker?) = true
+
+  override fun isInfoEnabled() = true
+
+  override fun isInfoEnabled(marker: Marker?) = true
+
+  override fun isWarnEnabled() = true
+
+  override fun isWarnEnabled(marker: Marker?) = true
+
+  override fun isErrorEnabled() = true
+
+  override fun isErrorEnabled(marker: Marker?) = true
+
+  override fun getFullyQualifiedCallerName() = "com.jetbrains.mock"
+
+  data class LoggingEvent(val level: Level?, val marker: Marker?, val messagePattern: String?, val arguments: Array<out Any>?, val throwable: Throwable?)
+}


### PR DESCRIPTION
In CLI, show the verification reports directory at the end of verification process.

```
2023-08-31T09:14:35 [main] INFO  verification - Total time spent downloading plugins and their dependencies: 0 ms
2023-08-31T09:14:35 [main] INFO  verification - Total amount of plugins and dependencies downloaded: 0 B
2023-08-31T09:14:35 [main] INFO  verification - Total amount of space used for plugins and dependencies: 528.57 MB
...
2023-08-31T09:14:35 [main] INFO  verification - Verification reports for example-plugin:25-SNAPSHOT saved to /Users/novotnyr/projects/jetbrains/intellij-plugin-verifier/plugins-verifier-service/verification-2023-08-31 at 09.14.26/IE-203.7717.75


Process finished with exit code 0
```