### PR TITLE
Provide problem solution hint for structure warnings in stdout

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
@@ -71,6 +71,7 @@ class WriterResultPrinter(private val out: PrintWriter) : ResultPrinter {
       appendLine("Plugin structure warnings (${pluginStructureWarnings.size}): ")
       for (warning in pluginStructureWarnings) {
         appendLine("$INDENT${warning.message}")
+        warning.problem.solutionHint.takeUnless { it.isBlank() }?.let { appendLine(INDENT + INDENT + it) }
       }
     }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/warnings/PluginStructureWarning.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/warnings/PluginStructureWarning.kt
@@ -6,13 +6,13 @@ package com.jetbrains.pluginverifier.warnings
 
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 
-data class PluginStructureWarning(private val pluginProblem: PluginProblem) {
+data class PluginStructureWarning(val problem: PluginProblem) {
 
   init {
-    check(pluginProblem.level == PluginProblem.Level.WARNING || pluginProblem.level == PluginProblem.Level.UNACCEPTABLE_WARNING)
+    check(problem.level == PluginProblem.Level.WARNING || problem.level == PluginProblem.Level.UNACCEPTABLE_WARNING)
   }
 
   val problemType: String get() = "Plugin descriptor warning"
 
-  val message: String get() = pluginProblem.message
+  val message: String get() = problem.message
 }


### PR DESCRIPTION
Provide solution hints - especially ability to mute / ignore the problem - for structure warnings.

An updated stream output along with the hint:

```
Plugin structure warnings (1): 
    Invalid plugin descriptor 'plugin.xml'. The plugin id should not contain the word 'intellij'.
        This plugin problem has been reported since 2024-03-26. If the plugin was previously uploaded to the JetBrains Marketplace, it can be suppressed using the `-mute TemplateWordInPluginId` command-line switch.
```