### PR TITLE
Deprecate Plugin Verifier Service

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,10 +67,6 @@ updates:
     ignore:
       - dependency-name: "structure-*"
   - package-ecosystem: "gradle"
-    directory: "/plugins-verifier-service/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gradle"
     directory: "/ide-diff-builder/mock-old-ide/"
     schedule:
       interval: "daily"

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -1,18 +1,22 @@
 #### Git repository content
 
-This GitHub [repository](https://github.com/JetBrains/intellij-plugin-verifier/) holds 4 projects:
+This GitHub [repository](https://github.com/JetBrains/intellij-plugin-verifier/) holds the following active projects:
 1) [intellij-plugin-structure](intellij-plugin-structure) - API for working with the IntelliJ Plugins and IntelliJ IDEs:
    reading the plugins' descriptors (_plugin.xml_ files), reading class files, verifying the plugins' structures.
 
 2) [intellij-plugin-verifier](intellij-plugin-verifier) - a bytecode verification library used to verify the API binary compatibility of IntelliJ plugins and IDE builds.
 
 3) [intellij-feature-extractor](intellij-feature-extractor) - a library used to extract the plugins' additional features, such as supported file extensions, configuration types etc.
+4) [ide-diff-builder](ide-diff-builder) - module that evaluates API difference between IDE releases and builds external annotations `@ApiStatus.AvailableSince` and `@ApiStatus.ScheduledForRemoval`.
 
-4) [plugins-verifier-service](plugins-verifier-service) (`plugins-verifier-service/README.md`) - an HTTP server responsible for:
+Deprecated projects:
+
+4) [plugins-verifier-service](plugins-verifier-service) (`plugins-verifier-service/README.md`). This project has been superseded by another implementation.
+
+    Originally, this was an HTTP server responsible for:
    * Running the _intellij-plugin-verifier_ tool for plugins from the JetBrains Plugin Repository against a set of predefined IDEs and sending the verification results for storage to the repository.
    * Running the _intellij-feature-extractor_ for plugins and sending the extracted features to the repository.
 
-5) [ide-diff-builder](ide-diff-builder) - module that evaluates API difference between IDE releases and builds external annotations `@ApiStatus.AvailableSince` and `@ApiStatus.ScheduledForRemoval`.
 
 #### Dependencies between the projects
 
@@ -25,9 +29,6 @@ The dependencies between the above projects are as follows:
 - `intellij-feature-extractor` -- depends on the:
   * `intellij-plugin-verifier` (module `verifier-core`)
   * `intellij-plugin-structure` (modules `structure-intellij-classes` and `structure-ide-classes`)
-- `plugins-verifier-service` -- composite build dependency on:
-  * `intellij-feature-extractor`,
-  * `intellij-plugin-verifier` (module `verifier-intellij`)
 
 ```mermaid
 ---
@@ -35,12 +36,17 @@ title: Project Dependencies
 ---
 classDiagram
    class IdeDiffBuilder
-   PluginsVerifierService ..> IntellijFeatureExtractor: depends
-   PluginsVerifierService ..> IntellijPluginVerifier: depends on\nverifier-intellij
    IntellijPluginVerifier ..> IntellijPluginStructure: depends on\nstructure-intellij
    IntellijFeatureExtractor ..> IntellijPluginVerifier: depends on\nverifier-core
    IntellijFeatureExtractor ..> IntellijPluginStructure: depends on\nstructure-intellij-classes,\nstructure-ide-classes
 ```
+
+Deprecated projects dependencies:
+
+- `plugins-verifier-service` -- composite build dependency on:
+  * `intellij-feature-extractor`,
+  * `intellij-plugin-verifier` (module `verifier-intellij`)
+
 
 #### Configuring the local environment
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -11,7 +11,10 @@ This GitHub [repository](https://github.com/JetBrains/intellij-plugin-verifier/)
 
 Deprecated projects:
 
-4) [plugins-verifier-service](plugins-verifier-service) (`plugins-verifier-service/README.md`). This project has been superseded by another implementation.
+4) [plugins-verifier-service](plugins-verifier-service) (`plugins-verifier-service/README.md`). 
+This project has been superseded by another implementation.
+The only used feature is `org.jetbrains.plugins.verifier.service.service.features.FeatureExtractorService`
+referenced by JetBrains Marketplace project.
 
     Originally, this was an HTTP server responsible for:
    * Running the _intellij-plugin-verifier_ tool for plugins from the JetBrains Plugin Repository against a set of predefined IDEs and sending the verification results for storage to the repository.

--- a/intellij-plugin-verifier/README.md
+++ b/intellij-plugin-verifier/README.md
@@ -27,7 +27,6 @@ Plugin Verifier accepts as its input a plugin `P` and an IDE build `X` to check 
      - `non-extendable-api-usages.txt`
      - `plugin-structure-warnings.txt`
    - displayed as TeamCity failed tests (`TeamCityResultPrinter`)
-   - converted to JSON and sent to [JetBrains Marketplace](https://plugins.jetbrains.com/) by the Plugin Verifier Service
 
 #### How to verify plugin locally
 

--- a/plugins-verifier-service/README.md
+++ b/plugins-verifier-service/README.md
@@ -1,4 +1,12 @@
 ## Plugin Verifier Service
+
+## Deprecation Notice
+
+The _Plugin Verifier Service_ is deprecated and no longer under active development.
+
+It has been replaced by a different implementation.
+
+## About Project
 Service used to off-load heavy verification tasks from [JetBrains Marketplace](https://plugins.jetbrains.com/):
 - verify newly uploaded plugins against IDE builds using the *IntelliJ Plugin Verifier* tool (see `/intellij-plugin-verifier`)
 - extract supported plugin features using the *IntelliJ Feature Extractor* tool (see `/intellij-feature-extractor`)

--- a/plugins-verifier-service/README.md
+++ b/plugins-verifier-service/README.md
@@ -4,7 +4,7 @@
 
 The _Plugin Verifier Service_ is deprecated and no longer under active development.
 
-It has been replaced by a different implementation.
+It has been replaced by a different implementation, except a single usage of `FeatureExtractorService`.
 
 ## About Project
 Service used to off-load heavy verification tasks from [JetBrains Marketplace](https://plugins.jetbrains.com/):


### PR DESCRIPTION
_Plugin Verifier Service_ has been replaced by a different implementation.

- Mark references in READMEs as deprecated
- Remove Dependabot monitoring