### PR TITLE
Typo in argument name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Here is the full syntax of the command:
     Specifies which subsystems of IDE should be checked.
     Available options: `all` (default), `android-only`, `without-android`.
 
-* `-ignore-problems (-ip)`
+* `-ignored-problems (-ip)`
 
     A file that contains a list of problems that will be ignored in report. 
     The file must contain lines in form `<plugin_xml_id>:<plugin_version>:<problem_description_regexp_pattern>`


### PR DESCRIPTION
The documentation says `-ignore-problems` but [it seems like](https://github.com/JetBrains/intellij-plugin-verifier/blob/639ae7ebbc433a81dd956564be57e4514d504ea7/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt#L17C1-L17C1) the actual name of that argument is `-ignored-problems`.