### PR TITLE
Enable ignoring of specific plugin problems

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -727,13 +727,9 @@ internal class PluginCreator private constructor(
   }
 
   private fun hasErrors(): Boolean {
-    return problems
-      .map {
-        problemResolver.classify(plugin, it)
-      }
-      .any {
-        it.level === ERROR
-      }
+    return problemResolver.classify(plugin, problems).any {
+      it.level == ERROR
+    }
   }
 
   private fun validateId(plugin: PluginBean) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
@@ -9,11 +9,11 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import kotlin.reflect.KClass
 
 class LevelRemappingPluginCreationResultResolver(private val delegatedResolver: PluginCreationResultResolver,
-                                                 additionalLevelRemapping: Map<KClass<*>, PluginProblem.Level> = emptyMap()
+                                                 additionalLevelRemapping: Map<KClass<*>, RemappedLevel> = emptyMap()
   ) : PluginCreationResultResolver {
 
-  private val remappedLevel: Map<KClass<*>, PluginProblem.Level> = additionalLevelRemapping +
-    mapOf(ForbiddenPluginIdPrefix::class to PluginProblem.Level.WARNING)
+  private val remappedLevel: Map<KClass<*>, RemappedLevel> = additionalLevelRemapping +
+    warning<ForbiddenPluginIdPrefix>()
 
   override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
     return when (val pluginCreationResult = delegatedResolver.resolve(plugin, problems)) {
@@ -40,27 +40,29 @@ class LevelRemappingPluginCreationResultResolver(private val delegatedResolver: 
   }
 
   private fun remapWarnings(warnings: List<PluginProblem>): List<PluginProblem> {
-    return warnings.map(::remapPluginProblemLevel)
+    return warnings.mapNotNull(::remapPluginProblemLevel)
   }
 
   private fun remapUnacceptableWarnings(unacceptableWarnings: List<PluginProblem>): List<PluginProblem> {
-    return unacceptableWarnings.map(::remapPluginProblemLevel)
+    return unacceptableWarnings.mapNotNull(::remapPluginProblemLevel)
   }
 
   private fun remapErrorsAndWarnings(errorsAndWarnings: List<PluginProblem>): List<PluginProblem> {
-    return errorsAndWarnings.map(::remapPluginProblemLevel)
+    return errorsAndWarnings.mapNotNull(::remapPluginProblemLevel)
   }
 
-  private fun remapPluginProblemLevel(pluginProblem: PluginProblem): PluginProblem {
-    val remappedLevel = remappedLevel[pluginProblem::class]
-    if (remappedLevel != null) {
-      return ReclassifiedPluginProblem(remappedLevel, pluginProblem)
+  private fun remapPluginProblemLevel(pluginProblem: PluginProblem): PluginProblem?{
+    return when (val remappedLevel = remappedLevel[pluginProblem::class]) {
+      is StandardLevel -> ReclassifiedPluginProblem(remappedLevel.originalLevel, pluginProblem)
+      is IgnoredLevel -> null
+      null -> pluginProblem
     }
-    return pluginProblem
   }
 
-  override fun classify(plugin: IdePlugin, problem: PluginProblem): PluginProblem {
-    return remapPluginProblemLevel(problem)
+  override fun classify(plugin: IdePlugin, problems: List<PluginProblem>): List<PluginProblem> {
+    return problems.mapNotNull {
+      remapPluginProblemLevel(it)
+    }
   }
 
   private fun List<PluginProblem>.hasNoErrors(): Boolean = none {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
@@ -12,8 +12,7 @@ class LevelRemappingPluginCreationResultResolver(private val delegatedResolver: 
                                                  additionalLevelRemapping: Map<KClass<*>, RemappedLevel> = emptyMap()
   ) : PluginCreationResultResolver {
 
-  private val remappedLevel: Map<KClass<*>, RemappedLevel> = additionalLevelRemapping +
-    warning<ForbiddenPluginIdPrefix>()
+  private val remappedLevel: Map<KClass<*>, RemappedLevel> = additionalLevelRemapping
 
   override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
     return when (val pluginCreationResult = delegatedResolver.resolve(plugin, problems)) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -3,9 +3,8 @@ package com.jetbrains.plugin.structure.intellij.problems
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.base.problems.*
+import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 
 /**
@@ -24,6 +23,14 @@ interface PluginCreationResultResolver {
    * Typically, this is used to change a [PluginProblem.Level] in specific scenarios.
    */
   fun classify(plugin: IdePlugin, problem: PluginProblem): PluginProblem = problem
+
+  /**
+   * Allows remapping a specific collection of plugin problems to another collection of plugin problems.
+   * Typically, this is used to change a [PluginProblem.Level] in specific scenarios.
+   *
+   * Note that the result collection might be smaller than the original collection due to ignored problems.
+   */
+  fun classify(plugin: IdePlugin, problems: List<PluginProblem>): List<PluginProblem> = problems
 }
 
 /**

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -19,12 +19,6 @@ interface PluginCreationResultResolver {
   fun isError(problem: PluginProblem): Boolean = problem.level == ERROR
 
   /**
-   * Allows remapping a specific plugin problem to another problem.
-   * Typically, this is used to change a [PluginProblem.Level] in specific scenarios.
-   */
-  fun classify(plugin: IdePlugin, problem: PluginProblem): PluginProblem = problem
-
-  /**
    * Allows remapping a specific collection of plugin problems to another collection of plugin problems.
    * Typically, this is used to change a [PluginProblem.Level] in specific scenarios.
    *

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
@@ -1,0 +1,21 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import kotlin.reflect.KClass
+
+sealed class RemappedLevel
+
+object IgnoredLevel : RemappedLevel()
+class StandardLevel(val originalLevel: PluginProblem.Level) : RemappedLevel()
+
+inline fun <reified T : PluginProblem> unacceptableWarning(): Map<KClass<*>, RemappedLevel> {
+  return mapOf(T::class to StandardLevel(PluginProblem.Level.UNACCEPTABLE_WARNING))
+}
+
+inline fun <reified T : PluginProblem> warning(): Map<KClass<*>, RemappedLevel> {
+  return mapOf(T::class to StandardLevel(PluginProblem.Level.WARNING))
+}
+
+inline fun <reified T : PluginProblem> ignore(): Map<KClass<*>, RemappedLevel> {
+  return mapOf(T::class to IgnoredLevel)
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KClass
 sealed class RemappedLevel
 
 object IgnoredLevel : RemappedLevel()
-class StandardLevel(val originalLevel: PluginProblem.Level) : RemappedLevel()
+data class StandardLevel(val originalLevel: PluginProblem.Level) : RemappedLevel()
 
 inline fun <reified T : PluginProblem> unacceptableWarning(): Map<KClass<*>, RemappedLevel> {
   return mapOf(T::class to StandardLevel(PluginProblem.Level.UNACCEPTABLE_WARNING))

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -5,14 +5,17 @@ import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.problems.*
 import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.slf4j.LoggerFactory
+
 
 class ExistingPluginValidationTest : BasePluginTest() {
   @Test
@@ -74,9 +77,10 @@ class ExistingPluginValidationTest : BasePluginTest() {
     val erroneousSinceBuild = "1.*"
     val header = ideaPlugin("com.example", sinceBuild = erroneousSinceBuild)
     val delegateResolver = IntelliJPluginCreationResultResolver()
+
     val problemResolver = LevelRemappingPluginCreationResultResolver(
       delegateResolver,
-      additionalLevelRemapping = mapOf(InvalidSinceBuild::class to PluginProblem.Level.WARNING))
+      additionalLevelRemapping = warning<InvalidSinceBuild>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -102,6 +106,33 @@ class ExistingPluginValidationTest : BasePluginTest() {
     assertThat("Reclassified problems contains an 'InvalidSinceBuild' plugin problem ", reclassifiedProblems.find { InvalidSinceBuild::class.isInstance(it) } != null)
   }
 
+  @Test
+  fun `plugin is built with forbidden word in plugin id but such problem is ignored`() {
+    val header = ideaPlugin("com.vendor.qodana.plugin")
+
+    val remappingProblemResolver = LevelRemappingPluginCreationResultResolver(
+      IntelliJPluginCreationResultResolver(),
+      additionalLevelRemapping = ignore<TemplateWordInPluginId>())
+
+    val result = buildPluginWithResult(remappingProblemResolver, pluginOf(header))
+    assertThat("Plugin Creation Result must succeed", result, instanceOf(PluginCreationSuccess::class.java))
+    val pluginCreated = result as PluginCreationSuccess
+    assertThat(pluginCreated.warnings, `is`(emptyList()))
+  }
+
+  @Test
+  fun `plugin is built with forbidden word in plugin id`() {
+    val header = ideaPlugin("com.vendor.qodana.plugin")
+
+    val problemResolver = IntelliJPluginCreationResultResolver()
+    val result = buildPluginWithResult(problemResolver, pluginOf(header))
+    assertThat("Plugin Creation Result must succeed", result, instanceOf(PluginCreationSuccess::class.java))
+    val pluginCreated = result as PluginCreationSuccess
+    assertEquals(1, pluginCreated.warnings.size)
+
+    val warning = pluginCreated.warnings.first()
+    assertThat(warning, instanceOf(TemplateWordInPluginId::class.java))
+  }
 
   @Test
   fun `plugin is not built due to two different plugin problems with 'error' severity but one level is remapped`() {
@@ -110,7 +141,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
     val header = ideaPlugin("plugin.with.two.problems", sinceBuild = erroneousSinceBuild, untilBuild = erroneousUntilBuild)
     val delegateResolver = IntelliJPluginCreationResultResolver()
     val problemResolver = LevelRemappingPluginCreationResultResolver(delegateResolver,
-      additionalLevelRemapping = mapOf(InvalidSinceBuild::class to PluginProblem.Level.WARNING))
+      additionalLevelRemapping = warning<InvalidSinceBuild>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -144,7 +175,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
       description = "<![CDATA[A failing plugin with HTTP link leading to <a href='http://jetbrains.com'>JetBrains</a>]]>")
 
     val problemResolver = LevelRemappingPluginCreationResultResolver(IntelliJPluginCreationResultResolver(),
-      additionalLevelRemapping = mapOf(InvalidSinceBuild::class to PluginProblem.Level.UNACCEPTABLE_WARNING))
+      additionalLevelRemapping = unacceptableWarning<InvalidSinceBuild>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -168,6 +199,18 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
     assertEquals(1, reclassifiedProblems.size)
     assertThat("Reclassified problems contains an 'InvalidSinceBuild' plugin problem ", reclassifiedProblems.find { InvalidSinceBuild::class.isInstance(it) } != null)
+  }
+
+  private fun pluginOf(header: String): ContentBuilder.() -> Unit = {
+    dir("META-INF") {
+      file("plugin.xml") {
+        """
+            <idea-plugin>
+              $header
+            </idea-plugin>
+          """
+      }
+    }
   }
 
   private fun ideaPlugin(pluginId: String = "someid",

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -50,7 +50,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
   fun `plugin is not built due to unsupported prefix ID but such problem level is remapped`() {
     val header = ideaPlugin("com.example")
     val delegateResolver = IntelliJPluginCreationResultResolver()
-    val problemResolver = LevelRemappingPluginCreationResultResolver(delegateResolver)
+    val problemResolver = LevelRemappingPluginCreationResultResolver(delegateResolver, warning<ForbiddenPluginIdPrefix>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -80,7 +80,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
     val problemResolver = LevelRemappingPluginCreationResultResolver(
       delegateResolver,
-      additionalLevelRemapping = warning<InvalidSinceBuild>())
+      additionalLevelRemapping = warning<InvalidSinceBuild>() + warning<ForbiddenPluginIdPrefix>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -178,17 +178,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
       additionalLevelRemapping = warning<HttpLinkInDescription>() + ignore<InvalidSinceBuild>()
     )
 
-    val result = buildPluginWithResult(problemResolver) {
-      dir("META-INF") {
-        file("plugin.xml") {
-          """
-            <idea-plugin>
-              $header
-            </idea-plugin>
-          """
-        }
-      }
-    }
+    val result = buildPluginWithResult(problemResolver, pluginOf(header))
 
     // InvalidSinceBuild is an ignored ERROR, hence leading to a creation success
     assertTrue(result is PluginCreationSuccess)


### PR DESCRIPTION
Some plugin problems need to be ignored. An example issue is [MP-5911](https://youtrack.jetbrains.com/issue/MP-5911) _Not expected plugin verifier warning for plugin ID containing `intellij`_.

- Adjust `LevelRemappingPluginCreationResultResolver` to support _ignoring_ of specific plugin problems
- Improve syntax on various modes of level remapping.
- Add unit tests for various combinations of remapped plugin problems.
- Simplify remapping levels of plugin problem collections
- Remove ability to classify a single plugin problem as it is not used anywhere.