### PR TITLE
Improve presentation of dynamic status of a plugin in CLI

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -6,6 +6,7 @@ import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.dymamic.DynamicPlugins.simplifiedReasonsNotToLoadUnloadWithoutRestart
+import com.jetbrains.pluginverifier.output.DYNAMIC_PLUGIN_FAIL
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -154,7 +155,7 @@ private fun Markdown.printVerificationResult(result: PluginVerificationResult.Ve
     is DynamicPluginStatus.MaybeDynamic -> h2(dynaStatus) + paragraph("Plugin can probably be enabled or disabled without IDE restart")
     is DynamicPluginStatus.NotDynamic -> {
       h2(dynaStatus) +
-        paragraph("Plugin probably cannot be enabled or disabled without IDE restart")
+        paragraph(DYNAMIC_PLUGIN_FAIL)
         dynamicPluginStatus.simplifiedReasonsNotToLoadUnloadWithoutRestart().forEach {
           unorderedListItem(it)
         }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -5,6 +5,7 @@ import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
+import com.jetbrains.pluginverifier.dymamic.DynamicPlugins.simplifiedReasonsNotToLoadUnloadWithoutRestart
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -151,7 +152,14 @@ private fun Markdown.printVerificationResult(result: PluginVerificationResult.Ve
   val dynaStatus = "Dynamic Plugin Status"
   when (val dynamicPluginStatus = dynamicPluginStatus) {
     is DynamicPluginStatus.MaybeDynamic -> h2(dynaStatus) + paragraph("Plugin can probably be enabled or disabled without IDE restart")
-    is DynamicPluginStatus.NotDynamic -> h2(dynaStatus) + paragraph("Plugin probably cannot be enabled or disabled without IDE restart: " + dynamicPluginStatus.reasonsNotToLoadUnloadWithoutRestart.joinToString())
+    is DynamicPluginStatus.NotDynamic -> {
+      h2(dynaStatus) +
+        paragraph("Plugin probably cannot be enabled or disabled without IDE restart")
+        dynamicPluginStatus.simplifiedReasonsNotToLoadUnloadWithoutRestart().forEach {
+          unorderedListItem(it)
+        }
+        unorderedListEnd()
+    }
     null -> Unit
   }
 }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
@@ -12,6 +12,7 @@ import com.jetbrains.pluginverifier.output.DYNAMIC_PLUGIN_PASS
 import com.jetbrains.pluginverifier.output.ResultPrinter
 import com.jetbrains.pluginverifier.tasks.InvalidPluginFile
 import java.io.PrintWriter
+import java.util.*
 
 class WriterResultPrinter(private val out: PrintWriter) : ResultPrinter {
 
@@ -108,7 +109,8 @@ class WriterResultPrinter(private val out: PrintWriter) : ResultPrinter {
 
   private fun DynamicPluginStatus.NotDynamic.shortToFullDescriptions(): Map<String, List<String>> {
     val justReasonRestrictions = reasonsNotToLoadUnloadWithoutRestart.map { reason ->
-      reason.removePrefix(DynamicPlugins.MESSAGE + " because ").capitalize()
+      reason.removePrefix(DynamicPlugins.MESSAGE + " because ")
+        .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
     return justReasonRestrictions.associateWith { emptyList<String>() }
   }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dymamic/DynamicPlugins.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dymamic/DynamicPlugins.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.pluginverifier.PluginVerificationDescriptor
 import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
 import org.jdom2.Element
+import java.util.*
 
 /**
  * Utility methods that determine whether a plugin can be dynamically enabled/disabled [DynamicPluginStatus].
@@ -79,7 +80,8 @@ object DynamicPlugins {
 
   fun DynamicPluginStatus.NotDynamic.simplifiedReasonsNotToLoadUnloadWithoutRestart(): List<String> {
     return reasonsNotToLoadUnloadWithoutRestart.map { reason ->
-      reason.removePrefix("$MESSAGE because it ").capitalize()
+      reason.removePrefix("$MESSAGE because it ")
+        .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
     }
   }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dymamic/DynamicPlugins.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dymamic/DynamicPlugins.kt
@@ -14,7 +14,7 @@ import org.jdom2.Element
  * Utility methods that determine whether a plugin can be dynamically enabled/disabled [DynamicPluginStatus].
  */
 object DynamicPlugins {
-  private const val MESSAGE = "Plugin probably cannot be enabled or disabled without IDE restart"
+  const val MESSAGE = "Plugin probably cannot be enabled or disabled without IDE restart"
   fun getDynamicPluginStatus(context: PluginVerificationContext): DynamicPluginStatus? {
     val verificationDescriptor = context.verificationDescriptor
     val idePlugin = context.idePlugin
@@ -75,6 +75,12 @@ object DynamicPlugins {
     }
 
     return null
+  }
+
+  fun DynamicPluginStatus.NotDynamic.simplifiedReasonsNotToLoadUnloadWithoutRestart(): List<String> {
+    return reasonsNotToLoadUnloadWithoutRestart.map { reason ->
+      reason.removePrefix("$MESSAGE because it ").capitalize()
+    }
   }
 
   private fun formatListOfNames(names: List<String>): String =


### PR DESCRIPTION
- Use separate category for restrictions
- Explicitly emit a list of violated restrictions
- Address both plain text CLI and Markdown output

Sample stdout/CLI output:

```
Deprecated API usages (1): 
    #Deprecated method com.intellij.ide.ApplicationInitializedListener.componentsInitialized() is overridden
        Deprecated method com.intellij.ide.ApplicationInitializedListener.componentsInitialized() : void is overridden in class com.github.novotnyr.nondynamic.MyApplicationInitializedListener

Dynamic Plugin Eligibility (negative due to 2 restrictions):
    Plugin probably cannot be enabled or disabled without IDE restart
    #It declares non-dynamic extensions: `com.intellij.applicationInitializedListener`
    #It declares a group without 'id' specified
```