### PR TITLE
CLI switch to suppress internal API usages by internal plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This command is used to check one or more plugins against one or more IDEs ([opt
 #### Specific options
 
 * `-suppress-internal-api-usages` will suppress internal API usages from JetBrains plugins.
-This option is used by JetBrains MarketPlace by default. 
+This option is used by JetBrains Marketplace by default. 
 
     Allowed values: 
  

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This command is used to check one or more plugins against one or more IDEs ([opt
         [-team-city | -tc ]
         [-tc-grouping | -g ]
         [-external-prefixes <':'-separated list>]
-        [-suppress-internal-api-usages no|internal-plugins]
+        [-suppress-internal-api-usages no|jetbrains-plugins]
 
 `<plugins>` is either `<plugin path>` or `'@<file>'` with a list of plugin paths to verify, separated by a newline.
 
@@ -157,16 +157,13 @@ This command is used to check one or more plugins against one or more IDEs ([opt
 
 #### Specific options
 
-* `-suppress-internal-api-usages` will suppress internal API usages from internal plugins.
+* `-suppress-internal-api-usages` will suppress internal API usages from JetBrains plugins.
 This option is used by JetBrains MarketPlace by default. 
 
     Allowed values: 
  
   * `no`: all internal API usages will be reported. This is the default value.
-  * `internal-plugins`: internal API usages by internal plugins will not be reported.  
-
-
-  
+  * `jetbrains-plugins`: internal API usages by JetBrains plugins will not be reported.  
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,24 @@ This command is used to check one or more plugins against one or more IDEs ([opt
         [-team-city | -tc ]
         [-tc-grouping | -g ]
         [-external-prefixes <':'-separated list>]
+        [-suppress-internal-api-usages no|internal-plugins]
 
 `<plugins>` is either `<plugin path>` or `'@<file>'` with a list of plugin paths to verify, separated by a newline.
 
 `<IDE>` is either a path to local IDE installation, or an IDE pattern (see bellow in the [common options](#common-options)) 
+
+#### Specific options
+
+* `-suppress-internal-api-usages` will suppress internal API usages from internal plugins.
+This option is used by JetBrains MarketPlace by default. 
+
+    Allowed values: 
+ 
+  * `no`: all internal API usages will be reported. This is the default value.
+  * `internal-plugins`: internal API usages by internal plugins will not be reported.  
+
+
+  
 
 #### Examples
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -71,7 +71,7 @@ open class CmdOpts(
 
   @set:Argument(
     "suppress-internal-api",
-    description = "Suppress internal API usage checks. Available options: none (default), internal-plugins."
+    description = "Suppress internal API usage checks. Available options: no (default), internal-plugins."
   )
-  var suppressInternalApiUsageWarnings: String? = "none"
+  var suppressInternalApiUsageWarnings: String? = "no"
 )

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -67,5 +67,11 @@ open class CmdOpts(
     alias = "kop",
     description = "Only the problems matching lines in this file will be reflected in report. The file must contain lines in form: <problem_description_regexp_pattern>"
   )
-  var keepOnlyProblemsFile: String? = null
+  var keepOnlyProblemsFile: String? = null,
+
+  @set:Argument(
+    "suppress-internal-api",
+    description = "Suppress internal API usage checks. Available options: none (default), internal-plugins."
+  )
+  var suppressInternalApiUsageWarnings: String? = "none"
 )

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -70,7 +70,7 @@ open class CmdOpts(
   var keepOnlyProblemsFile: String? = null,
 
   @set:Argument(
-    "suppress-internal-api",
+    "suppress-internal-api-usages",
     description = "Suppress internal API usage checks. Available options: no (default), internal-plugins."
   )
   var suppressInternalApiUsageWarnings: String? = "no"

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -71,7 +71,7 @@ open class CmdOpts(
 
   @set:Argument(
     "suppress-internal-api-usages",
-    description = "Suppress internal API usage checks. Available options: no (default), internal-plugins."
+    description = "Suppress internal API usage checks. Available options: no (default), jetbrains-plugins."
   )
   var suppressInternalApiUsageWarnings: String? = "no"
 )

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
@@ -16,7 +16,8 @@ class CheckPluginParams(
   val problemsFilters: List<ProblemsFilter>,
   val verificationDescriptors: List<PluginVerificationDescriptor>,
   val invalidPluginFiles: List<InvalidPluginFile>,
-  val excludeExternalBuildClassesSelector: Boolean
+  val excludeExternalBuildClassesSelector: Boolean,
+  val internalApiVerificationMode: InternalApiVerificationMode = InternalApiVerificationMode.FULL
 ) : TaskParameters {
 
   override val presentableText
@@ -31,4 +32,16 @@ class CheckPluginParams(
     ideDescriptors.forEach { it.closeLogged() }
   }
 
+}
+
+enum class InternalApiVerificationMode {
+  /**
+   * Full verification of internal API usages for all plugins.
+   */
+  FULL,
+
+  /**
+   * Internal plugins that use internal APIs will not be reported.
+   */
+  IGNORE_IN_INTERNAL_PLUGINS
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
@@ -43,5 +43,5 @@ enum class InternalApiVerificationMode {
   /**
    * Internal plugins that use internal APIs will not be reported.
    */
-  IGNORE_IN_INTERNAL_PLUGINS
+  IGNORE_IN_JETBRAINS_PLUGINS
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParams.kt
@@ -41,7 +41,7 @@ enum class InternalApiVerificationMode {
   FULL,
 
   /**
-   * Internal plugins that use internal APIs will not be reported.
+   * JetBrains plugins that use internal APIs will not be reported.
    */
   IGNORE_IN_JETBRAINS_PLUGINS
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -22,7 +22,7 @@ import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMod
 import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS
 import java.nio.file.Paths
 
-const val INTERNAL_PLUGINS_API_USAGE_MODE = "internal-plugins"
+const val JETBRAINS_PLUGINS_API_USAGE_MODE = "jetbrains-plugins"
 
 class CheckPluginParamsBuilder(
   val pluginRepository: PluginRepository,
@@ -94,7 +94,7 @@ class CheckPluginParamsBuilder(
   }
 
   private val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
-    get() = if (suppressInternalApiUsageWarnings?.equals(INTERNAL_PLUGINS_API_USAGE_MODE) == true) {
+    get() = if (suppressInternalApiUsageWarnings?.equals(JETBRAINS_PLUGINS_API_USAGE_MODE) == true) {
       IGNORE_IN_INTERNAL_PLUGINS
     } else {
       FULL

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -18,6 +18,8 @@ import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepository
 import com.jetbrains.pluginverifier.resolution.DefaultClassResolverProvider
 import com.jetbrains.pluginverifier.tasks.TaskParametersBuilder
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.FULL
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS
 import java.nio.file.Paths
 
 class CheckPluginParamsBuilder(
@@ -84,9 +86,18 @@ class CheckPluginParamsBuilder(
       problemsFilters,
       verificationDescriptors,
       pluginsSet.invalidPluginFiles,
-      opts.excludeExternalBuildClassesSelector
+      opts.excludeExternalBuildClassesSelector,
+      opts.internalApiVerificationMode
     )
   }
+
+
+  internal val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
+    get() = if (suppressInternalApiUsageWarnings?.equals("internal-plugins") == true) {
+      IGNORE_IN_INTERNAL_PLUGINS
+    } else {
+      FULL
+    }
 
   /**
    * Creates the [DependencyFinder] that firstly tries to resolve the dependency among the verified plugins.
@@ -100,8 +111,6 @@ class CheckPluginParamsBuilder(
     val ideDependencyFinder = createIdeBundledOrPluginRepositoryDependencyFinder(ideDescriptor.ide, pluginRepository, pluginDetailsCache)
     return CompositeDependencyFinder(listOf(localFinder, ideDependencyFinder))
   }
-
-
 }
 
 fun interface IdeDescriptorParser {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -19,7 +19,7 @@ import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRep
 import com.jetbrains.pluginverifier.resolution.DefaultClassResolverProvider
 import com.jetbrains.pluginverifier.tasks.TaskParametersBuilder
 import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.FULL
-import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_JETBRAINS_PLUGINS
 import java.nio.file.Paths
 
 const val JETBRAINS_PLUGINS_API_USAGE_MODE = "jetbrains-plugins"
@@ -95,7 +95,7 @@ class CheckPluginParamsBuilder(
 
   private val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
     get() = if (suppressInternalApiUsageWarnings?.equals(JETBRAINS_PLUGINS_API_USAGE_MODE) == true) {
-      IGNORE_IN_INTERNAL_PLUGINS
+      IGNORE_IN_JETBRAINS_PLUGINS
     } else {
       FULL
     }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -93,8 +93,7 @@ class CheckPluginParamsBuilder(
     )
   }
 
-
-  internal val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
+  private val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
     get() = if (suppressInternalApiUsageWarnings?.equals(INTERNAL_PLUGINS_API_USAGE_MODE) == true) {
       IGNORE_IN_INTERNAL_PLUGINS
     } else {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -22,6 +22,8 @@ import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMod
 import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS
 import java.nio.file.Paths
 
+const val INTERNAL_PLUGINS_API_USAGE_MODE = "internal-plugins"
+
 class CheckPluginParamsBuilder(
   val pluginRepository: PluginRepository,
   val reportage: PluginVerificationReportage,
@@ -93,7 +95,7 @@ class CheckPluginParamsBuilder(
 
 
   internal val CmdOpts.internalApiVerificationMode: InternalApiVerificationMode
-    get() = if (suppressInternalApiUsageWarnings?.equals("internal-plugins") == true) {
+    get() = if (suppressInternalApiUsageWarnings?.equals(INTERNAL_PLUGINS_API_USAGE_MODE) == true) {
       IGNORE_IN_INTERNAL_PLUGINS
     } else {
       FULL

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
@@ -47,7 +47,7 @@ class CheckPluginTask(private val parameters: CheckPluginParams) : Task {
   }
 
   private val CheckPluginParams.resolveApiUsageFilters: List<ApiUsageFilter>
-    get() = if (internalApiVerificationMode == InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS) {
+    get() = if (internalApiVerificationMode == InternalApiVerificationMode.IGNORE_IN_JETBRAINS_PLUGINS) {
       listOf(InternalApiUsageFilter())
     } else {
       emptyList()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginTask.kt
@@ -6,6 +6,8 @@ package com.jetbrains.pluginverifier.tasks.checkPlugin
 
 import com.jetbrains.pluginverifier.PluginVerifier
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
+import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
+import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
 import com.jetbrains.pluginverifier.repository.PluginRepository
@@ -33,7 +35,8 @@ class CheckPluginTask(private val parameters: CheckPluginParams) : Task {
           problemsFilters,
           pluginDetailsCache,
           listOf(DynamicallyLoadedFilter()),
-          excludeExternalBuildClassesSelector
+          excludeExternalBuildClassesSelector,
+          parameters.resolveApiUsageFilters
         )
       }
 
@@ -43,4 +46,10 @@ class CheckPluginTask(private val parameters: CheckPluginParams) : Task {
     }
   }
 
+  private val CheckPluginParams.resolveApiUsageFilters: List<ApiUsageFilter>
+    get() = if (internalApiVerificationMode == InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS) {
+      listOf(InternalApiUsageFilter())
+    } else {
+      emptyList()
+    }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
@@ -31,7 +31,7 @@ class CheckPluginParamsBuilderTest {
   @Test
   fun `internal API switch is parsed`() {
     val cmdOpts = CmdOpts().apply {
-      suppressInternalApiUsageWarnings = INTERNAL_PLUGINS_API_USAGE_MODE
+      suppressInternalApiUsageWarnings = JETBRAINS_PLUGINS_API_USAGE_MODE
     }
 
     val ideDescriptorParser = IdeDescriptorParser { _, _ -> emptyList() }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
@@ -42,6 +42,6 @@ class CheckPluginParamsBuilderTest {
     val params = CheckPluginParamsBuilder(pluginRepository, pluginVerificationReportage, pluginDetailsCache, ideDescriptorParser)
       .build(cmdOpts, freeArgs = listOf(somePluginZipFile.absolutePathString(), someIde.absolutePathString()))
 
-    assertEquals(InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS, params.internalApiVerificationMode)
+    assertEquals(InternalApiVerificationMode.IGNORE_IN_JETBRAINS_PLUGINS, params.internalApiVerificationMode)
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
@@ -31,8 +31,7 @@ class CheckPluginParamsBuilderTest {
   @Test
   fun `internal API switch is parsed`() {
     val cmdOpts = CmdOpts().apply {
-      //TODO use constant
-      suppressInternalApiUsageWarnings = "internal-plugins"
+      suppressInternalApiUsageWarnings = INTERNAL_PLUGINS_API_USAGE_MODE
     }
 
     val ideDescriptorParser = IdeDescriptorParser { _, _ -> emptyList() }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilderTest.kt
@@ -1,0 +1,48 @@
+package com.jetbrains.pluginverifier.tasks.checkPlugin
+
+import com.jetbrains.pluginverifier.options.CmdOpts
+import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
+import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginDetailsCache
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginRepositoryAdapter
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginVerificationReportage
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
+
+class CheckPluginParamsBuilderTest {
+  private lateinit var pluginRepository: PluginRepository
+
+  private lateinit var pluginVerificationReportage: PluginVerificationReportage
+
+  private lateinit var pluginDetailsCache: PluginDetailsCache
+
+  @Before
+  fun setUp() {
+    pluginRepository = MockPluginRepositoryAdapter()
+    pluginVerificationReportage = MockPluginVerificationReportage()
+    pluginDetailsCache = MockPluginDetailsCache()
+  }
+
+  @Test
+  fun `internal API switch is parsed`() {
+    val cmdOpts = CmdOpts().apply {
+      //TODO use constant
+      suppressInternalApiUsageWarnings = "internal-plugins"
+    }
+
+    val ideDescriptorParser = IdeDescriptorParser { _, _ -> emptyList() }
+
+    val somePluginZipFile = createTempFile(suffix = ".zip")
+    val someIde = createTempDirectory("idea-IU-117.963")
+
+    val params = CheckPluginParamsBuilder(pluginRepository, pluginVerificationReportage, pluginDetailsCache, ideDescriptorParser)
+      .build(cmdOpts, freeArgs = listOf(somePluginZipFile.absolutePathString(), someIde.absolutePathString()))
+
+    assertEquals(InternalApiVerificationMode.IGNORE_IN_INTERNAL_PLUGINS, params.internalApiVerificationMode)
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginDetailsCache.kt
@@ -1,0 +1,14 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
+import com.jetbrains.pluginverifier.repository.PluginInfo
+
+class MockPluginDetailsCache : PluginDetailsCache {
+  override fun getPluginDetailsCacheEntry(pluginInfo: PluginInfo): PluginDetailsCache.Result {
+    return PluginDetailsCache.Result.FileNotFound("Mock cache does not provide any files")
+  }
+
+  override fun close() {
+    // no-op
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginVerificationReportage.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginVerificationReportage.kt
@@ -1,0 +1,17 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
+import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
+import com.jetbrains.pluginverifier.repository.PluginInfo
+
+class MockPluginVerificationReportage : PluginVerificationReportage {
+  override fun logVerificationStage(stageMessage: String) = Unit
+
+  override fun logPluginVerificationIgnored(pluginInfo: PluginInfo, verificationTarget: PluginVerificationTarget, reason: String) =
+    Unit
+
+  override fun reportVerificationResult(pluginVerificationResult: PluginVerificationResult) = Unit
+
+  override fun close() = Unit
+}


### PR DESCRIPTION
Add a `--suppress-internal-api-usages` switch to disable internal API usages reporting by internal plugins.

See #952 for original implementation, which did not provide CLI switch.