### PR TITLE
Show total duration of plugin verification in CLI

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -140,8 +140,8 @@ object PluginVerifierMain {
         val taskResultsPrinter = taskResult.createTaskResultsPrinter(pluginRepository)
         taskResultsPrinter.printResults(taskResult, outputOptions)
         reportage.reportDownloadStatistics(outputOptions, pluginFilesBank)
-        reportage.reportVerificationDuration(this)
         reportageAggregator.handleAggregatedReportage()
+        reportage.reportVerificationDuration(this)
       }
     }
   }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/profiling/PluginVerificationProfilings.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/profiling/PluginVerificationProfilings.kt
@@ -1,0 +1,16 @@
+package com.jetbrains.pluginverifier.tasks.profiling
+
+import com.jetbrains.pluginverifier.tasks.TaskResult
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.system.measureTimeMillis
+
+fun measurePluginVerification(measuredBlock: (Unit) -> TaskResult): MeasuredResult {
+  val result = AtomicReference<TaskResult>()
+  val durationInMillis: Long = measureTimeMillis {
+    result.set(measuredBlock.invoke(Unit))
+  }
+  return MeasuredResult(result.get(), Duration.ofMillis(durationInMillis))
+}
+
+data class MeasuredResult(val taskResult: TaskResult, val duration: Duration)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationReportageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationReportageTest.kt
@@ -1,0 +1,23 @@
+package com.jetbrains.pluginverifier.reporting
+
+import com.jetbrains.pluginverifier.tasks.profiling.measurePluginVerification
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginVerificationReportage
+import com.jetbrains.pluginverifier.tests.mocks.MockTaskResult
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class DurationMeasuringPluginVerificationReportageTest {
+
+  @Test
+  fun `run duration on function`() {
+    measurePluginVerification {
+      MockPluginVerificationReportage().run {
+        TimeUnit.MILLISECONDS.sleep(5)
+        MockTaskResult()
+      }
+    }.run {
+      assertTrue(this.duration.nano > 0)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
@@ -11,13 +11,14 @@ class DurationMeasuringPluginVerificationTest {
 
   @Test
   fun `run duration on function`() {
+    val sleepDuration = 5L
     measurePluginVerification {
       MockPluginVerificationReportage().run {
-        TimeUnit.MILLISECONDS.sleep(5)
+        TimeUnit.MILLISECONDS.sleep(sleepDuration)
         MockTaskResult()
       }
     }.run {
-      assertTrue(this.duration.nano > 0)
+      assertTrue(this.duration.nano > sleepDuration)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
@@ -18,7 +18,7 @@ class DurationMeasuringPluginVerificationTest {
         MockTaskResult()
       }
     }.run {
-      assertTrue(this.duration.nano > sleepDuration)
+      assertTrue(this.duration.nano >= sleepDuration)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/DurationMeasuringPluginVerificationTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
-class DurationMeasuringPluginVerificationReportageTest {
+class DurationMeasuringPluginVerificationTest {
 
   @Test
   fun `run duration on function`() {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockTaskResult.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockTaskResult.kt
@@ -1,0 +1,8 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.tasks.TaskResult
+
+class MockTaskResult : TaskResult {
+  override fun createTaskResultsPrinter(pluginRepository: PluginRepository) = SimpleTaskResultPrinter()
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/SimpleTaskResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/SimpleTaskResultPrinter.kt
@@ -1,0 +1,13 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.pluginverifier.output.OutputOptions
+import com.jetbrains.pluginverifier.tasks.TaskResult
+import com.jetbrains.pluginverifier.tasks.TaskResultPrinter
+
+class SimpleTaskResultPrinter : TaskResultPrinter {
+  private val taskResults : List<TaskResult> = mutableListOf()
+
+  override fun printResults(taskResult: TaskResult, outputOptions: OutputOptions) {
+    taskResults + taskResult
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/SimpleTaskResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/SimpleTaskResultPrinter.kt
@@ -5,9 +5,7 @@ import com.jetbrains.pluginverifier.tasks.TaskResult
 import com.jetbrains.pluginverifier.tasks.TaskResultPrinter
 
 class SimpleTaskResultPrinter : TaskResultPrinter {
-  private val taskResults : List<TaskResult> = mutableListOf()
-
   override fun printResults(taskResult: TaskResult, outputOptions: OutputOptions) {
-    taskResults + taskResult
+    // no-op
   }
 }


### PR DESCRIPTION
Show the total duration of plugin verification on console.

The console will show the following line in the final stage of verification process:

```
2023-10-02T12:40:47 [main] INFO  verification - Total time spent in plugin verification: 7 s 51 ms
```