### PR TITLE
Support remapping plugin problem to ERROR level

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/RemappedPluginProblems.kt
@@ -8,6 +8,10 @@ sealed class RemappedLevel
 object IgnoredLevel : RemappedLevel()
 data class StandardLevel(val originalLevel: PluginProblem.Level) : RemappedLevel()
 
+inline fun <reified T : PluginProblem> error(): Map<KClass<*>, RemappedLevel> {
+  return mapOf(T::class to StandardLevel(PluginProblem.Level.ERROR))
+}
+
 inline fun <reified T : PluginProblem> unacceptableWarning(): Map<KClass<*>, RemappedLevel> {
   return mapOf(T::class to StandardLevel(PluginProblem.Level.UNACCEPTABLE_WARNING))
 }


### PR DESCRIPTION
Support remapping any plugin problem to _error_ level.

Such remapping might change a successful plugin construction result from _successful_ to _failed_ status.

A specific plugin problem might be originally a _warning_, which corresponds to a successful construction, but remapping such issue to an _error_ will lead to a _construction failure_.

