### PR TITLE
Value in <since-build> in plugin descriptor should not contain a wildcard

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -845,6 +845,9 @@ internal class PluginCreator private constructor(
       if (sinceBuildParsed == null) {
         registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
       } else {
+        if (sinceBuild.endsWith(".*")) {
+          registerProblem(SinceBuildCannotContainWildcard(descriptorPath, sinceBuildParsed))
+        }
         if (sinceBuildParsed.baselineVersion < 130 && sinceBuild.endsWith(".*")) {
           registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
         }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -848,7 +848,7 @@ internal class PluginCreator private constructor(
         if (sinceBuild.endsWith(".*")) {
           registerProblem(SinceBuildCannotContainWildcard(descriptorPath, sinceBuildParsed))
         }
-        if (sinceBuildParsed.baselineVersion < 130 && sinceBuild.endsWith(".*")) {
+        if (sinceBuildParsed.baselineVersion < 130) {
           registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
         }
         if (sinceBuildParsed.baselineVersion > 999) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -60,8 +60,8 @@ class InvalidSinceBuild(
   sinceBuild: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The <since-build> parameter ($sinceBuild) format is invalid. Ensure it is greater than <130>, " +
-                    "it doesn't end with a dot star suffix <.*> and represents the actual build numbers."
+  detailedMessage = "The <since-build> parameter ($sinceBuild) format is invalid. Ensure it is greater than <130> " +
+                    "and represents the actual build numbers."
 ) {
   override val level
     get() = Level.ERROR
@@ -95,7 +95,7 @@ class SinceBuildCannotContainWildcard(
   sinceBuild: IdeVersion,
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The <since-build> parameter ($sinceBuild) must not contain a wildcard (dot-star suffix .*)."
+  detailedMessage = "The <since-build> parameter ($sinceBuild) must not contain a wildcard (dot-star suffix) '.*')."
 ) {
   override val level
     get() = Level.WARNING

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -90,6 +90,22 @@ class SinceBuildGreaterThanUntilBuild(
     get() = Level.ERROR
 }
 
+class SinceBuildCannotContainWildcard(
+  descriptorPath: String,
+  sinceBuild: IdeVersion,
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The <since-build> parameter ($sinceBuild) must not contain a wildcard (dot-star suffix .*)."
+) {
+  override val level
+    get() = Level.WARNING
+
+  override val hint = ProblemSolutionHint(
+    example = "<since-build>241</vendor>",
+    documentationUrl = "https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html"
+  )
+}
+
 class ErroneousSinceBuild(
   descriptorPath: String,
   sinceBuild: IdeVersion

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -229,8 +229,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         version = ""
-      }
-      , listOf(PropertyNotSpecified("version", "plugin.xml")))
+      }, listOf(PropertyNotSpecified("version", "plugin.xml")))
   }
 
   @Test
@@ -291,12 +290,12 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
   @Test
   fun `multiple dependencies reuse a single config-file`() {
     `test valid plugin xml`(
-            perfectXmlBuilder.modify {
-              depends = """
+      perfectXmlBuilder.modify {
+        depends = """
                 <depends config-file="shared.xml">com.jetbrains.module-one</depends>
                 <depends config-file="shared.xml">com.jetbrains.module-two</depends>
               """.trimIndent()
-            }
+      }
     )
   }
 
@@ -392,11 +391,15 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
 
   @Test
   fun `wildcard in old ide`() {
+    val wildcardSinceBuild = "129.0.*"
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        ideaVersion = """<idea-version since-build="129.0.*"/>"""
+        ideaVersion = """<idea-version since-build="$wildcardSinceBuild"/>"""
       },
-      listOf(InvalidSinceBuild("plugin.xml", "129.0.*"))
+      listOf(
+        InvalidSinceBuild("plugin.xml", wildcardSinceBuild),
+        SinceBuildCannotContainWildcard("plugin.xml", IdeVersion.createIdeVersion(wildcardSinceBuild))
+      )
     )
   }
 
@@ -446,7 +449,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
     )
     val linksString = testLinks.joinToString(", ") {
       val tag = it.first
-      val attr = when(tag) {
+      val attr = when (tag) {
         "img" -> "src"
         else -> "href"
       }
@@ -645,9 +648,9 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
     )
 
     `test invalid plugin xml`(
-        perfectXmlBuilder.modify {
-          ideaVersion = """<idea-version since-build="171.1" until-build="2018.*"/>"""
-        }, listOf(ErroneousUntilBuild("plugin.xml", IdeVersion.createIdeVersion("2018.*")))
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="171.1" until-build="2018.*"/>"""
+      }, listOf(ErroneousUntilBuild("plugin.xml", IdeVersion.createIdeVersion("2018.*")))
     )
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
@@ -351,6 +350,20 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       listOf(SinceBuildGreaterThanUntilBuild("plugin.xml", IdeVersion.createIdeVersion("131.1"), IdeVersion.createIdeVersion("120.1")))
     )
   }
+
+  @Test
+  fun `since build contains wildcard `() {
+    val specifiedVersion = "131.*"
+    `test plugin xml warnings`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="$specifiedVersion" until-build="234.*"/>"""
+      },
+      listOf(
+        SinceBuildCannotContainWildcard("plugin.xml", IdeVersion.createIdeVersion(specifiedVersion))
+      )
+    )
+  }
+
 
   @Test
   fun `empty vendor`() {


### PR DESCRIPTION
In the plugin descriptor, the `<since-build>` should not contain a wildcard. 

See [corresponding documentation in the IntelliJ Platform Plugin SDK](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#build-number-validity).

I am adding this as a _warning_, later to be elevated to _error_.