### PR TITLE
Create a Gradle task to emit the release notes

### DIFF
--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -278,15 +278,16 @@ abstract class MostRecentVersionChangelog : BaseChangelogTask() {
   @TaskAction
   fun run() {
     with(changelog.get()) {
-      val markdown = releasedItems.first()
+      releasedItems.first()
         .withHeader(false)
         .let {
           renderItem(it, Changelog.OutputType.MARKDOWN)
         }
-
-      changelogWriter.use { writer ->
-        writer.append(markdown)
-      }
+        .let { changelogItem ->
+          changelogWriter.use {
+            it.append(changelogItem)
+          }
+        }
     }
   }
 

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -270,6 +270,10 @@ changelog {
   path = file("../CHANGELOG.md").canonicalPath
 }
 
+/**
+ * Writes a changelog for the most recently released version.
+ * The 'CHANGELOG.md' set in the 'changelog' plugin is used as a source
+ */
 abstract class MostRecentVersionChangelog : BaseChangelogTask() {
   @TaskAction
   fun run() {
@@ -287,7 +291,7 @@ abstract class MostRecentVersionChangelog : BaseChangelogTask() {
   }
 
   private val changelogWriter: BufferedWriter
-  get() = project.layout.buildDirectory.file("changelog.md").get().asFile.bufferedWriter()
+    get() = project.layout.buildDirectory.file("changelog.md").get().asFile.bufferedWriter()
 }
 
 tasks.register<MostRecentVersionChangelog>("mostRecentVersionChangelog") {


### PR DESCRIPTION
Create a Gradle task to emit release notes as a Markdown file.

Release notes are taken from the most recent released version in the `CHANGELOG.md`.

# Motivation

[Gradle Changelog Plugin](https://github.com/JetBrains/gradle-changelog-plugin) writes the changelog into stdout.
On GitHub Actions, this is captured into an environment variable.
Then, it is used to create _release notes_ for the corresponding GitHub release.

In TeamCity, this is not feasible due to technical reasons and build scripts.

Hence, we will write the most recent Changelog into a Markdown file in the `build` directory.
In the subsequent TeamCity build steps,
this file is picked up and used as a Release Notes document used in the GitHub release.

# Solution

We are extending an `BaseChangelogTask` task from Gradle Changelog Plugin, applying customizations and
emitting just the most recent version of the project into a Markdown file.

# Non-goal

We can extract away the task and handling code into `buildSrc`
but in current Gradle there are issues when extending and applying a third party plugin.