### PR TITLE
Publish intellij-plugin-verifier to Maven Central

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jsoup = "1.16.1"
 junit = "4.13.2"
 kotson = "2.5.0"
 logback-classic = "1.4.7"
+nexus-publish = "1.3.0"
 okhttp = "4.11.0"
 okhttp-loggingInterceptor = "4.11.0"
 retrofit = "2.9.0"
@@ -42,3 +43,4 @@ xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   `maven-publish`
   signing
   alias(sharedLibs.plugins.kotlin.jvm)
-  id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+  alias(sharedLibs.plugins.nexus.publish)
 }
 
 var intellijPluginStructureVersion = "dev"
@@ -68,7 +68,7 @@ val mavenCentralUsername = findProperty("mavenCentralUsername")?.toString()
 val mavenCentralPassword = findProperty("mavenCentralPassword")?.toString()
 
 nexusPublishing {
-  this.repositories {
+  repositories {
     sonatype {
       username = mavenCentralUsername
       password = mavenCentralPassword

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -100,15 +100,17 @@ nexusPublishing {
 }
 
 object Publications {
-  const val cli = "VerifierCli"
-  const val core = "VerifierCore"
-  const val intellij = "VerifierIntelliJ"
-  const val repository = "Repository"
+  val cli = Pub(":verifier-cli", "VerifierCli")
+  val core = Pub(":verifier-core", "VerifierCore")
+  val intellij = Pub(":verifier-intellij", "VerifierIntelliJ")
+  val repository = Pub(":verifier-repository", "Repository")
+  data class Pub(val project: String, val name: String)
 }
 
 publishing {
   publications {
-    fun configurePublication(publicationName: String, projectName: String): MavenPublication {
+    fun configurePublication(publication: Publications.Pub): MavenPublication {
+      val (projectName, publicationName) = publication
       return create<MavenPublication>(publicationName) {
         val proj = project(":$projectName")
         groupId = proj.group.toString()
@@ -119,12 +121,10 @@ publishing {
         artifact(proj.tasks["sourcesJar"])
       }
     }
-    project(":verifier-cli").afterEvaluate {
-      configurePublication(Publications.cli, ":verifier-cli")
-    }
-    configurePublication(Publications.core, ":verifier-core")
-    configurePublication(Publications.intellij, ":verifier-intellij")
-    configurePublication(Publications.repository, ":verifier-repository")
+    configurePublication(Publications.cli)
+    configurePublication(Publications.core)
+    configurePublication(Publications.intellij)
+    configurePublication(Publications.repository)
   }
 
   repositories {
@@ -146,10 +146,10 @@ signing {
 
     useInMemoryPgpKeys(signingKey, signingPassword)
 
-    sign(publishing.publications[Publications.cli])
-    sign(publishing.publications[Publications.core])
-    sign(publishing.publications[Publications.intellij])
-    sign(publishing.publications[Publications.repository])
+    sign(publishing.publications[Publications.cli.name])
+    sign(publishing.publications[Publications.core.name])
+    sign(publishing.publications[Publications.intellij.name])
+    sign(publishing.publications[Publications.repository.name])
   }
 }
 

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -87,8 +87,8 @@ subprojects {
   }
 }
 
-val mavenCentralUsername = findProperty("mavenCentralUsername")?.toString()
-val mavenCentralPassword = findProperty("mavenCentralPassword")?.toString()
+val mavenCentralUsername: String? by project
+val mavenCentralPassword: String? by project
 
 nexusPublishing {
   repositories {
@@ -141,8 +141,8 @@ publishing {
 signing {
   isRequired = mavenCentralUsername != null
   if (isRequired) {
-    val signingKey = findProperty("signingKey").toString()
-    val signingPassword = findProperty("signingPassword").toString()
+    val signingKey: String? by project
+    val signingPassword: String? by project
 
     useInMemoryPgpKeys(signingKey, signingPassword)
 

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -100,12 +100,20 @@ nexusPublishing {
   }
 }
 
-data class Publication(val project: String, val name: String) {
+data class Publication(val project: String, val name: String, val readableName: String, val description: String) {
   companion object {
-    val cli = Publication(":verifier-cli", "VerifierCli")
-    val core = Publication(":verifier-core", "VerifierCore")
-    val intellij = Publication(":verifier-intellij", "VerifierIntelliJ")
-    val repository = Publication(":verifier-repository", "Repository")
+    val cli = Publication("verifier-cli", "VerifierCli",
+      "JetBrains Plugin Verifier CLI",
+      "Command-line interface for JetBrains Plugin Verifier with set of high-level tasks for plugin and IDE validation")
+    val core = Publication("verifier-core", "VerifierCore",
+      "JetBrains Plugin Verifier Core",
+      "Core classes of JetBrains Plugin Verifier with verification rules, general usage detection and bytecode verification engine")
+    val intellij = Publication("verifier-intellij", "VerifierIntelliJ",
+      "JetBrains Plugin Verifier IntelliJ",
+      "JetBrains Plugin Verifier Classes for IntelliJ Platform integration with API usage detection and reporting.")
+    val repository = Publication("verifier-repository", "Repository",
+      "JetBrains Plugin Verifier Repository Integration",
+      "JetBrains Plugin Verifier integration with JetBrains Marketplace plugin repository")
   }
 }
 
@@ -165,6 +173,80 @@ fun PublicationContainer.publish(publication: Publication) {
 
     from(proj.components["java"])
     artifact(proj.tasks["sourcesJar"])
+
+    pom {
+      name = publication.readableName
+      description = publication.description
+      url = "https://github.com/JetBrains/intellij-plugin-verifier/tree/master/intellij-plugin-verifier/$projectName"
+      licenses {
+        license {
+          name = "The Apache Software License, Version 2.0"
+          url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+      }
+      developers {
+        developer {
+          id = "satamas"
+          name = "Semyon Atamas"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "AlexanderPrendota"
+          name = "Alexander Prendota"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "ktisha"
+          name = "Ekaterina Smal"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "chashnikov"
+          name = "Nikolay Chashnikov"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "chrkv"
+          name = "Ivan Chirkov"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "Ololoshechkin"
+          name = "Brilyantov Vadim"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "shalupov"
+          name = "Leonid Shalupov"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "hsz"
+          name = "Jakub Chrzanowski"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "kesarevs"
+          name = "Kesarev Sergey"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "LChernigovskaya"
+          name = "Lidiya Chernigovskaya"
+          organization = "JetBrains"
+        }
+        developer {
+          id = "novotnyr"
+          name = "Robert Novotny"
+          organization = "JetBrains"
+        }
+      }
+      scm {
+        connection = "scm:git:git://github.com/JetBrains/intellij-plugin-verifier.git"
+        developerConnection = "scm:git:ssh://github.com/JetBrains/intellij-plugin-verifier.git"
+        url = "https://github.com/JetBrains/intellij-plugin-verifier"
+      }
+    }
   }
 }
 

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   `maven-publish`
   alias(sharedLibs.plugins.kotlin.jvm)
+  alias(sharedLibs.plugins.nexus.publish)
 }
 
 val projectVersion: String by extra {


### PR DESCRIPTION
Enable publication of `intellij-plugin-verifier` to Maven Central.

- Improve Gradle build process
- Add signing via Gradle plugin
- Add publishing to Maven Central via Gradle plugin