### PR TITLE
Rework plugin problem level remapping when reclassifying structural plugin descriptor problems

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginProblems.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginProblems.kt
@@ -1,0 +1,25 @@
+package com.jetbrains.plugin.structure.base.problems
+
+fun PluginProblem.isReclassified(): Boolean = this is ReclassifiedPluginProblem
+
+/**
+ * Unwrap an original problem from a reclassified problem.
+ * If this is not a reclassified problem, return itself.
+ */
+val PluginProblem.unwrapped: PluginProblem
+  get() = if (this is ReclassifiedPluginProblem) {
+    unwrapped
+  } else {
+    this
+  }
+
+/**
+ * Indicate if this problem is an [Invalid Descriptor Problem](InvalidDescriptorProblem).
+ * If this is a reclassified problem, the original problem will be unwrapped and checked.
+ */
+val PluginProblem.isInvalidDescriptorProblem: Boolean
+  get() = if (isReclassified()) {
+    unwrapped is InvalidDescriptorProblem
+  } else {
+    this is InvalidDescriptorProblem
+  }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -69,7 +69,9 @@ class IdePluginManager private constructor(
               createInvalidPlugin(jarFile, descriptorPath, UnableToReadDescriptor(descriptorPath, message))
             }
           }
-          else -> createInvalidPlugin(jarFile, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
+          else -> createInvalidPlugin(jarFile, descriptorPath, PluginDescriptorIsNotFound(descriptorPath)).also {
+            LOG.debug("Unable to resolve descriptor [{}] from [{}] ({})", descriptorPath, jarFile, descriptor)
+          }
         }
       }
     } catch (e: JarArchiveCannotBeOpenException) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -419,13 +419,6 @@ class IdePluginManager private constructor(
       }
     }
 
-    private val PluginProblem.isInvalidDescriptorProblem: Boolean
-      get() = if (this is ReclassifiedPluginProblem) {
-        unwrapped is InvalidDescriptorProblem
-      } else {
-        this is InvalidDescriptorProblem
-      }
-
     private fun getIconFileName(iconTheme: IconTheme) = "pluginIcon${iconTheme.suffix}.svg"
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -414,10 +414,17 @@ class IdePluginManager private constructor(
         is PluginCreationSuccess<*> -> false
         is PluginCreationFail<*> -> {
           val errorsAndWarnings = pluginCreationResult.errorsAndWarnings
-          errorsAndWarnings.all { it.level !== PluginProblem.Level.ERROR || it is InvalidDescriptorProblem }
+          errorsAndWarnings.all { it.level !== PluginProblem.Level.ERROR || it.isInvalidDescriptorProblem }
         }
       }
     }
+
+    private val PluginProblem.isInvalidDescriptorProblem: Boolean
+      get() = if (this is ReclassifiedPluginProblem) {
+        unwrapped is InvalidDescriptorProblem
+      } else {
+        this is InvalidDescriptorProblem
+      }
 
     private fun getIconFileName(iconTheme: IconTheme) = "pluginIcon${iconTheme.suffix}.svg"
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
@@ -1,0 +1,46 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginIcon
+import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import org.jdom2.Document
+import org.jdom2.Element
+import java.nio.file.Path
+
+/**
+ * An invalid plugin that was either not fully parsed or that has been parsed with syntax error in the descriptor.
+ * Such placeholder class can be used in the verification engines to filter out specific verification rules
+ * despite the incomplete or erroneous metadata from plugin descriptor.
+ */
+class InvalidPlugin(override val underlyingDocument: Document) : IdePlugin {
+  override var pluginId: String? = null
+  override var pluginName: String? = null
+  override var pluginVersion: String? = null
+  override var url: String? = null
+  override var changeNotes: String? = null
+  override var description: String? = null
+  override var vendor: String? = null
+  override var vendorEmail: String? = null
+  override var vendorUrl: String? = null
+  override var icons: List<PluginIcon> = emptyList()
+  override var thirdPartyDependencies: List<ThirdPartyDependency> = emptyList()
+
+  override val sinceBuild: IdeVersion? = null
+  override val untilBuild: IdeVersion? = null
+  override val extensions: Map<String, List<Element>> = emptyMap()
+  override val appContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor()
+  override val projectContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor()
+  override val moduleContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor()
+  override val dependencies: List<PluginDependency> = emptyList()
+  override val incompatibleModules: List<String> = emptyList()
+  override val definedModules: Set<String> = emptySet()
+  override val optionalDescriptors: List<OptionalPluginDescriptor> = emptyList()
+  override val modulesDescriptors: List<ModuleDescriptor> = emptyList()
+  override val originalFile: Path? = null
+  override val productDescriptor: ProductDescriptor? = null
+  override val declaredThemes: List<IdeTheme> = emptyList()
+  override val useIdeClassLoader: Boolean = false
+  override val isImplementationDetail: Boolean = false
+  override val isV2: Boolean = false
+  override fun isCompatibleWithIde(ideVersion: IdeVersion): Boolean = false
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -219,6 +219,24 @@ internal class PluginCreator private constructor(
     plugin.originalFile = originalFile
   }
 
+  /**
+   * Create an instance of an invalid plugin with the most basic information.
+   *
+   * This allows creating a bare-bones plugin with invalid data.
+   * Plugin problems associated with this invalid data might be reclassified by the [problem resolver](#problemResolver).
+   */
+  private fun newInvalidPlugin(bean: PluginBean, document: Document): InvalidPlugin {
+    return InvalidPlugin(document).apply {
+      pluginId = bean.id?.trim()
+      pluginName = bean.name?.trim()
+      bean.vendor?.let {
+        vendor = if (it.name != null) it.name.trim() else null
+        vendorUrl = it.url
+        vendorEmail = it.email
+      }
+    }
+  }
+
   private fun IdePluginImpl.setInfoFromBean(bean: PluginBean, document: Document) {
     pluginName = bean.name?.trim()
     pluginId = bean.id?.trim() ?: pluginName
@@ -656,7 +674,7 @@ internal class PluginCreator private constructor(
     val document = resolveXIncludesOfDocument(originalDocument, documentName, pathResolver, documentPath) ?: return
     val bean = readDocumentIntoXmlBean(document) ?: return
     validatePluginBean(bean, validateDescriptor)
-    if (hasErrors()) {
+    if (hasPluginBeanErrors(bean, document)) {
       return
     }
 
@@ -730,6 +748,31 @@ internal class PluginCreator private constructor(
 
   private fun hasErrors(): Boolean {
     return problemResolver.classify(plugin, problems).any {
+      it.level == ERROR
+    }
+  }
+
+  /**
+   * Checks if the _bean_ has any core plugin bean errors in the plugin descriptor.
+   *
+   * Such core errors are field validation errors (missing fields, empty values).
+   * If any such core error is found, an instance of invalid plugin with the most
+   * basic information is created and filtered by [problem resolver](problemResolver).
+   *
+   * This enables problem resolver to intentionally ignore core plugin bean errors
+   * and reclassify these errors into warnings or even ignore them.
+   *
+   * The usual example is an internal JetBrains plugin that might violate rules for
+   * allowed field values in the plugin descriptor.
+   *
+   * @see validatePluginBean
+   */
+  private fun hasPluginBeanErrors(bean: PluginBean, document: Document): Boolean {
+    if (problems.isEmpty()) {
+      return false
+    }
+    val invalidPlugin = newInvalidPlugin(bean, document)
+    return problemResolver.classify(invalidPlugin, problems).any {
       it.level == ERROR
     }
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/JetBrainsPluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/JetBrainsPluginCreationResultResolver.kt
@@ -1,0 +1,44 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors
+import java.io.IOException
+import kotlin.reflect.KClass
+
+const val JETBRAINS_PLUGIN_REMAPPING_SET = "jetbrains-plugin"
+
+class JetBrainsPluginCreationResultResolver(private val delegatedResolver: PluginCreationResultResolver,
+                                            levelRemapping: Map<KClass<*>, RemappedLevel> = emptyMap()
+) : PluginCreationResultResolver {
+
+  private val jetBrainsResolver = LevelRemappingPluginCreationResultResolver(delegatedResolver,
+    levelRemapping, unwrapRemappedProblems = true)
+
+  override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
+    return getCreationResultResolver(plugin).resolve(plugin, problems)
+  }
+
+  override fun classify(plugin: IdePlugin, problems: List<PluginProblem>): List<PluginProblem> {
+    return getCreationResultResolver(plugin).classify(plugin, problems)
+  }
+
+  private fun getCreationResultResolver(plugin: IdePlugin): PluginCreationResultResolver {
+    return if (PluginVendors.isDevelopedByJetBrains(plugin)) {
+      jetBrainsResolver
+    } else {
+      delegatedResolver
+    }
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    fun fromClassPathJson(delegatedResolver: PluginCreationResultResolver): JetBrainsPluginCreationResultResolver {
+      val levelRemappingManager = levelRemappingFromClassPathJson()
+      val levelRemapping = levelRemappingManager.getLevelRemapping(JETBRAINS_PLUGIN_REMAPPING_SET)
+
+      return JetBrainsPluginCreationResultResolver(delegatedResolver, levelRemapping)
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
@@ -11,11 +11,9 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import kotlin.reflect.KClass
 
 class LevelRemappingPluginCreationResultResolver(private val delegatedResolver: PluginCreationResultResolver,
-                                                 additionalLevelRemapping: Map<KClass<*>, RemappedLevel> = emptyMap(),
+                                                 private val remappedLevel: Map<KClass<*>, RemappedLevel> = emptyMap(),
                                                  private val unwrapRemappedProblems: Boolean = false
   ) : PluginCreationResultResolver {
-
-  private val remappedLevel: Map<KClass<*>, RemappedLevel> = additionalLevelRemapping
 
   override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationResult<IdePlugin> {
     return when (val pluginCreationResult = delegatedResolver.resolve(plugin, problems)) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolver.kt
@@ -7,6 +7,7 @@ import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.UNACCEPTABLE_WARNING
 import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.WARNING
 import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.base.problems.unwrapped
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import kotlin.reflect.KClass
 
@@ -56,8 +57,8 @@ class LevelRemappingPluginCreationResultResolver(private val delegatedResolver: 
     return errorsAndWarnings.mapNotNull(::remapPluginProblemLevel)
   }
 
-  private fun remapPluginProblemLevel(pluginProblem: PluginProblem): PluginProblem?{
-    val problem = if (unwrapRemappedProblems && pluginProblem is ReclassifiedPluginProblem)  {
+  private fun remapPluginProblemLevel(pluginProblem: PluginProblem): PluginProblem? {
+    val problem = if (unwrapRemappedProblems) {
       pluginProblem.unwrapped
     } else {
       pluginProblem

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
@@ -103,6 +103,13 @@ fun ProblemLevelRemappingManager.getLevelRemapping(levelRemappingDefinitionName:
   }
 }
 
+fun ProblemLevelRemappingManager.newDefaultResolver(levelRemappingDefinitionName: String): PluginCreationResultResolver {
+  val defaultResolver = IntelliJPluginCreationResultResolver()
+  val problemLevelRemapping = getLevelRemapping(levelRemappingDefinitionName)
+  val levelRemappingResolver = LevelRemappingPluginCreationResultResolver(defaultResolver, additionalLevelRemapping = problemLevelRemapping)
+  return JetBrainsPluginCreationResultResolver.fromClassPathJson(delegatedResolver = levelRemappingResolver)
+}
+
 class LevelRemappingDefinitions {
   private val definitions = mutableMapOf<String, LevelRemappingDefinition>()
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
@@ -106,7 +106,7 @@ fun ProblemLevelRemappingManager.getLevelRemapping(levelRemappingDefinitionName:
 fun ProblemLevelRemappingManager.newDefaultResolver(levelRemappingDefinitionName: String): PluginCreationResultResolver {
   val defaultResolver = IntelliJPluginCreationResultResolver()
   val problemLevelRemapping = getLevelRemapping(levelRemappingDefinitionName)
-  val levelRemappingResolver = LevelRemappingPluginCreationResultResolver(defaultResolver, additionalLevelRemapping = problemLevelRemapping)
+  val levelRemappingResolver = LevelRemappingPluginCreationResultResolver(defaultResolver, problemLevelRemapping)
   return JetBrainsPluginCreationResultResolver.fromClassPathJson(delegatedResolver = levelRemappingResolver)
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/ProblemLevelRemappingManager.kt
@@ -88,6 +88,21 @@ class JsonUrlProblemLevelRemappingManager(private val pluginProblemsJsonUrl: URL
   }
 }
 
+fun ProblemLevelRemappingManager.getLevelRemapping(levelRemappingDefinitionName: String): LevelRemappingDefinition {
+  return runCatching {
+    val levelRemappings = initialize()
+    val levelRemappingDefinition = levelRemappings[levelRemappingDefinitionName]
+      ?: emptyLevelRemapping(levelRemappingDefinitionName).also {
+        LOG.warn(("Plugin problem remapping definition '$levelRemappingDefinitionName' was not found. " +
+          "Problem levels will not be remapped"))
+      }
+    levelRemappingDefinition
+  }.getOrElse {
+    LOG.error(it.message, it)
+    emptyLevelRemapping(levelRemappingDefinitionName)
+  }
+}
+
 class LevelRemappingDefinitions {
   private val definitions = mutableMapOf<String, LevelRemappingDefinition>()
 

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -8,5 +8,10 @@
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId": "error",
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "error"
+  },
+  "jetbrains-plugin": {
+    "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "ignore",
+    "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId": "ignore",
+    "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore"
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
@@ -15,7 +15,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
     val definitionManager = JsonUrlProblemLevelRemappingManager(PLUGIN_PROBLEMS_FILE_NAME.asUrl())
     val levelRemappings =  definitionManager.load()
 
-    assertThat(levelRemappings.size, `is`(2))
+    assertThat(levelRemappings.size, `is`(3))
 
     val existingPluginLevelRemapping = levelRemappings["existing-plugin"]
     Assert.assertNotNull(existingPluginLevelRemapping)
@@ -36,7 +36,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
   fun `plugin problems are loaded from JSON in classpath`() {
     val levelMappingManager = levelRemappingFromClassPathJson()
     val levelRemappings =  levelMappingManager.load()
-    assertThat(levelRemappings.size, `is`(2))
+    assertThat(levelRemappings.size, `is`(3))
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/LevelRemappingPluginCreationResultResolverTest.kt
@@ -1,0 +1,34 @@
+package com.jetbrains.plugin.structure.intellij.problems
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class LevelRemappingPluginCreationResultResolverTest {
+  @Test
+  fun `remapped problem is unwrapped and remapped again`() {
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = "com.intellij.someplugin"
+      vendor = "" // deliberately empty
+    }
+
+    val pluginProblem = VendorCannotBeEmpty(PLUGIN_XML)
+
+    val resolver = LevelRemappingPluginCreationResultResolver(IntelliJPluginCreationResultResolver(),
+      unacceptableWarning<VendorCannotBeEmpty>(), unwrapRemappedProblems = true)
+    val creationResult = resolver.resolve(idePlugin, listOf(
+      ReclassifiedPluginProblem(PluginProblem.Level.WARNING, pluginProblem)
+    ))
+    assertThat(creationResult, instanceOf(PluginCreationSuccess::class.java))
+    val creationSuccess = creationResult as PluginCreationSuccess
+    assertThat(creationSuccess.unacceptableWarnings.size, `is`(1))
+    assertThat(creationSuccess.warnings.size, `is`(0))
+  }
+}

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
@@ -1,6 +1,8 @@
 package com.jetbrains.pluginverifier.options
 
-import com.jetbrains.plugin.structure.intellij.problems.*
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.ProblemLevelRemappingManager
+import com.jetbrains.plugin.structure.intellij.problems.newDefaultResolver
 import com.jetbrains.pluginverifier.options.SubmissionType.EXISTING
 import com.jetbrains.pluginverifier.options.SubmissionType.NEW
 
@@ -10,22 +12,10 @@ const val NEW_PLUGIN_REMAPPING_SET = "new-plugin"
 class PluginParsingConfigurationResolution {
   fun resolveProblemLevelMapping(configuration: PluginParsingConfiguration,
                                  problemLevelMappingManager: ProblemLevelRemappingManager): PluginCreationResultResolver {
-    return when (configuration.pluginSubmissionType) {
-      EXISTING -> getPluginCreationResultResolver(EXISTING_PLUGIN_REMAPPING_SET, problemLevelMappingManager)
-        .withJetBrainsPluginProblemLevelRemapping()
-
-      NEW -> getPluginCreationResultResolver(NEW_PLUGIN_REMAPPING_SET, problemLevelMappingManager)
-        .withJetBrainsPluginProblemLevelRemapping()
+    val levelRemappingDefinitionName = when (configuration.pluginSubmissionType) {
+      EXISTING -> EXISTING_PLUGIN_REMAPPING_SET
+      NEW -> NEW_PLUGIN_REMAPPING_SET
     }
+    return problemLevelMappingManager.newDefaultResolver(levelRemappingDefinitionName)
   }
 }
-
-private fun getPluginCreationResultResolver(levelRemappingDefinitionName: String, problemLevelMappingManager: ProblemLevelRemappingManager): PluginCreationResultResolver {
-  val defaultResolver = IntelliJPluginCreationResultResolver()
-  val problemLevelRemapping = problemLevelMappingManager.getLevelRemapping(levelRemappingDefinitionName)
-  val levelRemappingResolver = LevelRemappingPluginCreationResultResolver(defaultResolver, additionalLevelRemapping = problemLevelRemapping)
-  return JetBrainsPluginCreationResultResolver.fromClassPathJson(delegatedResolver = levelRemappingResolver)
-}
-
-private fun PluginCreationResultResolver.withJetBrainsPluginProblemLevelRemapping() =
-  JetBrainsPluginCreationResultResolver.fromClassPathJson(this)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
@@ -26,12 +26,12 @@ private fun getPluginCreationResultResolver(levelRemappingDefinitionName: String
   val defaultResolver = IntelliJPluginCreationResultResolver()
   val problemLevelRemapping = runCatching {
     val levelRemappings = problemLevelMappingManager.initialize()
-    val existingPluginLevelRemapping = levelRemappings[levelRemappingDefinitionName]
+    val levelRemappingDefinition = levelRemappings[levelRemappingDefinitionName]
       ?: emptyLevelRemapping(levelRemappingDefinitionName).also {
         LOG.warn(("Plugin problem remapping definition '$levelRemappingDefinitionName' was not found. " +
           "Problem levels will not be remapped"))
       }
-    existingPluginLevelRemapping
+    levelRemappingDefinition
   }.getOrElse {
     LOG.error(it.message, it)
     emptyMap()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
@@ -3,10 +3,6 @@ package com.jetbrains.pluginverifier.options
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.pluginverifier.options.SubmissionType.EXISTING
 import com.jetbrains.pluginverifier.options.SubmissionType.NEW
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
-private val LOG: Logger = LoggerFactory.getLogger(PluginParsingConfigurationResolution::class.java)
 
 const val EXISTING_PLUGIN_REMAPPING_SET = "existing-plugin"
 const val NEW_PLUGIN_REMAPPING_SET = "new-plugin"

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
@@ -51,16 +51,13 @@ class PluginParsingConfigurationResolutionTest {
     val creationResultResolver = configurationResolution.resolveProblemLevelMapping(config,
       levelRemappingFromClassPathJson())
 
-    assertThat(creationResultResolver, instanceOf(LevelRemappingPluginCreationResultResolver::class.java))
-    val levelRemappingResolver = creationResultResolver as LevelRemappingPluginCreationResultResolver
-
     val problemsThatShouldBeIgnored = listOf(
       ForbiddenPluginIdPrefix(pluginId, "some.forbidden.plugin.id"),
       TemplateWordInPluginId(pluginId, "forbiddenTemplateWord"),
       TemplateWordInPluginName(pluginId, "forbiddenTemplateWord"),
     )
     val warnings = listOf(SuspiciousUntilBuild("999"))
-    val creationResult = levelRemappingResolver.resolve(plugin, problemsThatShouldBeIgnored + warnings)
+    val creationResult = creationResultResolver.resolve(plugin, problemsThatShouldBeIgnored + warnings)
     assertTrue(creationResult is PluginCreationSuccess)
     val creationSuccess = creationResult as PluginCreationSuccess
     assertThat(creationSuccess.warnings.size, `is`(1))
@@ -76,14 +73,11 @@ class PluginParsingConfigurationResolutionTest {
     }
     val creationResultResolver = configurationResolution.resolveProblemLevelMapping(config, levelMapper)
 
-    assertThat(creationResultResolver, instanceOf(LevelRemappingPluginCreationResultResolver::class.java))
-    val levelRemappingResolver = creationResultResolver as LevelRemappingPluginCreationResultResolver
-
     val problemsThatShouldBeRemapped = listOf(
       ErroneousSinceBuild(PLUGIN_XML, IdeVersion.createIdeVersion("123"))
     )
     val warnings = listOf(SuspiciousUntilBuild("999"))
-    val creationResult = levelRemappingResolver.resolve(plugin, problemsThatShouldBeRemapped + warnings)
+    val creationResult = creationResultResolver.resolve(plugin, problemsThatShouldBeRemapped + warnings)
     assertTrue(creationResult is PluginCreationSuccess)
     val creationSuccess = creationResult as PluginCreationSuccess
     assertThat(creationSuccess.warnings.size, `is`(2))

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -81,7 +81,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
     val problemResolver = LevelRemappingPluginCreationResultResolver(
       delegateResolver,
-      additionalLevelRemapping = warning<InvalidSinceBuild>() + warning<ForbiddenPluginIdPrefix>())
+      warning<InvalidSinceBuild>() + warning<ForbiddenPluginIdPrefix>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -113,7 +113,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
     val remappingProblemResolver = LevelRemappingPluginCreationResultResolver(
       IntelliJPluginCreationResultResolver(),
-      additionalLevelRemapping = ignore<TemplateWordInPluginId>())
+      ignore<TemplateWordInPluginId>())
 
     val result = buildPluginWithResult(remappingProblemResolver, pluginOf(header))
     assertThat("Plugin Creation Result must succeed", result, instanceOf(PluginCreationSuccess::class.java))
@@ -141,8 +141,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
     val erroneousUntilBuild = "1000"
     val header = ideaPlugin("plugin.with.two.problems", sinceBuild = erroneousSinceBuild, untilBuild = erroneousUntilBuild)
     val delegateResolver = IntelliJPluginCreationResultResolver()
-    val problemResolver = LevelRemappingPluginCreationResultResolver(delegateResolver,
-      additionalLevelRemapping = warning<InvalidSinceBuild>())
+    val problemResolver = LevelRemappingPluginCreationResultResolver(delegateResolver, warning<InvalidSinceBuild>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -176,7 +175,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
       description = "<![CDATA[A failing plugin with HTTP link leading to <a href='http://jetbrains.com'>JetBrains</a>]]>")
 
     val problemResolver = LevelRemappingPluginCreationResultResolver(IntelliJPluginCreationResultResolver(),
-      additionalLevelRemapping = warning<HttpLinkInDescription>() + ignore<InvalidSinceBuild>()
+      warning<HttpLinkInDescription>() + ignore<InvalidSinceBuild>()
     )
 
     val result = buildPluginWithResult(problemResolver, pluginOf(header))
@@ -208,7 +207,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
       description = "<![CDATA[A failing plugin with HTTP link leading to <a href='http://jetbrains.com'>JetBrains</a>]]>")
 
     val problemResolver = LevelRemappingPluginCreationResultResolver(IntelliJPluginCreationResultResolver(),
-      additionalLevelRemapping = unacceptableWarning<InvalidSinceBuild>())
+      unacceptableWarning<InvalidSinceBuild>())
 
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {


### PR DESCRIPTION
- Fix case when reclassified plugin problem level might not be used properly, leading to a plugin descriptor discovery issue. 
- Unwrap plugin problem which have reclassified problem level.
- Introduce a special case of _invalid plugin_ which contains seemingly invalid plugin descriptor data. In some scenarios, even plugin with core plugin errors might be treated as valid due to relaxed rules. This is often a case with JetBrains plugins.
Before this improvement, a Plugin creation result resolver was not able to reclassify such basic validation problems.
- Introduce a set of plugin problem remappings for JetBrains plugins.

See [MP-6388](https://youtrack.jetbrains.com/issue/MP-6388)