### PR TITLE
Distinguish errors and other plugin problems in Markdown and Console outputs

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginProblems.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginProblems.kt
@@ -23,3 +23,6 @@ val PluginProblem.isInvalidDescriptorProblem: Boolean
   } else {
     this is InvalidDescriptorProblem
   }
+
+val PluginProblem.isError: Boolean
+  get() = level == PluginProblem.Level.ERROR

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -557,9 +557,7 @@ internal class PluginCreator private constructor(
         registerProblem(SuperfluousNonOptionalDependencyDeclaration(dependencyBean.dependencyId))
       }
     }
-    ReusedDescriptorVerifier(descriptorPath).verify(dependencies) {
-      problems += it
-    }
+    ReusedDescriptorVerifier(descriptorPath).verify(dependencies, ::registerProblem)
   }
 
   private fun validateProductDescriptor(productDescriptor: ProductDescriptorBean?) {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.pluginverifier.output.markdown
 
+import com.jetbrains.plugin.structure.base.problems.isError
 import com.jetbrains.plugin.structure.base.utils.create
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
@@ -55,12 +56,23 @@ class MarkdownResultPrinter(private val out: PrintWriter) : ResultPrinter, AutoC
         }
       }
       if (invalidPluginFiles.isNotEmpty()) {
-        for ((pluginFile, pluginErrors) in invalidPluginFiles) {
+        for ((pluginFile, pluginProblems) in invalidPluginFiles) {
           h2("${pluginFile.fileName}")
           paragraph("Full path: `$pluginFile`")
+          val (pluginErrors, otherPluginProblems) = pluginProblems.partition { it.isError }
           if (pluginErrors.isNotEmpty()) {
+            h3("Plugin Problems")
             for (pluginError in pluginErrors) {
               unorderedListItem("$pluginError")
+            }
+            unorderedListEnd()
+          }
+          if (otherPluginProblems.isNotEmpty()) {
+            val prefix = if (pluginErrors.isEmpty()) "" else "Additional "
+
+            h3("${prefix}Plugin Warnings")
+            for (pluginProblem in otherPluginProblems) {
+              unorderedListItem("$pluginProblem")
             }
             unorderedListEnd()
           }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.pluginverifier.output.stream
 
+import com.jetbrains.plugin.structure.base.problems.isError
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.dymamic.DynamicPlugins
@@ -34,10 +35,20 @@ class WriterResultPrinter(private val out: PrintWriter) : ResultPrinter {
   fun printInvalidPluginFiles(invalidPluginFiles: List<InvalidPluginFile>) {
     if (invalidPluginFiles.isNotEmpty()) {
       out.println("The following files specified for the verification are not valid plugins:")
-      for ((pluginFile, pluginErrors) in invalidPluginFiles) {
+      for ((pluginFile, pluginProblems) in invalidPluginFiles) {
         out.println("    $pluginFile")
-        for (pluginError in pluginErrors) {
-          out.println("        $pluginError")
+        val (pluginErrors, otherPluginProblems) = pluginProblems.partition { it.isError }
+        if (pluginErrors.isNotEmpty()) {
+          out.println("        Plugin problems:")
+          for (pluginError in pluginErrors) {
+            out.println("            $pluginError")
+          }
+        }
+        if (otherPluginProblems.isNotEmpty()) {
+          out.println("        Additional plugin warnings:")
+          for (pluginProblem in otherPluginProblems) {
+            out.println("            $pluginProblem")
+          }
         }
       }
     }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/InvalidPluginFile.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/InvalidPluginFile.kt
@@ -9,6 +9,6 @@ import java.nio.file.Path
 
 /**
  * Descriptor of a plugin which was specified for the verification
- * but which has structure [errors] [pluginErrors].
+ * but which has structure [problems] [problems].
  */
-data class InvalidPluginFile(val pluginFile: Path, val pluginErrors: List<PluginProblem>)
+data class InvalidPluginFile(val file: Path, val problems: List<PluginProblem>)


### PR DESCRIPTION
In stdout output, distinguish between errors and other plugin problems:

```
The following files specified for the verification are not valid plugins:
    /opt/my-plugin.jar
        Plugin problems:
            Invalid plugin descriptor 'plugin.xml'. The plugin id should not contain the word 'intellij'.
        Additional plugin warnings:
            Invalid plugin descriptor 'plugin.xml'. Multiple dependencies (4) use the same config-file attribute value 'plugin-apexdoc-lightweight.xml': [com.jetbrains.php, com.intellij.modules.python, com.intellij.modules.ruby, com.intellij.modules.webstorm].
```

Markdown:
```
# Invalid plugin

The following file specified for the verification is not a valid plugin.

## plugin.zip

Full path: `plugin.zip`

### Plugin Problems

* Invalid plugin descriptor 'plugin.xml'. The <since-build> parameter (1) format is invalid. Ensure it is greater than <130> and represents the actual build numbers.

### Additional Plugin Warnings

* Invalid plugin descriptor 'id'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
````        
        