### PR TITLE
Pass structure warnings to verification reports

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -6,12 +6,13 @@ package com.jetbrains.plugin.structure.intellij.plugin
 
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import org.jdom2.Document
 import org.jdom2.Element
 import java.nio.file.Path
 
-class IdePluginImpl : IdePlugin {
+class IdePluginImpl : IdePlugin, StructurallyValidated {
   override var pluginId: String? = null
 
   override var pluginName: String? = null
@@ -76,6 +77,8 @@ class IdePluginImpl : IdePlugin {
 
   override fun isCompatibleWithIde(ideVersion: IdeVersion) =
     (sinceBuild == null || sinceBuild!! <= ideVersion) && (untilBuild == null || ideVersion <= untilBuild!!)
+
+  override val problems: MutableList<PluginProblem> = mutableListOf()
 
   override fun toString(): String =
     (pluginId ?: pluginName ?: "<unknown plugin ID>") + (pluginVersion?.let { ":$it" } ?: "")

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -129,7 +129,8 @@ internal class PluginCreator private constructor(
   val contentModules = arrayListOf<Module>()
 
   private val plugin = IdePluginImpl()
-  private val problems = arrayListOf<PluginProblem>()
+  private val problems: MutableList<PluginProblem>
+    get() = plugin.problems
 
   val pluginId: String?
     get() = plugin.pluginId ?: parentPlugin?.pluginId

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/StructurallyValidated.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/StructurallyValidated.kt
@@ -1,0 +1,7 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+
+interface StructurallyValidated {
+  val problems: List<PluginProblem>
+}

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
@@ -128,8 +128,12 @@ class HtmlResultPrinter(
           printShortAndFullDescriptionItems("Override-only API usages", overrideOnlyMethodUsages) { it.shortDescription to it.fullDescription }
           if (pluginStructureWarnings.isNotEmpty()) {
             printShortAndFullDescription("Plugin structure defects") {
-              pluginStructureWarnings.forEach {
-                +it.message
+              ul {
+                pluginStructureWarnings.forEach {
+                  li {
+                    +it.message
+                  }
+                }
               }
             }
           }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProvider.kt
@@ -29,11 +29,6 @@ interface PluginDetailsProvider {
   fun providePluginDetails(pluginInfo: PluginInfo, pluginFileLock: FileLock): Result
 
   /**
-   * Creates [PluginDetails] for existing plugin with warnings of the plugin structure.
-   */
-  fun providePluginDetails(pluginInfo: PluginInfo, idePlugin: IdePlugin, warnings: List<PluginProblem>): Result
-
-  /**
    * Represents possible results of [providing] [providePluginDetails] the [PluginDetails].
    */
   sealed class Result : Closeable {

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
@@ -14,6 +14,7 @@ import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExte
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.StructurallyValidated
 import com.jetbrains.plugin.structure.intellij.problems.UnableToReadPluginFile
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.files.FileLock
@@ -34,7 +35,7 @@ class PluginDetailsProviderImpl(private val extractDirectory: Path) : PluginDeta
             readPluginClasses(
               pluginInfo,
               plugin,
-              warnings,
+              plugin.problems,
               pluginFileLock
             )
           }
@@ -50,7 +51,9 @@ class PluginDetailsProviderImpl(private val extractDirectory: Path) : PluginDeta
   override fun providePluginDetails(
     pluginInfo: PluginInfo,
     idePlugin: IdePlugin
-  ) = readPluginClasses(pluginInfo, idePlugin, emptyList(), null)
+  ): PluginDetailsProvider.Result {
+    return readPluginClasses(pluginInfo, idePlugin, idePlugin.problems, null)
+  }
 
   private fun readPluginClasses(
     pluginInfo: PluginInfo,
@@ -77,5 +80,8 @@ class PluginDetailsProviderImpl(private val extractDirectory: Path) : PluginDeta
       )
     )
   }
+
+  private val IdePlugin.problems: List<PluginProblem>
+    get() = if (this is StructurallyValidated) this.problems else emptyList()
 
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
@@ -52,13 +52,6 @@ class PluginDetailsProviderImpl(private val extractDirectory: Path) : PluginDeta
     idePlugin: IdePlugin
   ) = readPluginClasses(pluginInfo, idePlugin, emptyList(), null)
 
-  override fun providePluginDetails(
-    pluginInfo: PluginInfo,
-    idePlugin: IdePlugin,
-    warnings: List<PluginProblem>
-  ) = readPluginClasses(pluginInfo, idePlugin, warnings, null)
-
-
   private fun readPluginClasses(
     pluginInfo: PluginInfo,
     idePlugin: IdePlugin,

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputTest.kt
@@ -1,0 +1,237 @@
+package com.jetbrains.pluginverifier.output
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
+import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
+import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.PluginVerificationTarget
+import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.DependencyNode
+import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
+import com.jetbrains.pluginverifier.jdk.JdkVersion
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.results.hierarchy.ClassHierarchy
+import com.jetbrains.pluginverifier.results.instruction.Instruction
+import com.jetbrains.pluginverifier.results.location.ClassLocation
+import com.jetbrains.pluginverifier.results.location.MethodLocation
+import com.jetbrains.pluginverifier.results.location.toReference
+import com.jetbrains.pluginverifier.results.modifiers.Modifiers
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.results.problems.MethodNotFoundProblem
+import com.jetbrains.pluginverifier.results.problems.SuperInterfaceBecameClassProblem
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.results.reference.MethodReference
+import com.jetbrains.pluginverifier.tasks.InvalidPluginFile
+import com.jetbrains.pluginverifier.usages.experimental.ExperimentalClassUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalClassUsage
+import com.jetbrains.pluginverifier.usages.nonExtendable.NonExtendableTypeInherited
+import com.jetbrains.pluginverifier.warnings.PluginStructureWarning
+import org.junit.Assert.assertEquals
+import java.io.StringWriter
+import kotlin.io.path.Path
+
+const val PLUGIN_ID = "pluginId"
+const val PLUGIN_VERSION = "1.0"
+
+typealias VerifiedPluginHandler = (PluginVerificationResult.Verified) -> Unit
+
+open class BaseOutputTest<T : ResultPrinter> {
+  private val pluginInfo = mockPluginInfo()
+  private val verificationTarget = PluginVerificationTarget.IDE(IdeVersion.createIdeVersion("232"), JdkVersion("11", null))
+
+  protected lateinit var out: StringWriter
+  protected lateinit var resultPrinter: T
+
+  fun interface VerifiedPluginWithPrinterRunner<T, R> {
+    fun run(resultPrinter: T, result: R)
+  }
+
+  open fun setUp() {
+    out = StringWriter()
+  }
+
+  private val dependenciesGraph: DependenciesGraph = DependenciesGraph(
+        verifiedPlugin = DependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+        vertices = emptyList(),
+        edges = emptyList(),
+        missingDependencies = emptyMap())
+
+  open fun `when plugin is compatible`(testRunner: VerifiedPluginHandler) {
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph))
+  }
+
+  open fun `when plugin has compatibility warnings`(testRunner: VerifiedPluginHandler) {
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, mockCompatibilityProblems()))
+  }
+
+  open fun `when plugin has structural problems`(testRunner: VerifiedPluginHandler) {
+    val structureWarnings = setOf(
+      PluginStructureWarning(NoModuleDependencies(IdePluginManager.PLUGIN_XML))
+    )
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, pluginStructureWarnings = structureWarnings))
+  }
+
+  open fun `when plugin has internal API usage problems`(testRunner: VerifiedPluginHandler) {
+    val internalApiUsages = setOf(
+      InternalClassUsage(ClassReference("com.jetbrains.InternalClass"), internalApiClassLocation, mockMethodLocationInSampleStuffFactory)
+    )
+
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, internalApiUsages = internalApiUsages))
+  }
+
+  open fun `when plugin has non-extendable API usages problems`(testRunner: VerifiedPluginHandler) {
+    val nonExtendableClass = ClassLocation("NonExtendableClass", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+    val extendingClass = ClassLocation("ExtendingClass", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+
+    val nonExtendableApiUsages = setOf(
+      NonExtendableTypeInherited(nonExtendableClass, extendingClass)
+    )
+
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, nonExtendableApiUsages = nonExtendableApiUsages))
+  }
+
+  open fun `when plugin has experimental API usage problems`(testRunner: VerifiedPluginHandler) {
+    val experimentalClass = ClassLocation("ExperimentalClass", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+    val extendingClass = ClassLocation("ExtendingClass", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+    val usageLocation = MethodLocation(
+      extendingClass,
+      "someMethod",
+      "()V",
+      emptyList(),
+      null,
+      Modifiers.of(Modifiers.Modifier.PUBLIC)
+    )
+
+    val experimentalApiUsages = setOf(
+      ExperimentalClassUsage(experimentalClass.toReference(), experimentalClass, usageLocation)
+    )
+
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, experimentalApiUsages = experimentalApiUsages))
+  }
+
+  open fun `when plugin has missing dependencies`(testRunner: VerifiedPluginHandler) {
+    val pluginDependency = DependencyNode(PLUGIN_ID, PLUGIN_VERSION)
+    val expectedDependency = MissingDependency(PluginDependencyImpl("MissingPlugin", true, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
+
+    val dependenciesGraph = DependenciesGraph(
+      verifiedPlugin = pluginDependency,
+      vertices = emptyList(),
+      edges = emptyList(),
+      missingDependencies = mapOf(pluginDependency to setOf(expectedDependency))
+    )
+
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph))
+  }
+
+  open fun `when plugin is dynamic`(testRunner: VerifiedPluginHandler) {
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, dynamicPluginStatus = DynamicPluginStatus.MaybeDynamic))
+  }
+
+  open fun `when plugin is dynamic and has structural warnings`(testRunner: VerifiedPluginHandler) {
+    val structureWarnings = setOf(
+      PluginStructureWarning(NoModuleDependencies(IdePluginManager.PLUGIN_XML))
+    )
+    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph,
+      dynamicPluginStatus = DynamicPluginStatus.MaybeDynamic,
+      pluginStructureWarnings = structureWarnings
+    ))
+  }
+
+  open fun `when plugin has structural problems with invalid plugin ID`(testRunner: VerifiedPluginWithPrinterRunner<T, List<InvalidPluginFile>>) {
+    val pluginId = "com.example.intellij"
+    val prefix = "com.example"
+    val invalidPluginFiles = listOf(
+      InvalidPluginFile(Path("plugin.zip"), listOf(ForbiddenPluginIdPrefix(pluginId, prefix)))
+    )
+
+    testRunner.run(resultPrinter, invalidPluginFiles)
+  }
+
+  fun output() = out.buffer.toString()
+
+  private fun printResults(verificationResult: PluginVerificationResult) {
+    resultPrinter.printResults(listOf(verificationResult))
+  }
+
+  fun assertOutput(expected: String) {
+    assertEquals(expected, output())
+  }
+
+  private fun VerifiedPluginHandler.runTest(verificationResult: PluginVerificationResult.Verified) {
+    printResults(verificationResult)
+    this(verificationResult)
+  }
+}
+
+private fun mockPluginInfo(): PluginInfo =
+  object : PluginInfo(PLUGIN_ID, PLUGIN_ID, PLUGIN_VERSION, null, null, null) {}
+
+private fun mockCompatibilityProblems(): Set<CompatibilityProblem> =
+  setOf(superInterfaceBecameClassProblem(), superInterfaceBecameClassProblemInOtherLocation(), methodNotFoundProblem(), methodNotFoundProblemInSampleStuffFactoryClass())
+
+private fun superInterfaceBecameClassProblem(): SuperInterfaceBecameClassProblem {
+  val child = ClassLocation("com.jetbrains.plugin.Child", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+  val clazz = ClassLocation("com.jetbrains.plugin.Parent", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+  return SuperInterfaceBecameClassProblem(child, clazz)
+}
+
+private fun superInterfaceBecameClassProblemInOtherLocation(): SuperInterfaceBecameClassProblem {
+  val child = ClassLocation("com.jetbrains.plugin.pkg.Child", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+  val clazz = ClassLocation("com.jetbrains.plugin.pkg.Parent", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+  return SuperInterfaceBecameClassProblem(child, clazz)
+}
+
+private val javaLangObjectClassHierarchy = ClassHierarchy(
+  "java/lang/Object",
+  false,
+  null,
+  emptyList()
+)
+
+private val sampleStuffFactoryLocation = ClassLocation("SampleStuffFactory", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+private val internalApiClassLocation = ClassLocation("InternalApiRegistrar", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin)
+
+private val mockMethodLocationInSampleStuffFactory = MethodLocation(
+  sampleStuffFactoryLocation,
+  "produceStuff",
+  "()V",
+  emptyList(),
+  null,
+  Modifiers.of(Modifiers.Modifier.PUBLIC)
+)
+
+private fun methodNotFoundProblem(): MethodNotFoundProblem {
+  val deletedClassRef = ClassReference("org/some/deleted/Class")
+  val referencingMethodLocation = MethodLocation(
+    ClassLocation("SomeClassUsingDeletedClass", null, Modifiers.of(Modifiers.Modifier.PUBLIC), SomeFileOrigin),
+    "someMethodReferencingDeletedClass",
+    "()V",
+    emptyList(),
+    null,
+    Modifiers.of(Modifiers.Modifier.PUBLIC)
+  )
+  return MethodNotFoundProblem(
+    MethodReference(deletedClassRef, "foo", "()V"),
+    referencingMethodLocation,
+    Instruction.INVOKE_VIRTUAL,
+    javaLangObjectClassHierarchy
+  )
+}
+
+private fun methodNotFoundProblemInSampleStuffFactoryClass(): MethodNotFoundProblem {
+  val deletedClassRef = ClassReference("org/some/deleted/Class")
+  return MethodNotFoundProblem(
+    MethodReference(deletedClassRef, "foo", "()V"),
+    mockMethodLocationInSampleStuffFactory,
+    Instruction.INVOKE_VIRTUAL,
+    javaLangObjectClassHierarchy
+  )
+}
+
+private object SomeFileOrigin : FileOrigin {
+  override val parent: FileOrigin? = null
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputTest.kt
@@ -1,0 +1,164 @@
+package com.jetbrains.pluginverifier.output.stream
+
+import com.jetbrains.pluginverifier.output.BaseOutputTest
+import org.junit.Before
+import org.junit.Test
+import java.io.PrintWriter
+
+class StreamOutputTest : BaseOutputTest<WriterResultPrinter>() {
+  @Before
+  override fun setUp() {
+    super.setUp()
+    resultPrinter = WriterResultPrinter(PrintWriter(out))
+  }
+
+  @Test
+  fun `plugin is compatible`() {
+    `when plugin is compatible` {
+      val expected = """
+      Plugin pluginId 1.0 against 232.0: Compatible
+
+      
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has compatibility warnings`() {
+    `when plugin has compatibility warnings` {
+      val expected = """
+        Plugin pluginId 1.0 against 232.0: 4 compatibility problems
+        Compatibility problems (4): 
+            #Incompatible change of super interface com.jetbrains.plugin.Parent to class
+                Class com.jetbrains.plugin.Child has a *super interface* com.jetbrains.plugin.Parent which is actually a *class*. This can lead to **IncompatibleClassChangeError** exception at runtime.
+            #Incompatible change of super interface com.jetbrains.plugin.pkg.Parent to class
+                Class com.jetbrains.plugin.pkg.Child has a *super interface* com.jetbrains.plugin.pkg.Parent which is actually a *class*. This can lead to **IncompatibleClassChangeError** exception at runtime.
+            #Invocation of unresolved method org.some.deleted.Class.foo() : void
+                Method SomeClassUsingDeletedClass.someMethodReferencingDeletedClass() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
+                Method SampleStuffFactory.produceStuff() : void contains an *invokevirtual* instruction referencing an unresolved method org.some.deleted.Class.foo() : void. This can lead to **NoSuchMethodError** exception at runtime.
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has structural problems`() {
+    `when plugin has structural problems` {
+      val expected = """
+          Plugin pluginId 1.0 against 232.0: Compatible. 1 plugin configuration defect
+          Plugin structure warnings (1): 
+              Invalid plugin descriptor 'plugin.xml'. The plugin configuration file does not include any module dependency tags. So, the plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. Please note that plugins should declare a dependency on `com.intellij.modules.platform` to indicate dependence on shared functionality.
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has internal API usage problems`() {
+    `when plugin has internal API usage problems` {
+      val expected = """
+          Plugin pluginId 1.0 against 232.0: Compatible. 1 usage of internal API
+          Internal API usages (1): 
+              #Internal class InternalApiRegistrar reference
+                  Internal class InternalApiRegistrar is referenced in SampleStuffFactory.produceStuff() : void. This class is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the class is not supposed to be used in client code.
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has non-extendable API usages problems`() {
+    `when plugin has non-extendable API usages problems` {
+      val expected = """
+        Plugin pluginId 1.0 against 232.0: Compatible. 1 non-extendable API usage violation
+        Non-extendable API usages (1): 
+            #Non-extendable class NonExtendableClass is extended
+                Non-extendable class NonExtendableClass is extended by ExtendingClass. This class is marked with @org.jetbrains.annotations.ApiStatus.NonExtendable, which indicates that the class is not supposed to be extended. See documentation of the @ApiStatus.NonExtendable for more info.
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has experimental API usage problems`() {
+    `when plugin has experimental API usage problems` {
+      val expected = """
+        Plugin pluginId 1.0 against 232.0: Compatible. 1 usage of experimental API
+        Experimental API usages (1): 
+            #Experimental API class ExperimentalClass reference
+                Experimental API class ExperimentalClass is referenced in ExtendingClass.someMethod() : void. This class can be changed in a future release leading to incompatibilities
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has missing dependencies`() {
+    `when plugin has missing dependencies` {
+      val expected = """
+          Plugin pluginId 1.0 against 232.0: Compatible
+          Missing dependencies: 
+              MissingPlugin (optional): Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin is dynamic`() {
+    `when plugin is dynamic` {
+      val expected = """
+          Plugin pluginId 1.0 against 232.0: Compatible
+          Dynamic Plugin Eligibility:
+              Plugin can probably be enabled or disabled without IDE restart
+
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has structural problems with invalid plugin ID`() {
+    `when plugin has structural problems with invalid plugin ID` { resultPrinter, result ->
+      resultPrinter.printInvalidPluginFiles(result)
+
+      val expected = """
+        The following files specified for the verification are not valid plugins:
+            plugin.zip
+                Invalid plugin descriptor 'id'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
+
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin is dynamic and has structural warnings`() {
+    `when plugin is dynamic and has structural warnings` {
+      val expected = """
+        Plugin pluginId 1.0 against 232.0: Compatible. 1 plugin configuration defect
+        Plugin structure warnings (1): 
+            Invalid plugin descriptor 'plugin.xml'. The plugin configuration file does not include any module dependency tags. So, the plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. Please note that plugins should declare a dependency on `com.intellij.modules.platform` to indicate dependence on shared functionality.
+        Dynamic Plugin Eligibility:
+            Plugin can probably be enabled or disabled without IDE restart
+
+
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.pluginverifier.tests.dependencies
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
@@ -137,20 +136,6 @@ class IdeDependencyFinderTest {
           pluginInfo,
           idePlugin,
           emptyList(),
-          IdePluginClassesLocations(
-            idePlugin,
-            Closeable { },
-            emptyMap()
-          ),
-          null
-        )
-      )
-
-      override fun providePluginDetails(pluginInfo: PluginInfo, idePlugin: IdePlugin, warnings: List<PluginProblem>) = PluginDetailsProvider.Result.Provided(
-        PluginDetails(
-          pluginInfo,
-          idePlugin,
-          warnings,
           IdePluginClassesLocations(
             idePlugin,
             Closeable { },


### PR DESCRIPTION
Pass structure warnings and structure unacceptable warnings to the verification reports.

This will show warnings in all outputs (HTML, Markdown, stdout).

For example:

```
Plugin com.github.novotnyr.plugin-service-preloading:1.0-SNAPSHOT against IE-203.7717.75: Compatible. 2 plugin configuration defects
Plugin structure warnings (2): 
    Invalid plugin descriptor 'plugin.xml'. The change-notes parameter contains the default value 'Add change notes here' or 'most HTML tags may be used'.
    Service preloading is deprecated in the <com.intellij.applicationService> element. Remove the 'preload' attribute and migrate to listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html.
Dynamic Plugin Eligibility:
    Plugin can probably be enabled or disabled without IDE restart
```

See [MP-6458](https://youtrack.jetbrains.com/issue/MP-6458) Structure Warnings are not reported in CLI outputs

- Make default IntelliJ plugin implementation carry structural problems
- Improve presentation of plugin defects in the HTML output
- Plugin Detail Provider will resolve available plugin problems from plugin implementation
- Remove unused methods from Plugin Detail Provider which handle plugin problems in a manual way