### PR TITLE
Indicate no verification output formats with an explicit empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ Here is the full syntax of the command:
 
     * `plain,markdown` will enable console output and the Markdown verification reports.
     * `-plain` will disable console output, but retain the default HTML output.
+    * `""` (literal empty string) will disable all verification report formats. 
+    This will essentially suppress console output, leaving only logging messages.
+    
 
 * `-runtime-dir (-r)`
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -67,8 +67,10 @@ object OptionsParser {
   }
 
   private fun parseOutputFormats(opts: CmdOpts): List<OutputFormat> {
+    if (opts.outputFormats.isExplicitlyEmpty()) {
+      return emptyList()
+    }
     val (exclusions, inclusions) = opts.outputFormats.partition { it.trim().startsWith("-") }
-
 
     val includedFormats = inclusions.mapNotNull {
       try {
@@ -263,4 +265,12 @@ object OptionsParser {
 
     return KeepOnlyProblemsFilter(keepOnlyConditions)
   }
+
+  /**
+   * Indicates that array has a single element -- an empty string.
+   * This is to handle array-like arguments passed from CLI.
+   */
+  private fun Array<String>.isExplicitlyEmpty(): Boolean = size == 1 && first().isEmpty()
+
 }
+

--- a/intellij-plugin-verifier/verifier-test/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
 
   testImplementation(libs.systemStubs.junit4)
   testImplementation(libs.jimfs)
+
+  testImplementation(sharedLibs.spullara.cliParser)
 }
 
 val prepareMockPlugin by tasks.registering(Copy::class) {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -3,7 +3,8 @@ package com.jetbrains.pluginverifier.tests.cli
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
 import com.jetbrains.pluginverifier.output.OutputFormat
-import org.junit.Assert.assertEquals
+import com.sampullara.cli.Args
+import org.junit.Assert.*
 import org.junit.Test
 
 class OptionsParserTest {
@@ -58,12 +59,39 @@ class OptionsParserTest {
   }
 
   @Test
-  fun `verification output format is specified and excludes plaintext`() {
-    val opts = CmdOpts(outputFormats = arrayOf("-html", "plain"))
+  fun `verification output format is specified, but empty string is provided to indicate no output formats`() {
+    val args = arrayOf("-verification-reports-formats", "")
+    val opts = CmdOpts()
+    Args.parse(opts, args, false)
+
     val options = OptionsParser.parseOutputOptions(opts)
     with(options) {
-      assertEquals(1, outputFormats.size)
-      assertEquals(listOf(OutputFormat.PLAIN), outputFormats)
+      assertTrue(outputFormats.isEmpty())
     }
   }
+
+  @Test
+  fun `verification output format is specified, but no value is provided`() {
+    val illegalArgumentException = assertThrows(IllegalArgumentException::class.java) {
+      val args = arrayOf("-verification-reports-formats")
+      val opts = CmdOpts()
+      Args.parse(opts, args, false)
+    }
+    assertEquals("Must have a value for non-boolean argument verification-reports-formats", illegalArgumentException.message)
+  }
+
+  @Test
+  fun `no verification output format is specified, so revert to defaults`() {
+    val args = arrayOf("")
+
+    val opts = CmdOpts()
+    Args.parse(opts, args, false)
+
+    val options = OptionsParser.parseOutputOptions(opts)
+    with(options) {
+      assertEquals(2, outputFormats.size)
+      assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+
 }


### PR DESCRIPTION
When the `-vrf` parameter is missing, a default set of verification output format is used. This is to maintain the backwards compatibility.

However, in order to integrate with [Gradle IntelliJ Plugin](https://github.com/JetBrains/gradle-intellij-plugin), we need to explicitly indicate an empty list of verification output formats.

Due to the `spullara/cli-parser` and its handling of empty arrays, an empty string literal passed as a CLI argument, is used to indicate an empty array of output formats.