### PR TITLE
check-trunk-api:  Remove --major-ide-version (-miv) CLI switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ Here is the full syntax of the command:
     check-trunk-api <trunk IDE>
         [-runtime-dir | -r <file>]
         [-major-ide-path | -mip <file>]
-        [-major-ide-version | -miv <IDE version>]
         [-external-prefixes <':'-separated list>]
         [-subsystems-to-check | -subsystems]
         [-release-jetbrains-plugins | -rjbp <path>]
@@ -226,11 +225,6 @@ Here is the full syntax of the command:
 * `-major-ide-path (-mip)`
 
     The path to the major IDE release build to compare API problems of the trunk (master) IDE build.
-
-* `-major-ide-version (-miv)`
-
-    The IDE version with which to compare API problems.
-    This IDE will be downloaded from the [IntelliJ Release repository](https://www.jetbrains.com/intellij-repository/releases).
 
 * `-release-jetbrains-plugins (-rjbp)`
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
@@ -251,12 +251,6 @@ class CheckTrunkApiParamsBuilder(
 }
 
 class CheckTrunkApiOpts {
-  @set:Argument("major-ide-version", alias = "miv", description = "The IDE version with which to compare API problems. This IDE will be downloaded from the IDE builds repository: https://www.jetbrains.com/intellij-repository/releases/.")
-  var majorIdeVersion: String? = null
-
-  @set:Argument("save-major-ide-file", alias = "smif", description = "Whether to save a downloaded release IDE in cache directory for use in later verifications")
-  var saveMajorIdeFile: Boolean = false
-
   @set:Argument("major-ide-path", alias = "mip", description = "The path to release (major) IDE build with which to compare API problems in trunk (master) IDE build.")
   var majorIdePath: String? = null
 


### PR DESCRIPTION
In `check-trunk-api` command, remove `--major-ide-version` (-miv) CLI switch.

It has not been used anywhere since major refactoring in 2017.

There are no requirements to use it, nor there were any complaints, until recently.

The alternative is to use `--major-ide-path` with a path to the IDE in the local filesystem.

See [MP-6080](https://youtrack.jetbrains.com/issue/MP-6080).