### PR TITLE
Discover JARs in 'lib/modules' for Platform 2024.2

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -109,6 +109,8 @@ fun Path.listFiles(): List<Path> {
   return Files.list(this).use { it.collect(Collectors.toList()) }
 }
 
+fun Path.listJars(): List<Path> = listFiles().filter { it.isJar() }
+
 fun Path.listAllFiles() =
   Files.walk(this).use { stream -> stream.filter { it.isFile }.map { this.relativize(it) }.toList() }
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreator.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreator.kt
@@ -6,8 +6,8 @@ package com.jetbrains.plugin.structure.ide.classes
 
 import com.jetbrains.plugin.structure.base.utils.closeOnException
 import com.jetbrains.plugin.structure.base.utils.isDirectory
-import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
 import com.jetbrains.plugin.structure.classes.resolvers.DirectoryResolver
@@ -48,9 +48,9 @@ object IdeResolverCreator {
       return EmptyResolver
     }
 
-    val jars = libDirectory.listFiles().filter { file -> file.isJar() }
-    val antJars = libDirectory.resolve("ant").resolve("lib").listFiles().filter { it.isJar() }
-    val moduleJars = libDirectory.resolve("modules").listFiles().filter { it.isJar() }
+    val jars = libDirectory.listJars()
+    val antJars = libDirectory.resolve("ant").resolve("lib").listJars()
+    val moduleJars = libDirectory.resolve("modules").listJars()
     return CompositeResolver.create(buildJarOrZipFileResolvers(jars + antJars + moduleJars, readMode, parentOrigin))
   }
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreator.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreator.kt
@@ -4,8 +4,17 @@
 
 package com.jetbrains.plugin.structure.ide.classes
 
-import com.jetbrains.plugin.structure.base.utils.*
-import com.jetbrains.plugin.structure.classes.resolvers.*
+import com.jetbrains.plugin.structure.base.utils.closeOnException
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
+import com.jetbrains.plugin.structure.classes.resolvers.DirectoryResolver
+import com.jetbrains.plugin.structure.classes.resolvers.EmptyResolver
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.classes.resolvers.buildJarOrZipFileResolvers
 import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManagerImpl
 import com.jetbrains.plugin.structure.ide.IdeManagerImpl.Companion.isCompiledCommunity
@@ -41,7 +50,8 @@ object IdeResolverCreator {
 
     val jars = libDirectory.listFiles().filter { file -> file.isJar() }
     val antJars = libDirectory.resolve("ant").resolve("lib").listFiles().filter { it.isJar() }
-    return CompositeResolver.create(buildJarOrZipFileResolvers(jars + antJars, readMode, parentOrigin))
+    val moduleJars = libDirectory.resolve("modules").listFiles().filter { it.isJar() }
+    return CompositeResolver.create(buildJarOrZipFileResolvers(jars + antJars + moduleJars, readMode, parentOrigin))
   }
 
   //TODO: Resolver created this way contains all libraries declared in the project,

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -7,7 +7,13 @@ package com.jetbrains.plugin.structure.ide
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.utils.*
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isFile
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.readLines
+import com.jetbrains.plugin.structure.base.utils.readText
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.JarFilesResourceResolver
@@ -63,10 +69,17 @@ class IdeManagerImpl : IdeManager() {
     val platformJarFiles = idePath.resolve("lib")
       .listFiles()
       .filter { it.isJar() }
-    val platformResourceResolver = PlatformResourceResolver(platformJarFiles)
+    val platformModuleJarFiles = platformModuleJarFiles(idePath)
+    val platformResourceResolver = PlatformResourceResolver(platformJarFiles + platformModuleJarFiles)
     val bundledPlugins = readBundledPlugins(idePath, platformResourceResolver, ideVersion)
     val platformPlugins = readPlatformPlugins(idePath, product, platformJarFiles, platformResourceResolver, ideVersion)
     return bundledPlugins + platformPlugins
+  }
+
+  private fun platformModuleJarFiles(idePath: Path): List<Path> {
+    return idePath.resolve("lib").resolve("modules")
+      .listFiles()
+      .filter { it.isJar() }
   }
 
   /**

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -10,8 +10,8 @@ import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.isFile
-import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.base.utils.readLines
 import com.jetbrains.plugin.structure.base.utils.readText
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
@@ -66,9 +66,7 @@ class IdeManagerImpl : IdeManager() {
   }
 
   private fun readDistributionBundledPlugins(idePath: Path, product: IntelliJPlatformProduct, ideVersion: IdeVersion): List<IdePlugin> {
-    val platformJarFiles = idePath.resolve("lib")
-      .listFiles()
-      .filter { it.isJar() }
+    val platformJarFiles = idePath.resolve("lib").listJars()
     val platformModuleJarFiles = platformModuleJarFiles(idePath)
     val platformResourceResolver = PlatformResourceResolver(platformJarFiles + platformModuleJarFiles)
     val bundledPlugins = readBundledPlugins(idePath, platformResourceResolver, ideVersion)
@@ -77,9 +75,7 @@ class IdeManagerImpl : IdeManager() {
   }
 
   private fun platformModuleJarFiles(idePath: Path): List<Path> {
-    return idePath.resolve("lib").resolve("modules")
-      .listFiles()
-      .filter { it.isJar() }
+    return idePath.resolve("lib").resolve("modules").listJars()
   }
 
   /**


### PR DESCRIPTION
Discover JARs in 'lib/modules' for Platform 2024.2.

This is a simplistic fix for JARs not being found in the Platform 2024.2 and newer, where the distribution is organized differently.

- Discover plugins in `lib/modules`, if necessary.
- When building the classpath for verification, check `lib/modules` as well.

This addresses VCS plugin reorganization and undiscovered classes.