### PR TITLE
Simplify JRT filesystem handling to make it compatible with JDK 17

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorCreator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorCreator.kt
@@ -18,6 +18,7 @@ object JdkDescriptorCreator {
 
   fun createBundledJdkDescriptor(ide: Ide, readMode: Resolver.ReadMode = Resolver.ReadMode.FULL): JdkDescriptor? {
     val bundledJdkPath = listOf(
+      ide.idePath.resolve("jbr").resolve("Contents").resolve("Home"),
       ide.idePath.resolve("jbr"),
       ide.idePath.resolve("jre64")
     ).find { it.isDirectory } ?: return null

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorCreator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorCreator.kt
@@ -12,7 +12,7 @@ import com.jetbrains.plugin.structure.classes.resolvers.buildJarOrZipFileResolve
 import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import java.nio.file.Path
-import java.util.Locale
+import java.util.*
 
 object JdkDescriptorCreator {
 
@@ -58,8 +58,8 @@ object JdkDescriptorCreator {
 
   private fun readFullVersion(jdkPath: Path): String? {
     val linuxOrWindowsRelease = jdkPath.resolve("release")
-    val maxOsRelease = jdkPath.resolve("Contents").resolve("Home").resolve("release")
-    for (releasePath in listOf(linuxOrWindowsRelease, maxOsRelease)) {
+    val macOsRelease = jdkPath.resolve("Contents").resolve("Home").resolve("release")
+    for (releasePath in listOf(linuxOrWindowsRelease, macOsRelease)) {
       if (releasePath.exists()) {
         val properties = releasePath.readLines().associate {
           val list = it.split("=")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -5,15 +5,12 @@
 package com.jetbrains.pluginverifier.jdk
 
 import com.jetbrains.plugin.structure.base.utils.closeAll
-import com.jetbrains.plugin.structure.base.utils.closeLogged
-import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
 import com.jetbrains.plugin.structure.classes.resolvers.*
 import com.jetbrains.plugin.structure.classes.utils.AsmUtil
 import org.objectweb.asm.tree.ClassNode
 import java.io.Closeable
 import java.net.URI
-import java.net.URLClassLoader
 import java.nio.file.*
 import java.util.*
 import java.util.stream.Collectors
@@ -41,7 +38,7 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
 
   init {
     val fileSystem = try {
-      getOrCreateJrtFileSystem(jdkPath)
+      getJrtFileSystem(jdkPath)
     } catch (e: Exception) {
       throw RuntimeException("Unable to read content from jrt:/ file system.", e)
     }
@@ -67,37 +64,8 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
     }
   }
 
-  private fun getOrCreateJrtFileSystem(jdkPath: Path): FileSystem {
-    val javaVersion = System.getProperty("java.version")?.substringBefore(".")?.toIntOrNull()
-    val jrtFsJars = listOf(
-      jdkPath.resolve("lib").resolve("jrt-fs.jar"),
-      jdkPath.resolve("Contents").resolve("Home").resolve("lib").resolve("jrt-fs.jar")
-    )
-    val jrtJar = jrtFsJars.find { it.exists() }
-
-    requireNotNull(jrtJar) { "Invalid JDK. Neither of .jars exist: " + jrtFsJars.joinToString() }
-
-    val classLoader = URLClassLoader(arrayOf(jrtJar.toUri().toURL()))
-
-    return if (javaVersion == null || javaVersion < 17) {
-      try {
-        FileSystems.getFileSystem(JRT_SCHEME_URI)
-      } catch (e: Exception) {
-        try {
-          val fileSystem = FileSystems.newFileSystem(JRT_SCHEME_URI, hashMapOf("java.home" to jdkPath.toString()), classLoader)
-          closeableResources += classLoader
-          fileSystem
-        } catch (e: FileSystemAlreadyExistsException) {
-          classLoader.closeLogged()
-
-          //File system might be already created concurrently. Try to get existing file system again.
-          FileSystems.getFileSystem(JRT_SCHEME_URI)
-        }
-      }
-    }
-    else {
-      FileSystems.newFileSystem(JRT_SCHEME_URI, hashMapOf("java.home" to jdkPath.toString()), classLoader)
-    }
+  private fun getJrtFileSystem(javaHome: Path): FileSystem {
+    return FileSystems.newFileSystem(JRT_SCHEME_URI, mapOf("java.home" to javaHome.toString()))
   }
 
   private fun getModuleName(classPath: Path): String =

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -43,24 +43,25 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
       throw RuntimeException("Unable to read content from jrt:/ file system.", e)
     }
 
-    nameSeparator = fileSystem.separator
+    fileSystem.use {
+      nameSeparator = fileSystem.separator
+      modulesPath = fileSystem.getPath("/modules")
 
-    modulesPath = fileSystem.getPath("/modules")
-
-    classNameToModuleName = Files.walk(modulesPath).use { stream ->
-      stream
-        .filter { p -> p.fileName.toString().endsWith(".class") }
-        .collect(
-          Collectors.toMap(
-            { p -> getClassName(p) },
-            { p -> getModuleName(p) },
-            { one, _ -> one }
+      classNameToModuleName = Files.walk(modulesPath).use { stream ->
+        stream
+          .filter { p -> p.fileName.toString().endsWith(".class") }
+          .collect(
+            Collectors.toMap(
+              { p -> getClassName(p) },
+              { p -> getModuleName(p) },
+              { one, _ -> one }
+            )
           )
-        )
-    }
+      }
 
-    for (className in classNameToModuleName.keys) {
-      packageSet.addPackagesOfClass(className)
+      for (className in classNameToModuleName.keys) {
+        packageSet.addPackagesOfClass(className)
+      }
     }
   }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -4,12 +4,10 @@
 
 package com.jetbrains.pluginverifier.jdk
 
-import com.jetbrains.plugin.structure.base.utils.closeAll
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
 import com.jetbrains.plugin.structure.classes.resolvers.*
 import com.jetbrains.plugin.structure.classes.utils.AsmUtil
 import org.objectweb.asm.tree.ClassNode
-import java.io.Closeable
 import java.net.URI
 import java.nio.file.*
 import java.util.*
@@ -33,8 +31,6 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
   private val nameSeparator: String
 
   private val modulesPath: Path
-
-  private val closeableResources = arrayListOf<Closeable>()
 
   init {
     val fileSystem = try {
@@ -133,6 +129,6 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
   }
 
   override fun close() {
-    closeableResources.closeAll()
+    // no-op
   }
 }


### PR DESCRIPTION
Simplify `jrt://` filesystem handling when reading JDK internals.

Rationale:

- Consolidate different modes of usage to [`newFilesystem`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/FileSystems.html#newFileSystem(java.nio.file.Path,java.util.Map)) call
- Call to `getFilesystem` is not handling a scenario where JDK image has been created from different `JAVA_HOME` than the default one
- Usage of `classloader` is not necessary. This mechanism is used to discover nonstandard URL schemas, but `jrt://` is a default one. In addition, class loader is no longer used as a closeable resource.
- Discovery of Java JDK location (_Java Home_) with `Home/Contents` structure is consolidated into a single place on MacOS.

See [MP-6004](https://youtrack.jetbrains.com/issue/MP-6004)