### PR TITLE
Make telemetry aggregator thread-safe

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/telemetry/TelemetryAggregator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/telemetry/TelemetryAggregator.kt
@@ -3,10 +3,11 @@ package com.jetbrains.pluginverifier.reporting.telemetry
 import com.jetbrains.plugin.structure.base.telemetry.MutablePluginTelemetry
 import com.jetbrains.plugin.structure.base.telemetry.PluginTelemetry
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import java.util.concurrent.ConcurrentHashMap
 
 class TelemetryAggregator {
 
-  private val telemetries: MutableMap<PluginCoordinate, PluginTelemetry> = mutableMapOf()
+  private val telemetries: MutableMap<PluginCoordinate, PluginTelemetry> = ConcurrentHashMap()
 
   fun reportTelemetry(pluginInfo: PluginInfo, telemetry: PluginTelemetry) {
     telemetries.merge(pluginInfo.coordinate, telemetry) { existing, new ->


### PR DESCRIPTION
The `TelemetryAggregator` is used by multiple threads.

Specifically, the `com.jetbrains.pluginverifier.reporting.DirectoryBasedPluginVerificationReportage` is used in multiple threads by the [`runSeveralVerifiers()`](https://github.com/JetBrains/intellij-plugin-verifier/blob/b27974bc34ff2f57db31d72b4a29389accda21fe/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifierRun.kt#L35).

The underlying map has been made thread-safe. Note that the [`merge`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html#merge(K,V,java.util.function.BiFunction)) on the `ConcurrentHashMap` operation is handled atomically.