### PR TITLE
Recognize covariant return types when detecting method overrides

### DIFF
--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
@@ -34,11 +34,11 @@ const val JAVA_LANG_OBJECT: BinaryClassName = "java/lang/Object"
  * the method in the argument
  */
 fun Method.isOverriding(possiblyParentMethod: Method, resolver: Resolver): Boolean {
-  return nonStaticAndNonFinal(possiblyParentMethod)
-    && sameName(this, possiblyParentMethod)
+  return sameName(this, possiblyParentMethod)
+    && nonStaticAndNonFinal(possiblyParentMethod)
+    && sameOrBroaderVisibility(this, possiblyParentMethod)
     && sameParameters(this, possiblyParentMethod)
     && sameOrCovariantReturnType(this, possiblyParentMethod, resolver)
-    && sameOrBroaderVisibility(this, possiblyParentMethod)
 }
 
 data class MethodInClass(val method: Method, val klass: ClassFile)

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
@@ -32,6 +32,14 @@ fun Method.isOverriding(anotherMethod: Method): Boolean =
     && sameParametersAndReturnType(this, anotherMethod)
     && sameOrBroaderVisibility(this, anotherMethod)
 
+fun Method.isOverriding(possiblyParentMethod: Method, resolver: Resolver): Boolean {
+  return nonStaticAndNonFinal(possiblyParentMethod)
+    && sameName(this, possiblyParentMethod)
+    && sameParameters(this, possiblyParentMethod)
+    && sameOrCovariantReturnType(this, possiblyParentMethod, resolver)
+    && sameOrBroaderVisibility(this, possiblyParentMethod)
+}
+
 data class MethodInClass(val method: Method, val klass: ClassFile)
 
 private fun nonStaticAndNonFinal(anotherMethod: Method) = !anotherMethod.isStatic && !anotherMethod.isFinal
@@ -115,14 +123,6 @@ fun MethodInsnNode.matches(method: Method): Boolean =
 fun Method.returnType(): BinaryClassName {
   val returnType: Type = Type.getReturnType(this.descriptor)
   return returnType.className.toBinaryClassName()
-}
-
-fun Method.doesOverride(possiblyParentMethod: Method, resolver: Resolver): Boolean {
-  return nonStaticAndNonFinal(possiblyParentMethod)
-    && sameName(this, possiblyParentMethod)
-    && sameParameters(this, possiblyParentMethod)
-    && sameOrCovariantReturnType(this, possiblyParentMethod, resolver)
-    && sameOrBroaderVisibility(this, possiblyParentMethod)
 }
 
 fun sameOrCovariantReturnType(method: Method, possiblyParentMethod: Method, resolver: Resolver): Boolean {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
@@ -24,7 +24,7 @@ class BridgeMethodOverrideUsageFilter(private val nonBridgeMethodApiUsageFilterD
                                      callerMethod: Method,
                                      context: VerificationContext): Boolean {
     return if (callerMethod.isBridgeMethod) {
-      allowBridgeMethodInvocation(invokedMethod, invocationInstruction, callerMethod, context)
+      allowBridgeMethodInvocation(invokedMethod, callerMethod, context)
     } else {
       nonBridgeMethodApiUsageFilterDelegate.allowMethodInvocation(
         invokedMethod,
@@ -36,7 +36,6 @@ class BridgeMethodOverrideUsageFilter(private val nonBridgeMethodApiUsageFilterD
 
   //
   private fun allowBridgeMethodInvocation(invokedMethod: Method,
-                                          invocationInstruction: AbstractInsnNode,
                                           callerMethod: Method,
                                           context: VerificationContext): Boolean {
     return invokedMethod.doesOverride(callerMethod, context.classResolver)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
@@ -7,7 +7,7 @@ package com.jetbrains.pluginverifier.usages.overrideOnly
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
-import com.jetbrains.pluginverifier.verifiers.resolution.doesOverride
+import com.jetbrains.pluginverifier.verifiers.resolution.isOverriding
 import org.objectweb.asm.tree.AbstractInsnNode
 
 /**
@@ -38,6 +38,6 @@ class BridgeMethodOverrideUsageFilter(private val nonBridgeMethodApiUsageFilterD
   private fun allowBridgeMethodInvocation(invokedMethod: Method,
                                           callerMethod: Method,
                                           context: VerificationContext): Boolean {
-    return invokedMethod.doesOverride(callerMethod, context.classResolver)
+    return invokedMethod.isOverriding(callerMethod, context.classResolver)
   }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/BridgeMethodOverrideUsageFilter.kt
@@ -1,0 +1,44 @@
+ /*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.usages.overrideOnly
+
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.doesOverride
+import org.objectweb.asm.tree.AbstractInsnNode
+
+/**
+ * Usage filter for synthetic bridge method generated in specific inheritance scenarios
+ * for parameterized classes with generics.
+ *
+ * @param nonBridgeMethodApiUsageFilterDelegate a delegate [ApiUsageFilter][API Usage filter] that handles non-bridge methods
+ *
+ * See [Java Generics FAQ](http://www.angelikalanger.com/GenericsFAQ/FAQSections/TechnicalDetails.html#FAQ103)
+ */
+class BridgeMethodOverrideUsageFilter(private val nonBridgeMethodApiUsageFilterDelegate: ApiUsageFilter) : ApiUsageFilter {
+  override fun allowMethodInvocation(invokedMethod: Method,
+                                     invocationInstruction: AbstractInsnNode,
+                                     callerMethod: Method,
+                                     context: VerificationContext): Boolean {
+    return if (callerMethod.isBridgeMethod) {
+      allowBridgeMethodInvocation(invokedMethod, invocationInstruction, callerMethod, context)
+    } else {
+      nonBridgeMethodApiUsageFilterDelegate.allowMethodInvocation(
+        invokedMethod,
+        invocationInstruction,
+        callerMethod,
+        context)
+    }
+  }
+
+  //
+  private fun allowBridgeMethodInvocation(invokedMethod: Method,
+                                          invocationInstruction: AbstractInsnNode,
+                                          callerMethod: Method,
+                                          context: VerificationContext): Boolean {
+    return invokedMethod.doesOverride(callerMethod, context.classResolver)
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
@@ -22,7 +22,7 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
 
   private val allowedOverrideOnlyUsageFilter = CompositeApiUsageFilter(
     CallOfSuperConstructorOverrideOnlyAllowedUsageFilter(),
-    DelegateCallOnOverrideOnlyUsageFilter(),
+    DelegateCallOnOverrideOnlyUsageFilter().withBridgeMethodSupport(),
     SuperclassCallOnOverrideOnlyUsageFilter()
   )
 
@@ -100,6 +100,10 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
   private companion object {
     const val overrideOnlyAnnotationName = "org/jetbrains/annotations/ApiStatus\$OverrideOnly"
   }
+
+  private fun DelegateCallOnOverrideOnlyUsageFilter.withBridgeMethodSupport() =
+    BridgeMethodOverrideUsageFilter(this)
 }
+
 
 

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public interface DataIndexer<Key, Value, Data> {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
@@ -1,5 +1,6 @@
 package com.intellij.util.indexing;
 
+@SuppressWarnings("unused")
 public interface DataIndexer<Key, Value, Data> {
     // intentionally simplified
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/FileBasedIndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/FileBasedIndexExtension.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public abstract class FileBasedIndexExtension<K, V> extends IndexExtension<K, V, FileContent> {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/FileContent.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/FileContent.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public interface FileContent {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
@@ -4,5 +4,6 @@ import org.jetbrains.annotations.NotNull;
 
 public abstract class IndexExtension<Key, Value, Input> {
   public abstract @NotNull IndexId<Key, Value> getName();
+  @SuppressWarnings("unused")
   public abstract @NotNull DataIndexer<Key, Value, Input> getIndexer();
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
@@ -1,0 +1,8 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.NotNull;
+
+public abstract class IndexExtension<Key, Value, Input> {
+  public abstract @NotNull IndexId<Key, Value> getName();
+  public abstract @NotNull DataIndexer<Key, Value, Input> getIndexer();
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexId.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexId.java
@@ -1,5 +1,6 @@
 package com.intellij.util.indexing;
 
+@SuppressWarnings("unused")
 public class IndexId<K, V> {
 
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexId.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/IndexId.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public class IndexId<K, V> {
+
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/SingleEntryFileBasedIndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/SingleEntryFileBasedIndexExtension.java
@@ -1,0 +1,12 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.OverrideOnly
+public abstract class SingleEntryFileBasedIndexExtension<V> extends FileBasedIndexExtension<Integer, V>{
+
+    @NotNull
+    @Override
+    public abstract SingleEntryIndexer<V> getIndexer();
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/SingleEntryIndexer.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/util/indexing/SingleEntryIndexer.java
@@ -1,0 +1,8 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.OverrideOnly
+public abstract class SingleEntryIndexer<V> implements DataIndexer<Integer, V, FileContent>{
+  // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/DataIndexer.java
@@ -1,0 +1,6 @@
+package com.intellij.util.indexing;
+
+@SuppressWarnings("unused")
+public interface DataIndexer<Key, Value, Data> {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/FileBasedIndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/FileBasedIndexExtension.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public abstract class FileBasedIndexExtension<K, V> extends IndexExtension<K, V, FileContent> {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/FileContent.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/FileContent.java
@@ -1,0 +1,5 @@
+package com.intellij.util.indexing;
+
+public interface FileContent {
+    // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
@@ -1,0 +1,8 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.NotNull;
+
+public abstract class IndexExtension<Key, Value, Input> {
+  public abstract @NotNull IndexId<Key, Value> getName();
+  public abstract @NotNull DataIndexer<Key, Value, Input> getIndexer();
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexExtension.java
@@ -3,6 +3,8 @@ package com.intellij.util.indexing;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class IndexExtension<Key, Value, Input> {
+  @SuppressWarnings("unused")
   public abstract @NotNull IndexId<Key, Value> getName();
+  @SuppressWarnings("unused")
   public abstract @NotNull DataIndexer<Key, Value, Input> getIndexer();
 }

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexId.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/IndexId.java
@@ -1,0 +1,6 @@
+package com.intellij.util.indexing;
+
+@SuppressWarnings("unused")
+public class IndexId<K, V> {
+
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/SingleEntryFileBasedIndexExtension.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/SingleEntryFileBasedIndexExtension.java
@@ -1,0 +1,12 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.OverrideOnly
+public abstract class SingleEntryFileBasedIndexExtension<V> extends FileBasedIndexExtension<Integer, V> {
+
+    @NotNull
+    @Override
+    public abstract SingleEntryIndexer<V> getIndexer();
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/SingleEntryIndexer.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/util/indexing/SingleEntryIndexer.java
@@ -1,0 +1,8 @@
+package com.intellij.util.indexing;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.OverrideOnly
+public abstract class SingleEntryIndexer<V> implements DataIndexer<Integer, V, FileContent>{
+  // intentionally simplified
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
@@ -9,11 +9,6 @@ public abstract class AbstractFileIndex<T> extends SingleEntryFileBasedIndexExte
         // no implementation
     };
 
-    /*expected(OVERRIDE_ONLY)
-    Invocation of override-only method mock.plugin.overrideOnly.AbstractFileIndex.getIndexer()
-
-    Override-only method mock.plugin.overrideOnly.AbstractFileIndex.getIndexer() is invoked in mock.plugin.overrideOnly.AbstractFileIndex.getIndexer() : DataIndexer. This method is marked with @org.jetbrains.annotations.ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
-    */
     @NotNull
     @Override
     public SingleEntryIndexer<T> getIndexer() {

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
@@ -1,0 +1,22 @@
+package mock.plugin.overrideOnly;
+
+import com.intellij.util.indexing.SingleEntryFileBasedIndexExtension;
+import com.intellij.util.indexing.SingleEntryIndexer;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractFileIndex<T> extends SingleEntryFileBasedIndexExtension<T> {
+    private final SingleEntryIndexer<T> indexer = new SingleEntryIndexer<T>() {
+        // no implementation
+    };
+
+    /*expected(OVERRIDE_ONLY)
+    Invocation of override-only method mock.plugin.overrideOnly.AbstractFileIndex.getIndexer()
+
+    Override-only method mock.plugin.overrideOnly.AbstractFileIndex.getIndexer() is invoked in mock.plugin.overrideOnly.AbstractFileIndex.getIndexer() : DataIndexer. This method is marked with @org.jetbrains.annotations.ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
+    */
+    @NotNull
+    @Override
+    public SingleEntryIndexer<T> getIndexer() {
+        return indexer;
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/AbstractFileIndex.java
@@ -5,7 +5,7 @@ import com.intellij.util.indexing.SingleEntryIndexer;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractFileIndex<T> extends SingleEntryFileBasedIndexExtension<T> {
-    private final SingleEntryIndexer<T> indexer = new SingleEntryIndexer<T>() {
+    private final SingleEntryIndexer<T> indexer = new SingleEntryIndexer<>() {
         // no implementation
     };
 

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Child.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Child.java
@@ -1,0 +1,8 @@
+package mock.plugin.overrideOnly.covariant;
+
+public class Child extends Parent {
+    @Override
+    public ChildResult provide() {
+        return new ChildResult();
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/ChildResult.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/ChildResult.java
@@ -1,0 +1,5 @@
+package mock.plugin.overrideOnly.covariant;
+
+public class ChildResult extends ParentResult {
+    // empty class
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Parent.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Parent.java
@@ -1,0 +1,7 @@
+package mock.plugin.overrideOnly.covariant;
+
+public class Parent {
+    public ParentResult provide() {
+        return new ParentResult();
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Parent.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/Parent.java
@@ -1,6 +1,7 @@
 package mock.plugin.overrideOnly.covariant;
 
 public class Parent {
+    @SuppressWarnings("unused")
     public ParentResult provide() {
         return new ParentResult();
     }

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/ParentResult.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/covariant/ParentResult.java
@@ -1,0 +1,5 @@
+package mock.plugin.overrideOnly.covariant;
+
+public class ParentResult {
+    // empty class
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
@@ -111,7 +111,7 @@ class MethodsTest {
     val arrayListToString = resolver.findMethodInClass(abstractCollectionBinaryName, toStringDesc)
     val objectToString = resolver.findMethodInClass(objectBinaryName, toStringDesc)
 
-    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
+    assertTrue(arrayListToString.isOverriding(objectToString, resolver))
   }
 
   @Test
@@ -128,7 +128,7 @@ class MethodsTest {
     val arrayListToString = resolver.findMethodInClass(childName, getIndexerInChild)
     val objectToString = resolver.findMethodInClass(parentName, getIndexerInParent)
 
-    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
+    assertTrue(arrayListToString.isOverriding(objectToString, resolver))
   }
 
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
@@ -5,8 +5,10 @@ import com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator
 import com.jetbrains.pluginverifier.tests.findMockPluginJarPath
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Test
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodNode
 import java.nio.file.Path
 
 class MethodsTest {
@@ -37,6 +39,145 @@ class MethodsTest {
     }
   }
 
+  @Test
+  fun `method parameters match`() {
+    val resolver = createJdkResolver()
+    val arrayListBinaryName = "java/util/ArrayList"
+    val arrayList = resolver.resolveClass(arrayListBinaryName)
+    val linkedListBinaryName = "java/util/LinkedList"
+    val linkedList = resolver.resolveClass(linkedListBinaryName)
+    if (arrayList !is ResolutionResult.Found) {
+      fail("Class '$arrayListBinaryName' not found in the mock plugin by resolver")
+      return
+    }
+    if (linkedList !is ResolutionResult.Found) {
+      fail("Class '$linkedListBinaryName' not found in the mock plugin by resolver")
+      return
+    }
+    val methodName = "set"
+    val arrayListSetAsmMethod = arrayList.findMethodByName(methodName)
+    val linkedListSetAsmMethod = linkedList.findMethodByName(methodName)
+
+
+    if (arrayListSetAsmMethod == null) {
+      fail("Method '$methodName' not found in '$arrayListBinaryName'")
+      return
+    }
+
+    if (linkedListSetAsmMethod == null) {
+      fail("Method '$methodName' not found in '$linkedListBinaryName'")
+      return
+    }
+    val arrayListMethod = MethodAsm(arrayList.asClassFile(), arrayListSetAsmMethod)
+    val linkedListSetMethod = MethodAsm(linkedList.asClassFile(), linkedListSetAsmMethod)
+
+    sameParameters(arrayListMethod, linkedListSetMethod)
+  }
+
+  @Test
+  fun `method parameter count does not match`() {
+    val arrayListBinaryName = "java/util/ArrayList"
+
+    val resolver = createJdkResolver()
+    // E set(int,E)
+    val set = resolver.findMethodInClass(arrayListBinaryName, "(ILjava/lang/Object;)Ljava/lang/Object;")
+    // int size()
+    val size = resolver.findMethodInClass(arrayListBinaryName, "()I")
+
+    assertFalse(sameParameters(set, size))
+  }
+
+  @Test
+  fun `method parameters do not match`() {
+    val arrayListBinaryName = "java/util/ArrayList"
+
+    val resolver = createJdkResolver()
+    // E set(int,E)
+    val set = resolver.findMethodInClass(arrayListBinaryName, "(ILjava/lang/Object;)Ljava/lang/Object;")
+    // public List<E> subList(int fromIndex, int toIndex)
+    val subList = resolver.findMethodInClass(arrayListBinaryName, "(II)Ljava/util/List;")
+
+    assertFalse(sameParameters(set, subList))
+  }
+
+  @Test
+  fun `method parameters override with the same parameters`() {
+    val abstractCollectionBinaryName = "java/util/AbstractCollection"
+    val objectBinaryName = "java/lang/Object"
+
+    val toStringDesc = "()Ljava/lang/String;"
+
+    val resolver = createJdkResolver()
+    val arrayListToString = resolver.findMethodInClass(abstractCollectionBinaryName, toStringDesc)
+    val objectToString = resolver.findMethodInClass(objectBinaryName, toStringDesc)
+
+    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
+  }
+
+  @Test
+  fun `method parameters override with the covariancy`() {
+    val pkg = "mock/plugin/overrideOnly/covariant"
+
+    val childName: BinaryClassName = "$pkg/Child"
+    val parentName: BinaryClassName = "$pkg/Parent"
+
+    val getIndexerInChild = "()L$pkg/ChildResult;"
+    val getIndexerInParent = "()L$pkg/ParentResult;"
+
+    val resolver = createTestResolver()
+    val arrayListToString = resolver.findMethodInClass(childName, getIndexerInChild)
+    val objectToString = resolver.findMethodInClass(parentName, getIndexerInParent)
+
+    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
+  }
+
+
+  /*
+  @Test
+  fun `method parameters override with the covariancy`() {
+    val childName: BinaryClassName = "com/intellij/util/indexing/SingleEntryFileBasedIndexExtension"
+    val parentName: BinaryClassName = "com/intellij/util/indexing/IndexExtension"
+
+    val getIndexerInChild = "()Lcom/intellij/util/indexing/SingleEntryIndexer;"
+    val getIndexerInParent = "()Lcom/intellij/util/indexing/DataIndexer;"
+
+    val resolver = mockResolver
+    val arrayListToString = resolver.findMethodInClass(childName, getIndexerInChild)
+    val objectToString = resolver.findMethodInClass(parentName, getIndexerInParent)
+
+    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
+  }
+
+   */
+
+  @Throws(AssertionError::class)
+  private fun Resolver.findMethodInClass(cls: BinaryClassName, descriptor: String): MethodAsm {
+    val resolutionResult = resolveClass(cls)
+    if (resolutionResult !is ResolutionResult.Found) {
+      throw AssertionError("Class '$cls' not found in the mock plugin by resolver")
+    }
+    val methodNode = resolutionResult.findMethodByDesc(descriptor)
+      ?: throw AssertionError("Method '$descriptor' not found in '$cls'")
+
+    return MethodAsm(resolutionResult.asClassFile(), methodNode)
+  }
+
+  private fun ResolutionResult.Found<ClassNode>.findMethodByName(methodName: String): MethodNode? {
+    return value.methods.find {
+      it.name == methodName
+    }
+  }
+
+  private fun ResolutionResult.Found<ClassNode>.findMethodByDesc(methodDesc: String): MethodNode? {
+    return value.methods.find {
+      it.desc == methodDesc
+    }
+  }
+
+  private fun ResolutionResult.Found<ClassNode>.asClassFile(): ClassFile {
+    return ClassFileAsm(value, fileOrigin)
+  }
+
   private fun createTestResolver(): Resolver =
     JarFileResolver(
       findMockPluginJarPath(),
@@ -45,4 +186,11 @@ class MethodsTest {
         override val parent: FileOrigin? = null
       }
     )
+
+  private fun createJdkResolver(): Resolver {
+    val javaHome = System.getProperty("java.home")
+    val jdkDescriptor = JdkDescriptorCreator.createJdkDescriptor(Path.of(javaHome))
+
+    return jdkDescriptor.jdkResolver
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
@@ -94,7 +94,7 @@ class MethodsTest {
     val resolver = createJdkResolver()
     // E set(int,E)
     val set = resolver.findMethodInClass(arrayListBinaryName, "(ILjava/lang/Object;)Ljava/lang/Object;")
-    // public List<E> subList(int fromIndex, int toIndex)
+    // List<E> subList(int fromIndex, int toIndex)
     val subList = resolver.findMethodInClass(arrayListBinaryName, "(II)Ljava/util/List;")
 
     assertFalse(sameParameters(set, subList))
@@ -130,25 +130,6 @@ class MethodsTest {
 
     assertTrue(arrayListToString.isOverriding(objectToString, resolver))
   }
-
-
-  /*
-  @Test
-  fun `method parameters override with the covariancy`() {
-    val childName: BinaryClassName = "com/intellij/util/indexing/SingleEntryFileBasedIndexExtension"
-    val parentName: BinaryClassName = "com/intellij/util/indexing/IndexExtension"
-
-    val getIndexerInChild = "()Lcom/intellij/util/indexing/SingleEntryIndexer;"
-    val getIndexerInParent = "()Lcom/intellij/util/indexing/DataIndexer;"
-
-    val resolver = mockResolver
-    val arrayListToString = resolver.findMethodInClass(childName, getIndexerInChild)
-    val objectToString = resolver.findMethodInClass(parentName, getIndexerInParent)
-
-    assertTrue(arrayListToString.doesOverride(objectToString, resolver))
-  }
-
-   */
 
   @Throws(AssertionError::class)
   private fun Resolver.findMethodInClass(cls: BinaryClassName, descriptor: String): MethodAsm {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
@@ -121,14 +121,14 @@ class MethodsTest {
     val childName: BinaryClassName = "$pkg/Child"
     val parentName: BinaryClassName = "$pkg/Parent"
 
-    val getIndexerInChild = "()L$pkg/ChildResult;"
-    val getIndexerInParent = "()L$pkg/ParentResult;"
+    val descriptorInChild = "()L$pkg/ChildResult;"
+    val descriptorInParent = "()L$pkg/ParentResult;"
 
     val resolver = createTestResolver()
-    val arrayListToString = resolver.findMethodInClass(childName, getIndexerInChild)
-    val objectToString = resolver.findMethodInClass(parentName, getIndexerInParent)
+    val methodInChild = resolver.findMethodInClass(childName, descriptorInChild)
+    val methodInParent = resolver.findMethodInClass(parentName, descriptorInParent)
 
-    assertTrue(arrayListToString.isOverriding(objectToString, resolver))
+    assertTrue(methodInChild.isOverriding(methodInParent, resolver))
   }
 
   @Throws(AssertionError::class)


### PR DESCRIPTION
- Recognize covariant return types when detecting method overrides. For example, remember that `String foo()` might override `Object foo()` where `String extends Object`.
- Recognize synthetic [bridge methods](http://www.angelikalanger.com/GenericsFAQ/FAQSections/TechnicalDetails.html#FAQ103) when enumerating class methods. Bridge method is allowed to call an `@OverrideOnly` method, as it is a technical method to handle inheritance and generics.
- Reorganize method helper functions which detect overrides.
- Fix false positive in the Plugin Verifier that is connected with indexes.

See [MP-6438](https://youtrack.jetbrains.com/issue/MP-6438) 