### PR TITLE
Remove Guava dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@ kotlin = "1.8.21"
 caffeine = "3.1.8"
 commons-io = "2.12.0"
 gson = "2.10.1"
-guava = "31.1-jre"
 jackson-module-kotlin = "2.14.2"
 jetbrains-annotations = "24.0.1"
 jsoup = "1.16.1"
@@ -24,7 +23,6 @@ xz = "1.9"
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
 jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.8.21"
 
+caffeine = "3.1.8"
 commons-io = "2.12.0"
 gson = "2.10.1"
 guava = "31.1-jre"
@@ -20,6 +21,7 @@ spullara-cliParser = "1.1.6"
 xz = "1.9"
 
 [libraries]
+caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
 commons-io = { group = "commons-io", name = "commons-io", version.ref = "commons-io" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }

--- a/intellij-plugin-structure/structure-classes/build.gradle.kts
+++ b/intellij-plugin-structure/structure-classes/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
 
   implementation(project(":structure-base"))
 
-  api(sharedLibs.guava)
+  api(sharedLibs.caffeine)
 }

--- a/intellij-plugin-verifier/verifier-core/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-core/build.gradle.kts
@@ -2,5 +2,5 @@ dependencies {
   val intellijStructureVersion : String by rootProject.extra
   implementation("org.jetbrains.intellij.plugins:structure-classes:$intellijStructureVersion")
 
-  implementation(sharedLibs.guava)
+  implementation(sharedLibs.caffeine)
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.pluginverifier.verifiers.method
 
-import com.google.common.cache.Cache
-import com.google.common.cache.CacheBuilder
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import com.jetbrains.pluginverifier.results.location.MethodLocation
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.Opcodes
@@ -11,7 +11,7 @@ import org.objectweb.asm.tree.MethodInsnNode
 object KotlinMethods {
   private const val CAPACITY = 100L
 
-  private val cache: Cache<MethodLocation, Boolean> = CacheBuilder.newBuilder()
+  private val cache: Cache<MethodLocation, Boolean> = Caffeine.newBuilder()
     .maximumSize(CAPACITY)
     .build()
 

--- a/intellij-plugin-verifier/verifier-repository/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-repository/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
   api("org.jetbrains.intellij.plugins:structure-intellij-classes:$intellijStructureVersion")
   api("org.jetbrains.intellij.plugins:structure-ide:$intellijStructureVersion")
 
-  implementation(sharedLibs.guava)
+  implementation(sharedLibs.caffeine)
   implementation(libs.commons.compress)
   implementation(sharedLibs.xz)
 

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/AndroidStudioIdeRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/AndroidStudioIdeRepository.kt
@@ -5,16 +5,15 @@
 package com.jetbrains.pluginverifier.ide.repositories
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.base.Suppliers
 import com.jetbrains.plugin.structure.ide.IntelliJPlatformProduct
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.ide.AvailableIde
 import com.jetbrains.pluginverifier.misc.RestApiFailed
 import com.jetbrains.pluginverifier.misc.RestApiOk
 import com.jetbrains.pluginverifier.misc.RestApis
+import com.jetbrains.pluginverifier.repository.cache.memoize
 import java.net.URL
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 
 private const val FEED_URL = "https://download.jetbrains.com/toolbox/feeds"
 
@@ -24,7 +23,9 @@ class AndroidStudioIdeRepository(private val feedUrl: String = FEED_URL) : IdeRe
     AndroidStudioFeedConnector(feedUrl)
   }
 
-  private val indexCache = Suppliers.memoizeWithExpiration(this::updateIndex, 5, TimeUnit.MINUTES)
+  private val indexCache = memoize {
+    updateIndex()
+  }
 
   private fun updateIndex(): List<AvailableIde> {
     val feedEntries = feedConnector.getFeed()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/IntelliJIdeRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/IntelliJIdeRepository.kt
@@ -5,16 +5,15 @@
 package com.jetbrains.pluginverifier.ide.repositories
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.base.Suppliers
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
 import com.jetbrains.pluginverifier.ide.AvailableIde
 import com.jetbrains.pluginverifier.ide.IntelliJRepositoryIndexParser
 import com.jetbrains.pluginverifier.misc.RestApiFailed
 import com.jetbrains.pluginverifier.misc.RestApiOk
 import com.jetbrains.pluginverifier.misc.RestApis
+import com.jetbrains.pluginverifier.repository.cache.memoize
 import java.io.IOException
-import java.util.Locale
-import java.util.concurrent.TimeUnit
+import java.util.*
 
 /**
  * Provides index of IDE builds available for downloading,
@@ -60,7 +59,7 @@ open class IntelliJIdeRepository(private val channel: Channel) : IdeRepository {
     RepositoryIndexConnector(indexBaseUrl)
   }
 
-  private val indexCache = Suppliers.memoizeWithExpiration<List<AvailableIde>>(this::updateIndex, 1, TimeUnit.MINUTES)
+  private val indexCache = memoize(expirationInMinutes = 1) { updateIndex() }
 
   private fun updateIndex(): List<AvailableIde> {
     try {

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/ReleaseIdeRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/repositories/ReleaseIdeRepository.kt
@@ -5,13 +5,12 @@
 package com.jetbrains.pluginverifier.ide.repositories
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.base.Suppliers
 import com.jetbrains.pluginverifier.ide.AvailableIde
 import com.jetbrains.pluginverifier.ide.DataServicesIndexParser
 import com.jetbrains.pluginverifier.misc.RestApiFailed
 import com.jetbrains.pluginverifier.misc.RestApiOk
 import com.jetbrains.pluginverifier.misc.RestApis
-import java.util.concurrent.TimeUnit
+import com.jetbrains.pluginverifier.repository.cache.memoize
 
 private const val DATA_SERVICES_URL = "https://data.services.jetbrains.com"
 
@@ -24,7 +23,7 @@ class ReleaseIdeRepository(private val dataServicesUrl: String = DATA_SERVICES_U
     DataServicesConnector(dataServicesUrl)
   }
 
-  private val indexCache = Suppliers.memoizeWithExpiration<List<AvailableIde>>(this::updateIndex, 5, TimeUnit.MINUTES)
+  private val indexCache = memoize { updateIndex() }
 
   private fun updateIndex(): List<AvailableIde> {
     val products = dataServicesConnector.getProducts()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlBuilder.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlBuilder.kt
@@ -4,7 +4,6 @@
 
 package com.jetbrains.pluginverifier.misc
 
-import com.google.common.html.HtmlEscapers
 import java.io.PrintWriter
 
 class HtmlBuilder(val output: PrintWriter) {
@@ -140,7 +139,7 @@ class HtmlBuilder(val output: PrintWriter) {
   fun style(type: String = "", block: () -> Unit) = tag("style", block, mapOf("type" to type))
 
   operator fun String.unaryPlus() {
-    output.append(HtmlEscapers.htmlEscaper().escape(this))
+    output.append(this.escapeHtml4())
   }
 
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlEscaper.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlEscaper.kt
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2000-2023 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.misc
+
+import java.io.IOException
+import java.io.StringWriter
+import java.io.Writer
+import java.lang.Character.*
+import java.util.*
+
+/**
+ * HTML 4.0 String escaper.
+ *
+ * Code from Apache `commons-text`, adjusted for Kotlin and simplified.
+ */
+class HtmlEscaper {
+    /** The mapping to be used in translation.  */
+    private val lookupMap = mutableMapOf<CharSequence, CharSequence>()
+
+    /** The first character of each key in the lookupMap.  */
+    private val prefixSet = BitSet()
+
+    /** The length of the shortest key in the lookupMap.  */
+    private val shortest: Int
+
+    /** The length of the longest key in the lookupMap.  */
+    private val longest: Int
+
+    init {
+        var currentShortest = Int.MAX_VALUE
+        var currentLongest = 0
+        for ((key, value) in escapeLookup) {
+            this.lookupMap[key.toString()] = value.toString()
+            prefixSet.set(key[0].code)
+            val sz = key.length
+            if (sz < currentShortest) {
+                currentShortest = sz
+            }
+            if (sz > currentLongest) {
+                currentLongest = sz
+            }
+        }
+        shortest = currentShortest
+        longest = currentLongest
+    }
+
+    fun escape(input: CharSequence): String {
+        return StringWriter(input.length * 2).run {
+            escape(input, this)
+            this.toString()
+        }
+    }
+
+
+    @Throws(IOException::class)
+    private fun escape(input: CharSequence, index: Int, writer: Writer): Int {
+        // check if translation exists for the input at position index
+        if (!prefixSet[input[index].code]) return 0
+
+        var max = longest
+        if (index + longest > input.length) {
+            max = input.length - index
+        }
+        // implement greedy algorithm by trying maximum match first
+        for (i in max downTo shortest) {
+            val subSeq = input.subSequence(index, index + i)
+            val result = lookupMap[subSeq.toString()]
+            if (result != null) {
+                writer.write(result.toString())
+                return Character.codePointCount(subSeq, 0, subSeq.length)
+            }
+        }
+        return 0
+    }
+
+    @Throws(IOException::class)
+    private fun escape(input: CharSequence, writer: Writer) {
+        var pos = 0
+        val len = input.length
+        while (pos < len) {
+            val consumed = escape(input, pos, writer)
+            if (consumed == 0) {
+                // inlined implementation of Character.toChars(Character.codePointAt(input, pos))
+                // avoids allocating temp char arrays and duplicate checks
+                val c1 = input[pos]
+                writer.write(c1.code)
+                pos++
+                if (isHighSurrogate(c1) && pos < len) {
+                    val c2 = input[pos]
+                    if (isLowSurrogate(c2)) {
+                        writer.write(c2.code)
+                        pos++
+                    }
+                }
+                continue
+            }
+            // contract with translators is that they have to understand code points
+            // and they just took care of a surrogate pair
+            repeat(consumed) {
+                pos += charCount(codePointAt(input, pos))
+            }
+        }
+    }
+}
+
+private val escapeLookup: Map<CharSequence, CharSequence> = mapOf(
+  "\u00A0" to "&nbsp;",
+  "\u00A1" to "&iexcl;",
+  "\u00A2" to "&cent;",
+  "\u00A3" to "&pound;",
+  "\u00A4" to "&curren;",
+  "\u00A5" to "&yen;",
+  "\u00A6" to "&brvbar;",
+  "\u00A7" to "&sect;",
+  "\u00A8" to "&uml;",
+  "\u00A9" to "&copy;",
+  "\u00AA" to "&ordf;",
+  "\u00AB" to "&laquo;",
+  "\u00AC" to "&not;",
+  "\u00AD" to "&shy;",
+  "\u00AE" to "&reg;",
+  "\u00AF" to "&macr;",
+  "\u00B0" to "&deg;",
+  "\u00B1" to "&plusmn;",
+  "\u00B2" to "&sup2;",
+  "\u00B3" to "&sup3;",
+  "\u00B4" to "&acute;",
+  "\u00B5" to "&micro;",
+  "\u00B6" to "&para;",
+  "\u00B7" to "&middot;",
+  "\u00B8" to "&cedil;",
+  "\u00B9" to "&sup1;",
+  "\u00BA" to "&ordm;",
+  "\u00BB" to "&raquo;",
+  "\u00BC" to "&frac14;",
+  "\u00BD" to "&frac12;",
+  "\u00BE" to "&frac34;",
+  "\u00BF" to "&iquest;",
+  "\u00C0" to "&Agrave;",
+  "\u00C1" to "&Aacute;",
+  "\u00C2" to "&Acirc;",
+  "\u00C3" to "&Atilde;",
+  "\u00C4" to "&Auml;",
+  "\u00C5" to "&Aring;",
+  "\u00C6" to "&AElig;",
+  "\u00C7" to "&Ccedil;",
+  "\u00C8" to "&Egrave;",
+  "\u00C9" to "&Eacute;",
+  "\u00CA" to "&Ecirc;",
+  "\u00CB" to "&Euml;",
+  "\u00CC" to "&Igrave;",
+  "\u00CD" to "&Iacute;",
+  "\u00CE" to "&Icirc;",
+  "\u00CF" to "&Iuml;",
+  "\u00D0" to "&ETH;",
+  "\u00D1" to "&Ntilde;",
+  "\u00D2" to "&Ograve;",
+  "\u00D3" to "&Oacute;",
+  "\u00D4" to "&Ocirc;",
+  "\u00D5" to "&Otilde;",
+  "\u00D6" to "&Ouml;",
+  "\u00D7" to "&times;",
+  "\u00D8" to "&Oslash;",
+  "\u00D9" to "&Ugrave;",
+  "\u00DA" to "&Uacute;",
+  "\u00DB" to "&Ucirc;",
+  "\u00DC" to "&Uuml;",
+  "\u00DD" to "&Yacute;",
+  "\u00DE" to "&THORN;",
+  "\u00DF" to "&szlig;",
+  "\u00E0" to "&agrave;",
+  "\u00E1" to "&aacute;",
+  "\u00E2" to "&acirc;",
+  "\u00E3" to "&atilde;",
+  "\u00E4" to "&auml;",
+  "\u00E5" to "&aring;",
+  "\u00E6" to "&aelig;",
+  "\u00E7" to "&ccedil;",
+  "\u00E8" to "&egrave;",
+  "\u00E9" to "&eacute;",
+  "\u00EA" to "&ecirc;",
+  "\u00EB" to "&euml;",
+  "\u00EC" to "&igrave;",
+  "\u00ED" to "&iacute;",
+  "\u00EE" to "&icirc;",
+  "\u00EF" to "&iuml;",
+  "\u00F0" to "&eth;",
+  "\u00F1" to "&ntilde;",
+  "\u00F2" to "&ograve;",
+  "\u00F3" to "&oacute;",
+  "\u00F4" to "&ocirc;",
+  "\u00F5" to "&otilde;",
+  "\u00F6" to "&ouml;",
+  "\u00F7" to "&divide;",
+  "\u00F8" to "&oslash;",
+  "\u00F9" to "&ugrave;",
+  "\u00FA" to "&uacute;",
+  "\u00FB" to "&ucirc;",
+  "\u00FC" to "&uuml;",
+  "\u00FD" to "&yacute;",
+  "\u00FE" to "&thorn;",
+  "\u00FF" to "&yuml;",
+  // HTML 4.0 Extended
+  "\u0192" to "&fnof;",
+  "\u0391" to "&Alpha;",
+  "\u0392" to "&Beta;",
+  "\u0393" to "&Gamma;",
+  "\u0394" to "&Delta;",
+  "\u0395" to "&Epsilon;",
+  "\u0396" to "&Zeta;",
+  "\u0397" to "&Eta;",
+  "\u0398" to "&Theta;",
+  "\u0399" to "&Iota;",
+  "\u039A" to "&Kappa;",
+  "\u039B" to "&Lambda;",
+  "\u039C" to "&Mu;",
+  "\u039D" to "&Nu;",
+  "\u039E" to "&Xi;",
+  "\u039F" to "&Omicron;",
+  "\u03A0" to "&Pi;",
+  "\u03A1" to "&Rho;",
+  "\u03A3" to "&Sigma;",
+  "\u03A4" to "&Tau;",
+  "\u03A5" to "&Upsilon;",
+  "\u03A6" to "&Phi;",
+  "\u03A7" to "&Chi;",
+  "\u03A8" to "&Psi;",
+  "\u03A9" to "&Omega;",
+  "\u03B1" to "&alpha;",
+  "\u03B2" to "&beta;",
+  "\u03B3" to "&gamma;",
+  "\u03B4" to "&delta;",
+  "\u03B5" to "&epsilon;",
+  "\u03B6" to "&zeta;",
+  "\u03B7" to "&eta;",
+  "\u03B8" to "&theta;",
+  "\u03B9" to "&iota;",
+  "\u03BA" to "&kappa;",
+  "\u03BB" to "&lambda;",
+  "\u03BC" to "&mu;",
+  "\u03BD" to "&nu;",
+  "\u03BE" to "&xi;",
+  "\u03BF" to "&omicron;",
+  "\u03C0" to "&pi;",
+  "\u03C1" to "&rho;",
+  "\u03C2" to "&sigmaf;",
+  "\u03C3" to "&sigma;",
+  "\u03C4" to "&tau;",
+  "\u03C5" to "&upsilon;",
+  "\u03C6" to "&phi;",
+  "\u03C7" to "&chi;",
+  "\u03C8" to "&psi;",
+  "\u03C9" to "&omega;",
+  "\u03D1" to "&thetasym;",
+  "\u03D2" to "&upsih;",
+  "\u03D6" to "&piv;",
+  "\u2022" to "&bull;",
+  "\u2026" to "&hellip;",
+  "\u2032" to "&prime;",
+  "\u2033" to "&Prime;",
+  "\u203E" to "&oline;",
+  "\u2044" to "&frasl;",
+  "\u2118" to "&weierp;",
+  "\u2111" to "&image;",
+  "\u211C" to "&real;",
+  "\u2122" to "&trade;",
+  "\u2135" to "&alefsym;",
+  "\u2190" to "&larr;",
+  "\u2191" to "&uarr;",
+  "\u2192" to "&rarr;",
+  "\u2193" to "&darr;",
+  "\u2194" to "&harr;",
+  "\u21B5" to "&crarr;",
+  "\u21D0" to "&lArr;",
+  "\u21D1" to "&uArr;",
+  "\u21D2" to "&rArr;",
+  "\u21D3" to "&dArr;",
+  "\u21D4" to "&hArr;",
+  "\u2200" to "&forall;",
+  "\u2202" to "&part;",
+  "\u2203" to "&exist;",
+  "\u2205" to "&empty;",
+  "\u2207" to "&nabla;",
+  "\u2208" to "&isin;",
+  "\u2209" to "&notin;",
+  "\u220B" to "&ni;",
+  "\u220F" to "&prod;",
+  "\u2211" to "&sum;",
+  "\u2212" to "&minus;",
+  "\u2217" to "&lowast;",
+  "\u221A" to "&radic;",
+  "\u221D" to "&prop;",
+  "\u221E" to "&infin;",
+  "\u2220" to "&ang;",
+  "\u2227" to "&and;",
+  "\u2228" to "&or;",
+  "\u2229" to "&cap;",
+  "\u222A" to "&cup;",
+  "\u222B" to "&int;",
+  "\u2234" to "&there4;",
+  "\u223C" to "&sim;",
+  "\u2245" to "&cong;",
+  "\u2248" to "&asymp;",
+  "\u2260" to "&ne;",
+  "\u2261" to "&equiv;",
+  "\u2264" to "&le;",
+  "\u2265" to "&ge;",
+  "\u2282" to "&sub;",
+  "\u2283" to "&sup;",
+  "\u2284" to "&nsub;",
+  "\u2286" to "&sube;",
+  "\u2287" to "&supe;",
+  "\u2295" to "&oplus;",
+  "\u2297" to "&otimes;",
+  "\u22A5" to "&perp;",
+  "\u22C5" to "&sdot;",
+  "\u2308" to "&lceil;",
+  "\u2309" to "&rceil;",
+  "\u230A" to "&lfloor;",
+  "\u230B" to "&rfloor;",
+  "\u2329" to "&lang;",
+  "\u232A" to "&rang;",
+  "\u25CA" to "&loz;",
+  "\u2660" to "&spades;",
+  "\u2663" to "&clubs;",
+  "\u2665" to "&hearts;",
+  "\u2666" to "&diams;",
+  "\u0152" to "&OElig;",
+  "\u0153" to "&oelig;",
+  "\u0160" to "&Scaron;",
+  "\u0161" to "&scaron;",
+  "\u0178" to "&Yuml;",
+  "\u02C6" to "&circ;",
+  "\u02DC" to "&tilde;",
+  "\u2002" to "&ensp;",
+  "\u2003" to "&emsp;",
+  "\u2009" to "&thinsp;",
+  "\u200C" to "&zwnj;",
+  "\u200D" to "&zwj;",
+  "\u200E" to "&lrm;",
+  "\u200F" to "&rlm;",
+  "\u2013" to "&ndash;",
+  "\u2014" to "&mdash;",
+  "\u2018" to "&lsquo;",
+  "\u2019" to "&rsquo;",
+  "\u201A" to "&sbquo;",
+  "\u201C" to "&ldquo;",
+  "\u201D" to "&rdquo;",
+  "\u201E" to "&bdquo;",
+  "\u2020" to "&dagger;",
+  "\u2021" to "&Dagger;",
+  "\u2030" to "&permil;",
+  "\u2039" to "&lsaquo;",
+  "\u203A" to "&rsaquo;",
+  "\u20AC" to "&euro;",
+  // basic escapes
+  "\"" to "&quot;",
+  "&" to "&amp;",
+  "<" to "&lt;",
+  ">" to "&gt;"
+)
+
+fun String.escapeHtml4(): String {
+    return HtmlEscaper().escape(this)
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlEscaper.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/HtmlEscaper.kt
@@ -69,7 +69,7 @@ class HtmlEscaper {
             val result = lookupMap[subSeq.toString()]
             if (result != null) {
                 writer.write(result.toString())
-                return Character.codePointCount(subSeq, 0, subSeq.length)
+                return codePointCount(subSeq, 0, subSeq.length)
             }
         }
         return 0

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/RestApis.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/misc/RestApis.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.type.CollectionType
 import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.jetbrains.pluginverifier.network.threadFactory
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
 import org.bouncycastle.cms.CMSSignedData
 import java.net.URI
@@ -17,10 +17,7 @@ import java.util.concurrent.Executors
 fun createHttpClient(timeout: Duration = Duration.ofMinutes(5)): HttpClient {
   return HttpClient.newBuilder().connectTimeout(timeout)
           .executor(Executors.newCachedThreadPool(
-                  ThreadFactoryBuilder()
-                          .setNameFormat("plugin-verifier-http-%d")
-                          .setDaemon(true)
-                          .build()
+            threadFactory("plugin-verifier-http-%d", daemon = true)
           ))
           .followRedirects(HttpClient.Redirect.NORMAL)
           .build()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/network/ThreadFactories.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/network/ThreadFactories.kt
@@ -1,0 +1,14 @@
+package com.jetbrains.pluginverifier.network
+
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+fun threadFactory(nameFormat: String? = null, daemon: Boolean = false): ThreadFactory {
+  val count = AtomicInteger()
+  return ThreadFactory { r ->
+    Thread(r).apply {
+      nameFormat?.apply { name = nameFormat.format(count.getAndIncrement()) }
+      isDaemon = daemon
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/Memoizer.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/Memoizer.kt
@@ -1,0 +1,14 @@
+package com.jetbrains.pluginverifier.repository.cache
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
+
+fun <T> memoize(expirationInMinutes: Long = 5, delegateSupplier: () -> T): Supplier<T> = Caffeine.newBuilder()
+  .expireAfterWrite(expirationInMinutes, TimeUnit.MINUTES)
+  .build<Unit, T> {
+    delegateSupplier()
+  }
+  .let { cache ->
+    Supplier { cache.get(Unit) }
+  }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/custom/CustomPluginRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/custom/CustomPluginRepository.kt
@@ -4,20 +4,19 @@
 
 package com.jetbrains.pluginverifier.repository.repositories.custom
 
-import com.google.common.base.Suppliers
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.cache.memoize
 import com.jetbrains.pluginverifier.repository.repositories.VERSION_COMPARATOR
 import java.net.URL
-import java.util.concurrent.TimeUnit
 
 /**
  * Base class for all repositories configured for special plugins not available in JetBrains Marketplace.
  */
 abstract class CustomPluginRepository : PluginRepository {
 
-  private val allPluginsCache = Suppliers.memoizeWithExpiration({ requestAllPlugins() }, 1, TimeUnit.MINUTES)
+  private val allPluginsCache = memoize(expirationInMinutes = 1) { requestAllPlugins() }
 
   protected abstract fun requestAllPlugins(): List<CustomPluginInfo>
 


### PR DESCRIPTION
Remove Guava dependency.

This will remove ~2MB from the CLI JAR file size.

- Use [Caffeine](https://github.com/ben-manes/caffeine) instead of Guava Caching
- Use custom HTML4.0 escaping implementation, taken and simplified from [`commons-text`](https://commons.apache.org/proper/commons-text/)
- Use custom implementation of `ThreadFactoryBuilder` instead of Guava