### PR TITLE
Respect DeprecationLevel.HIDDEN in Kotlin @Deprecated annotation

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationUtil.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationUtil.kt
@@ -52,13 +52,13 @@ private inline fun <reified T : Enum<T>> AnnotationNode.getEnumValue(name: Strin
   val annValue = getAnnotationValue(name)
   // see org.objectweb.asm.tree.AnnotationNode.values semantics
   return if (annValue is Array<*> && annValue.size == 2)  {
-    enumValueOOrNull<T>(annValue[1] as String)
+    enumValueOrNull<T>(annValue[1] as String)
   } else {
     null
   }
 }
 
-private inline fun <reified T : Enum<T>> enumValueOOrNull(name: String): T? {
+private inline fun <reified T : Enum<T>> enumValueOrNull(name: String): T? {
   return try {
     enumValueOf<T>(name)
   } catch (e: IllegalArgumentException) {

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/deprecated/KotlinDeprecatedClass.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/deprecated/KotlinDeprecatedClass.kt
@@ -1,0 +1,16 @@
+package deprecated
+
+/**
+ * A class annotated with `kotlin.Deprecated` annotation instead of JVM `java.lang.Deprecated`.
+ *
+ * The annotation is compiled into class as per
+ * [Java Virtual Machine Specification](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.15).
+ */
+@Deprecated(message = "No longer available in the after-idea")
+class KotlinDeprecatedClass() {
+  @Deprecated(message = "Use the default constructor", level = DeprecationLevel.HIDDEN)
+  @Suppress("unused")
+  constructor(x: Int) : this() {
+    // no-op
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/deprecated/KotlinDeprecatedClass.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/deprecated/KotlinDeprecatedClass.kt
@@ -1,0 +1,8 @@
+package deprecated
+
+class KotlinDeprecatedClass() {
+  @Suppress("unused")
+  constructor(x: Int) : this() {
+    // no-op
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/deprecated/DeprecatedUser.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/deprecated/DeprecatedUser.java
@@ -1,9 +1,6 @@
 package mock.plugin.deprecated;
 
-import deprecated.DeprecatedClass;
-import deprecated.DeprecatedField;
-import deprecated.DeprecatedMethod;
-import deprecated.DeprecatedWithCommentClass;
+import deprecated.*;
 
 public class DeprecatedUser {
   /*expected(DEPRECATED)
@@ -13,6 +10,15 @@ public class DeprecatedUser {
   */
   public void clazz() {
     new DeprecatedClass();
+  }
+
+  /*expected(DEPRECATED)
+  Deprecated class deprecated.KotlinDeprecatedClass reference
+
+  Deprecated class deprecated.KotlinDeprecatedClass is referenced in mock.plugin.deprecated.DeprecatedUser.kotlinClazz() : void
+  */
+  public void kotlinClazz() {
+    new KotlinDeprecatedClass();
   }
 
   /*expected(DEPRECATED)

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/deprecated/DeprecatedUser.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/deprecated/DeprecatedUser.java
@@ -22,6 +22,15 @@ public class DeprecatedUser {
   }
 
   /*expected(DEPRECATED)
+  Deprecated class deprecated.KotlinDeprecatedClass reference
+
+  Deprecated class deprecated.KotlinDeprecatedClass is referenced in mock.plugin.deprecated.DeprecatedUser.kotlinDeprecatedClazzWithHiddenDeprecatedConstructor() : void
+  */
+  public void kotlinDeprecatedClazzWithHiddenDeprecatedConstructor() {
+    new KotlinDeprecatedClass(0);
+  }
+
+  /*expected(DEPRECATED)
   Deprecated class deprecated.DeprecatedWithCommentClass reference
 
   Deprecated class deprecated.DeprecatedWithCommentClass is referenced in mock.plugin.deprecated.DeprecatedUser.clazzWithComment() : void


### PR DESCRIPTION
Respect `DeprecationLevel.HIDDEN` in Kotlin @Deprecated annotation.

Do not treat such usages as deprecations.

Some libraries, e g. KotlinX Serialization, automatically inject such annotations into bytecode to manage internal processing.

The following usage is not considered to be a deprecation reported by the Plugin Verifier.

```
class KotlinDeprecatedClass() {
  @Deprecated(message = "Use the default constructor", level = DeprecationLevel.HIDDEN)
  constructor(x: Int) : this() {
    // no-op
  }
}
```

[See MP-6006](https://youtrack.jetbrains.com/issue/MP-6006) for further details.