### PR TITLE
Clarify `-runtime-dir` switch semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ Here is the full syntax of the command:
 
 * `-runtime-dir (-r)`
 
-    The path to the directory containing Java runtime jar.
-    If not specified, the JDK from 'JAVA_HOME' will be chosen.
+    The path to the directory containing Java runtime JAR files (JDK).
+    If not specified, the embedded JDK from the provided `IDE` parameter will be used.  
+    If the IDE does not contain an embedded JDK, the `JAVA_HOME` environment variable will be used to resolve the Java runtime.
 
 * `-external-prefixes (-ex-prefixes)`
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -106,7 +106,11 @@ object OptionsParser {
   }
 
   fun createIdeDescriptor(idePath: Path, opts: CmdOpts): IdeDescriptor {
-    val defaultJdkPath = opts.runtimeDir?.let { Paths.get(it) }
+    val defaultJdkPath = opts.runtimeDir?.let {
+      Paths.get(it).also {
+        LOG.info("Using Java runtime from $it")
+      }
+    }
     return IdeDescriptor.create(idePath, defaultJdkPath, null)
   }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorProviders.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkDescriptorProviders.kt
@@ -1,0 +1,59 @@
+package com.jetbrains.pluginverifier.jdk
+
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.pluginverifier.jdk.JdkDescriptorProvider.Result.Found
+import com.jetbrains.pluginverifier.jdk.JdkDescriptorProvider.Result.NotFound
+import java.nio.file.Path
+import java.nio.file.Paths
+
+interface JdkDescriptorProvider {
+  fun getJdkDescriptor(ide: Ide, defaultJdkPath: Path?): Result
+
+  sealed class Result {
+    data class Found(val jdkDescriptor: JdkDescriptor) : Result()
+    object NotFound: Result()
+  }
+}
+
+private fun JdkDescriptor?.toResult(): JdkDescriptorProvider.Result {
+  return this?.let { Found(it) } ?: NotFound
+}
+
+class DefaultJdkDescriptorProvider: JdkDescriptorProvider {
+  override fun getJdkDescriptor(ide: Ide, defaultJdkPath: Path?): JdkDescriptorProvider.Result {
+    val jdkDescriptor =
+      fromExplicitPath(defaultJdkPath)
+      ?: fromIdeBundled(ide)
+      ?: fromJavaHome()
+    return jdkDescriptor.toResult()
+  }
+
+  private fun fromIdeBundled(ide: Ide): JdkDescriptor? {
+    return JdkDescriptorCreator.createBundledJdkDescriptor(ide)
+  }
+
+  private fun fromExplicitPath(javaHome: Path?): JdkDescriptor? {
+    return if (javaHome?.isDirectory == true) {
+      JdkDescriptorCreator.createJdkDescriptor(javaHome)
+    } else {
+      null
+    }
+  }
+
+  private fun fromJavaHome(): JdkDescriptor? {
+    val javaHome: Path? = try {
+       System.getenv("JAVA_HOME")
+    } catch (e: SecurityException) {
+      null
+    }?.let {
+      Paths.get(it)
+    }?.takeIf {
+      it.isDirectory
+    }
+
+    return javaHome?.let {
+      JdkDescriptorCreator.createJdkDescriptor(it)
+    }
+  }
+}


### PR DESCRIPTION
The CLI `-runtime-dir` switch is misleading.

Currently, 
```
The path to the directory containing Java runtime jar. If not specified, the JDK from 'JAVA_HOME' will be chosen.
```
However, this is not right and it prevents the non-default JDKs being properly used. In addition, testing plugins against IDEs and separate JDKs is impossible.

## Suggested change

1. Use the `-runtime-dir` as a path to the JDK location (in the same spirit as `JAVA_HOME`). If this is not specified, then:
2. Discover JDK in the embedded IDE. If this is not available, then:
3. Fallback to `JAVA_HOME`.

See [MP-6028](https://youtrack.jetbrains.com/issue/MP-6028)