### PR TITLE
Plugin ID and plugin name property fixes

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -815,7 +815,7 @@ internal class PluginCreator private constructor(
       else -> {
         val templateWord = PLUGIN_NAME_RESTRICTED_WORDS.find { name.contains(it, true) }
         if (templateWord != null) {
-          registerProblem(TemplateWordInPluginName(descriptorPath, templateWord))
+          registerProblem(TemplateWordInPluginName(descriptorPath, name, templateWord))
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
         verifyNewlines("name", name, descriptorPath, ::registerProblem)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -46,10 +46,11 @@ class TemplateWordInPluginName(
 
 class TemplateWordInPluginId(
   descriptorPath: String,
+  pluginId: String,
   templateWord: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The plugin id should not contain the word '$templateWord'."
+  detailedMessage = "The plugin ID '$pluginId' should not include the word '$templateWord'."
 ) {
   override val level
     get() = Level.WARNING

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -179,10 +179,11 @@ open class NonexistentReleaseInUntilBuild(
 
 
 class ForbiddenPluginIdPrefix(
+  descriptorPath: String,
   pluginId: String,
   prefix: String
 ) : InvalidDescriptorProblem(
-  descriptorPath = "id",
+  descriptorPath = descriptorPath,
   detailedMessage = "The plugin ID '$pluginId' has a prefix '$prefix' that is not allowed."
 ) {
   override val level

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -34,10 +34,11 @@ class DefaultChangeNotes(descriptorPath: String) : InvalidDescriptorProblem(
 
 class TemplateWordInPluginName(
   descriptorPath: String,
+  pluginName: String,
   templateWord: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The plugin name should not contain the word '$templateWord'."
+  detailedMessage = "The plugin name '$pluginName' should not include the word '$templateWord'."
 ) {
   override val level
     get() = Level.WARNING

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -43,7 +43,7 @@ class PluginIdVerifier {
     val id = plugin.id
     DEFAULT_ILLEGAL_PREFIXES
       .filter(id::startsWith)
-      .forEach { problemRegistrar.registerProblem(ForbiddenPluginIdPrefix(id, it)) }
+      .forEach { problemRegistrar.registerProblem(ForbiddenPluginIdPrefix(descriptorPath, id, it)) }
 
     id.split('.')
       .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.toLowerCase()) }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -47,7 +47,7 @@ class PluginIdVerifier {
 
     id.split('.')
       .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.toLowerCase()) }
-      .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, idComponent)) }
+      .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, id, idComponent)) }
   }
 
   private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -70,13 +70,14 @@ class PluginIdVerifierTest {
   @Test
   fun `plugin with product name in ID is disallowed`() {
     PRODUCT_ID_RESTRICTED_WORDS.forEach {
-      val plugin = plugin("vendor.$it.quickride", "Third Party Inc.")
+      val pluginId = "vendor.$it.quickride"
+      val plugin = plugin(pluginId, "Third Party Inc.")
 
       verifier.verify(plugin, DESCRIPTOR_PATH, problemRegistrar)
 
       Assert.assertEquals(1, problems.size)
       val problem = problems[0]
-      Assert.assertEquals("Invalid plugin descriptor 'plugin.xml'. The plugin id should not contain the word '$it'.", problem.message)
+      Assert.assertEquals("Invalid plugin descriptor 'plugin.xml'. The plugin ID '$pluginId' should not include the word '$it'.", problem.message)
 
       problems.clear()
     }
@@ -84,19 +85,20 @@ class PluginIdVerifierTest {
 
   @Test
   fun `plugin with multiple case-sensitive names in ID is disallowed`() {
-    val plugin = plugin("vendor.DataLore.DataGrip", "Third Party Inc.")
+    val pluginId = "vendor.DataLore.DataGrip"
+    val plugin = plugin(pluginId, "Third Party Inc.")
     verifier.verify(plugin, DESCRIPTOR_PATH, problemRegistrar)
 
     Assert.assertEquals(2, problems.size)
     val dataLoreProblem = problems[0]
     Assert.assertEquals(
-      "Invalid plugin descriptor 'plugin.xml'. The plugin id should not contain the word 'DataLore'.",
+      "Invalid plugin descriptor 'plugin.xml'. The plugin ID '$pluginId' should not include the word 'DataLore'.",
       dataLoreProblem.message
     )
 
     val dataGripProblem = problems[1]
     Assert.assertEquals(
-      "Invalid plugin descriptor 'plugin.xml'. The plugin id should not contain the word 'DataGrip'.",
+      "Invalid plugin descriptor 'plugin.xml'. The plugin ID '$pluginId' should not include the word 'DataGrip'.",
       dataGripProblem.message
     )
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -47,7 +47,7 @@ class PluginIdVerifierTest {
     Assert.assertEquals(1, problems.size)
     val problem = problems[0]
     Assert.assertEquals(
-      "Invalid plugin descriptor 'id'. The plugin ID '$illegalId' has a prefix 'org.jetbrains' that is not allowed.",
+      "Invalid plugin descriptor 'plugin.xml'. The plugin ID '$illegalId' has a prefix 'org.jetbrains' that is not allowed.",
       problem.message
     )
   }
@@ -62,7 +62,7 @@ class PluginIdVerifierTest {
     Assert.assertEquals(1, problems.size)
     val problem = problems[0]
     Assert.assertEquals(
-      "Invalid plugin descriptor 'id'. The plugin ID '$genericId' has a prefix 'com.example' that is not allowed.",
+      "Invalid plugin descriptor 'plugin.xml'. The plugin ID '$genericId' has a prefix 'com.example' that is not allowed.",
       problem.message
     )
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -159,12 +159,13 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
   @Test
   fun `plugin id has template word prefix`() {
     PRODUCT_ID_RESTRICTED_WORDS.forEach { product ->
+      val pluginId = "plugin.${product}.improved"
       val warning = `test valid plugin xml`(
         perfectXmlBuilder.modify {
-          id = "<id>plugin.${product}.improved</id>"
+          id = "<id>$pluginId</id>"
         }
       ).warnings.single()
-      assertEquals(TemplateWordInPluginId("plugin.xml", product), warning)
+      assertEquals(TemplateWordInPluginId(PLUGIN_XML, pluginId, product), warning)
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -183,12 +183,13 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
   @Test
   fun `plugin name contains template words`() {
     for (templateWord in PLUGIN_NAME_RESTRICTED_WORDS) {
+      val pluginName = "bla ${templateWord}bla"
       val warning = `test valid plugin xml`(
         perfectXmlBuilder.modify {
-          name = "<name>bla ${templateWord}bla</name>"
+          name = "<name>$pluginName</name>"
         }
       ).warnings.single()
-      assertEquals(TemplateWordInPluginName("plugin.xml", templateWord), warning)
+      assertEquals(TemplateWordInPluginName("plugin.xml", pluginName, templateWord), warning)
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -153,7 +153,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
         id = "<id>com.example.plugin</id>"
       },
     ).warnings.single()
-    assertEquals(ForbiddenPluginIdPrefix("com.example.plugin", "com.example"), warning)
+    assertEquals(ForbiddenPluginIdPrefix(PLUGIN_XML,"com.example.plugin", "com.example"), warning)
   }
 
   @Test

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
@@ -3,7 +3,15 @@ package com.jetbrains.pluginverifier.options
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.intellij.problems.*
+import com.jetbrains.plugin.structure.intellij.problems.ErroneousSinceBuild
+import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
+import com.jetbrains.plugin.structure.intellij.problems.LevelRemappingDefinitions
+import com.jetbrains.plugin.structure.intellij.problems.ProblemLevelRemappingManager
+import com.jetbrains.plugin.structure.intellij.problems.StandardLevel
+import com.jetbrains.plugin.structure.intellij.problems.SuspiciousUntilBuild
+import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
+import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName
+import com.jetbrains.plugin.structure.intellij.problems.levelRemappingFromClassPathJson
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.pluginverifier.options.SubmissionType.EXISTING
@@ -52,7 +60,7 @@ class PluginParsingConfigurationResolutionTest {
       levelRemappingFromClassPathJson())
 
     val problemsThatShouldBeIgnored = listOf(
-      ForbiddenPluginIdPrefix(pluginId, "some.forbidden.plugin.id"),
+      ForbiddenPluginIdPrefix(PLUGIN_XML, pluginId, "some.forbidden.plugin.id"),
       TemplateWordInPluginId(pluginId, "forbiddenTemplateWord"),
       TemplateWordInPluginName(pluginId, "forbiddenTemplateWord"),
     )
@@ -112,7 +120,7 @@ class PluginParsingConfigurationResolutionTest {
     val forbiddenPluginIdPrefix = "com.example"
     val forbiddenPluginId = "$forbiddenPluginIdPrefix.plugin"
     val plugin = MockIdePlugin(pluginId = forbiddenPluginId)
-    val pluginProblems = listOf(ForbiddenPluginIdPrefix(forbiddenPluginId, forbiddenPluginIdPrefix))
+    val pluginProblems = listOf(ForbiddenPluginIdPrefix(PLUGIN_XML, forbiddenPluginId, forbiddenPluginIdPrefix))
 
     val creationResult = creationResultResolver.resolve(plugin, pluginProblems)
     assertThat(creationResult, instanceOf(PluginCreationSuccess::class.java))

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
@@ -62,7 +62,7 @@ class PluginParsingConfigurationResolutionTest {
     val problemsThatShouldBeIgnored = listOf(
       ForbiddenPluginIdPrefix(PLUGIN_XML, pluginId, "some.forbidden.plugin.id"),
       TemplateWordInPluginId(pluginId, "forbiddenTemplateWord"),
-      TemplateWordInPluginName(pluginId, "forbiddenTemplateWord"),
+      TemplateWordInPluginName(PLUGIN_XML, "IntelliJ Toolset","IntelliJ"),
     )
     val warnings = listOf(SuspiciousUntilBuild("999"))
     val creationResult = creationResultResolver.resolve(plugin, problemsThatShouldBeIgnored + warnings)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolutionTest.kt
@@ -61,7 +61,7 @@ class PluginParsingConfigurationResolutionTest {
 
     val problemsThatShouldBeIgnored = listOf(
       ForbiddenPluginIdPrefix(PLUGIN_XML, pluginId, "some.forbidden.plugin.id"),
-      TemplateWordInPluginId(pluginId, "forbiddenTemplateWord"),
+      TemplateWordInPluginId(PLUGIN_XML, pluginId, "forbiddenTemplateWord"),
       TemplateWordInPluginName(PLUGIN_XML, "IntelliJ Toolset","IntelliJ"),
     )
     val warnings = listOf(SuspiciousUntilBuild("999"))

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputTest.kt
@@ -6,6 +6,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
 import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
@@ -145,7 +146,7 @@ open class BaseOutputTest<T : ResultPrinter> {
     val pluginId = "com.example.intellij"
     val prefix = "com.example"
     val invalidPluginFiles = listOf(
-      InvalidPluginFile(Path("plugin.zip"), listOf(ForbiddenPluginIdPrefix(pluginId, prefix)))
+      InvalidPluginFile(Path("plugin.zip"), listOf(ForbiddenPluginIdPrefix(PLUGIN_XML, pluginId, prefix)))
     )
 
     testRunner.run(resultPrinter, invalidPluginFiles)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputTest.kt
@@ -186,7 +186,7 @@ class MarkdownOutputTest : BaseOutputTest<MarkdownResultPrinter>() {
           
           ### Plugin Warnings
           
-          * Invalid plugin descriptor 'id'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
+          * Invalid plugin descriptor 'plugin.xml'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
           
           
         """.trimIndent()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputTest.kt
@@ -140,7 +140,7 @@ class StreamOutputTest : BaseOutputTest<WriterResultPrinter>() {
         The following files specified for the verification are not valid plugins:
             plugin.zip
                 Additional plugin warnings:
-                    Invalid plugin descriptor 'id'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
+                    Invalid plugin descriptor 'plugin.xml'. The plugin ID 'com.example.intellij' has a prefix 'com.example' that is not allowed.
                         This plugin problem has been reported since 2024-03-26. If the plugin was previously uploaded to the JetBrains Marketplace, it can be suppressed using the `-mute ForbiddenPluginIdPrefix` command-line switch.
 
       """.trimIndent()


### PR DESCRIPTION
- Fix unit tests for `ForbiddenPluginIdPrefix` which confuse plugin descriptor with plugin ID
- Pass plugin ID / plugin name in the plugin problem with disallowed words
- Improve copywriting