### PR TITLE
Improve copywriting and thread safety on verification directory retrieval in CLI

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -35,18 +35,18 @@ object OptionsParser {
   private val TIMESTAMP_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' HH.mm.ss")
 
   private fun getVerificationReportsDirectory(opts: CmdOpts): Path {
-    val reportDirectory = opts.verificationReportsDir?.let { Paths.get(it) }
-    if (reportDirectory != null) {
-      if (reportDirectory.exists() && reportDirectory.listFiles().isNotEmpty()) {
-        LOG.info("Delete the verification directory ${reportDirectory.toAbsolutePath()} because it isn't empty")
-        reportDirectory.deleteLogged()
-      }
-      reportDirectory.createDir()
-      return reportDirectory
+    val reportDirectory = Paths.get(opts.verificationReportsDir ?: newVerificationDirectoryName())
+    if (reportDirectory.exists() && reportDirectory.listFiles().isNotEmpty()) {
+      LOG.info("Delete the verification directory ${reportDirectory.toAbsolutePath()} because it isn't empty")
+      reportDirectory.deleteLogged()
     }
+    reportDirectory.createDir()
+    return reportDirectory
+  }
+
+  private fun newVerificationDirectoryName(): String {
     val nowTime = TIMESTAMP_DATE_FORMAT.format(LocalDateTime.now())
-    val directoryName = ("verification-$nowTime").replaceInvalidFileNameCharacters()
-    return Paths.get(directoryName).createDir()
+    return "verification-$nowTime".replaceInvalidFileNameCharacters()
   }
 
   fun parseOutputOptions(opts: CmdOpts): OutputOptions {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -37,7 +37,7 @@ object OptionsParser {
   private fun getVerificationReportsDirectory(opts: CmdOpts): Path {
     val reportDirectory = Paths.get(opts.verificationReportsDir ?: newVerificationDirectoryName())
     if (reportDirectory.exists() && reportDirectory.listFiles().isNotEmpty()) {
-      LOG.info("Delete the verification directory ${reportDirectory.toAbsolutePath()} because it isn't empty")
+      LOG.info("The verification directory ${reportDirectory.toAbsolutePath()} is being deleted because it is not empty.")
       reportDirectory.deleteLogged()
     }
     reportDirectory.createDir()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -25,14 +25,14 @@ import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 object OptionsParser {
 
   private val LOG = LoggerFactory.getLogger(OptionsParser::class.java)
 
-  private val TIMESTAMP_DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd 'at' HH.mm.ss")
+  private val TIMESTAMP_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' HH.mm.ss")
 
   private fun getVerificationReportsDirectory(opts: CmdOpts): Path {
     val reportDirectory = opts.verificationReportsDir?.let { Paths.get(it) }
@@ -44,7 +44,7 @@ object OptionsParser {
       reportDirectory.createDir()
       return reportDirectory
     }
-    val nowTime = TIMESTAMP_DATE_FORMAT.format(Date())
+    val nowTime = TIMESTAMP_DATE_FORMAT.format(LocalDateTime.now())
     val directoryName = ("verification-$nowTime").replaceInvalidFileNameCharacters()
     return Paths.get(directoryName).createDir()
   }


### PR DESCRIPTION
- Use thread-safe date and time formatting
- Improve copywriting on log message