### PR TITLE
Log call stack when tracing annotation usage

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -21,7 +21,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-val LOG: Logger = LoggerFactory.getLogger(AnnotationResolver::class.java)
+private val LOG: Logger = LoggerFactory.getLogger(AnnotationResolver::class.java)
 
 class AnnotationResolver(val annotation: FullyQualifiedClassName) {
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -1,0 +1,55 @@
+package com.jetbrains.pluginverifier.usages.annotation
+
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
+import com.jetbrains.pluginverifier.verifiers.findAnnotation
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
+import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
+
+class AnnotationResolver(val annotation: FullyQualifiedClassName) {
+  fun resolve(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? {
+    if (classFileMember.isDirectlyAnnotatedWith(annotation)) {
+      return MemberAnnotation.AnnotatedDirectly(classFileMember, annotation)
+    }
+
+    if (classFileMember !is ClassFile) {
+      val memberAnnotation = resolve(classFileMember.containingClassFile, classResolver)
+      return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(classFileMember.containingClassFile, classFileMember, annotation) }
+    }
+
+    if (classFileMember.name.endsWith("package-info")) {
+      return null
+    }
+
+    val enclosingClassName = classFileMember.enclosingClassName
+    // If enclosing class name is the same as the current class name the endless loop happens
+    // (since the same class will be resolved and findEffectiveMemberAnnotation call leads here)
+    if (enclosingClassName != null && enclosingClassName != classFileMember.name) {
+      val enclosingClass = classResolver.resolveClassOrNull(enclosingClassName) ?: return null
+      val memberAnnotation = resolve(enclosingClass, classResolver)
+      return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(enclosingClass, classFileMember, annotation) }
+    }
+
+    val packageName = classFileMember.containingClassFile.packageName
+    if (packageName.isNotEmpty()) {
+      val packageInfoClass = classResolver.resolveClassOrNull("$packageName/package-info")
+      if (packageInfoClass != null) {
+        return if (packageInfoClass.isDirectlyAnnotatedWith(annotation)) {
+          MemberAnnotation.AnnotatedViaPackage(packageName, classFileMember, annotation)
+        } else {
+          null
+        }
+      }
+    }
+
+    return null
+  }
+
+  private fun ClassFileMember.isDirectlyAnnotatedWith(annotationName: String): Boolean =
+    annotations.findAnnotation(annotationName) != null
+}
+
+fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver): Boolean =
+  annotationResolver.resolve(this, classResolver) != null

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -1,43 +1,62 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
 package com.jetbrains.pluginverifier.usages.annotation
 
+import com.jetbrains.plugin.structure.classes.resolvers.DirectoryFileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.JarOrZipFileOrigin
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.pluginverifier.results.location.Location
+import com.jetbrains.pluginverifier.results.presentation.toFullJavaClassName
 import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
 import com.jetbrains.pluginverifier.usages.util.MemberAnnotation.*
 import com.jetbrains.pluginverifier.verifiers.findAnnotation
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+val LOG: Logger = LoggerFactory.getLogger(AnnotationResolver::class.java)
 
 class AnnotationResolver(val annotation: FullyQualifiedClassName) {
-  fun resolve(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? {
+
+  fun resolve(classFileMember: ClassFileMember, classResolver: Resolver, usageLocation: Location?): MemberAnnotation? {
+    return resolve(classFileMember, classResolver, ResolutionStack(annotation, usageLocation))
+  }
+
+  private fun resolve(classFileMember: ClassFileMember, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? = resolutionStack.execute(classFileMember) {
     resolveDirectAnnotation(classFileMember, classResolver)?.let { return it }
-    return when (classFileMember) {
+    when (classFileMember) {
       is ClassFile -> {
         if (classFileMember.name.endsWith("package-info")) return null
-        resolveInEnclosingClassName(classFileMember, classResolver)?.let { return it }
+        resolveInEnclosingClassName(classFileMember, classResolver, resolutionStack)?.let { return it }
         resolveInPackageInfo(classFileMember, classResolver)?.let { return it }
         null
       }
-      else -> resolveInNonClassFile(classFileMember, classResolver)
+      else -> resolveInNonClassFile(classFileMember, classResolver, resolutionStack)
     }
   }
 
   private fun resolveDirectAnnotation(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? =
     AnnotatedDirectly(classFileMember, annotation).takeIf { classFileMember.isDirectlyAnnotatedWith(annotation) }
 
-  private fun resolveInNonClassFile(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? =
-    resolve(classFileMember.containingClassFile, classResolver)?.let {
+  private fun resolveInNonClassFile(classFileMember: ClassFileMember, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? =
+    resolve(classFileMember.containingClassFile, classResolver, resolutionStack)?.let {
       AnnotatedViaContainingClass(classFileMember.containingClassFile, classFileMember, annotation)
     }
 
-  private fun resolveInEnclosingClassName(classFileMember: ClassFile, classResolver: Resolver): MemberAnnotation? {
+  private fun resolveInEnclosingClassName(classFileMember: ClassFile, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? {
     val enclosingClassName = classFileMember.enclosingClassName
     // If enclosing class name is the same as the current class name the endless loop happens
     // (since the same class will be resolved and findEffectiveMemberAnnotation call leads here)
     if (enclosingClassName == null || enclosingClassName == classFileMember.name) return null
     val enclosingClass = classResolver.resolveClassOrNull(enclosingClassName) ?: return null
-    return resolve(enclosingClass, classResolver)?.let {
+    return resolve(enclosingClass, classResolver, resolutionStack)?.let {
       AnnotatedViaContainingClass(enclosingClass, classFileMember, annotation)
     }
   }
@@ -51,9 +70,61 @@ class AnnotationResolver(val annotation: FullyQualifiedClassName) {
       ?.let { AnnotatedViaPackage(packageName, classFileMember, annotation) }
   }
 
+  private inline fun ResolutionStack.execute(classFileMember: ClassFileMember, block: (ResolutionStack) -> MemberAnnotation?): MemberAnnotation? {
+    return try {
+      push(classFileMember)
+      block(this).also {
+        if (LOG.isDebugEnabled && it != null) {
+          LOG.debug("Resolving annotation '{}': {}", annotation, toString())
+        }
+      }
+    } finally {
+      pop()
+    }
+  }
+
   private fun ClassFileMember.isDirectlyAnnotatedWith(annotationName: String): Boolean =
     annotations.findAnnotation(annotationName) != null
+
+
+  private class ResolutionStack(val annotation: FullyQualifiedClassName, private val usageLocation: Location?) {
+    private val stack = ArrayDeque<ClassFileMember>()
+
+    fun push(m: ClassFileMember) {
+      stack.add(m)
+    }
+
+    fun pop(): ClassFileMember? = stack.removeLastOrNull()
+
+    override fun toString(): String {
+      val prefix = if (usageLocation != null) "${usageLocation.presentableLocation} => " else ""
+
+      return prefix + stack.joinToString(separator = " -> ") {
+        when (it) {
+          is ClassFile -> toFullJavaClassName(it.name) + " [" + it.getFileName() + "]"
+          is Method -> toFullJavaClassName(it.containingClassFile.name) + "#" + it.name + " [" + it.getFileName() + "]"
+          is Field -> toFullJavaClassName(it.containingClassFile.name) + "#" + it.name + " [" + it.getFileName() + "]"
+          else -> it.toString()
+        }
+      }
+    }
+
+    private fun ClassFileMember.getFileName(): String {
+      return containingClassFile.classFileOrigin.getFileName()
+    }
+
+    fun FileOrigin.getFileName(): String {
+      return when (this) {
+        is JarOrZipFileOrigin -> fileName
+        is DirectoryFileOrigin -> directoryName
+        else -> toString()
+      }
+    }
+  }
 }
 
 fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver): Boolean =
-  annotationResolver.resolve(this, classResolver) != null
+  isMemberEffectivelyAnnotatedWith(annotationResolver, classResolver, location = null)
+
+fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver, location: Location?): Boolean =
+  annotationResolver.resolve(this, classResolver, location) != null

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -2,6 +2,7 @@ package com.jetbrains.pluginverifier.usages.annotation
 
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
+import com.jetbrains.pluginverifier.usages.util.MemberAnnotation.*
 import com.jetbrains.pluginverifier.verifiers.findAnnotation
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
@@ -10,41 +11,44 @@ import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
 
 class AnnotationResolver(val annotation: FullyQualifiedClassName) {
   fun resolve(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? {
-    if (classFileMember.isDirectlyAnnotatedWith(annotation)) {
-      return MemberAnnotation.AnnotatedDirectly(classFileMember, annotation)
+    resolveDirectAnnotation(classFileMember, classResolver)?.let { return it }
+    return when (classFileMember) {
+      is ClassFile -> {
+        if (classFileMember.name.endsWith("package-info")) return null
+        resolveInEnclosingClassName(classFileMember, classResolver)?.let { return it }
+        resolveInPackageInfo(classFileMember, classResolver)?.let { return it }
+        null
+      }
+      else -> resolveInNonClassFile(classFileMember, classResolver)
+    }
+  }
+
+  private fun resolveDirectAnnotation(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? =
+    AnnotatedDirectly(classFileMember, annotation).takeIf { classFileMember.isDirectlyAnnotatedWith(annotation) }
+
+  private fun resolveInNonClassFile(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? =
+    resolve(classFileMember.containingClassFile, classResolver)?.let {
+      AnnotatedViaContainingClass(classFileMember.containingClassFile, classFileMember, annotation)
     }
 
-    if (classFileMember !is ClassFile) {
-      val memberAnnotation = resolve(classFileMember.containingClassFile, classResolver)
-      return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(classFileMember.containingClassFile, classFileMember, annotation) }
-    }
-
-    if (classFileMember.name.endsWith("package-info")) {
-      return null
-    }
-
+  private fun resolveInEnclosingClassName(classFileMember: ClassFile, classResolver: Resolver): MemberAnnotation? {
     val enclosingClassName = classFileMember.enclosingClassName
     // If enclosing class name is the same as the current class name the endless loop happens
     // (since the same class will be resolved and findEffectiveMemberAnnotation call leads here)
-    if (enclosingClassName != null && enclosingClassName != classFileMember.name) {
-      val enclosingClass = classResolver.resolveClassOrNull(enclosingClassName) ?: return null
-      val memberAnnotation = resolve(enclosingClass, classResolver)
-      return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(enclosingClass, classFileMember, annotation) }
+    if (enclosingClassName == null || enclosingClassName == classFileMember.name) return null
+    val enclosingClass = classResolver.resolveClassOrNull(enclosingClassName) ?: return null
+    return resolve(enclosingClass, classResolver)?.let {
+      AnnotatedViaContainingClass(enclosingClass, classFileMember, annotation)
     }
+  }
 
+  private fun resolveInPackageInfo(classFileMember: ClassFile, classResolver: Resolver): MemberAnnotation? {
     val packageName = classFileMember.containingClassFile.packageName
-    if (packageName.isNotEmpty()) {
-      val packageInfoClass = classResolver.resolveClassOrNull("$packageName/package-info")
-      if (packageInfoClass != null) {
-        return if (packageInfoClass.isDirectlyAnnotatedWith(annotation)) {
-          MemberAnnotation.AnnotatedViaPackage(packageName, classFileMember, annotation)
-        } else {
-          null
-        }
-      }
-    }
-
-    return null
+    return packageName
+      .takeIf { it.isNotEmpty() }
+      ?.let { classResolver.resolveClassOrNull("$packageName/package-info") }
+      ?.takeIf { it.isDirectlyAnnotatedWith(annotation) }
+      ?.let { AnnotatedViaPackage(packageName, classFileMember, annotation) }
   }
 
   private fun ClassFileMember.isDirectlyAnnotatedWith(annotationName: String): Boolean =

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
@@ -6,8 +6,8 @@ package com.jetbrains.pluginverifier.usages.experimental
 
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.pluginverifier.usages.ApiUsage
-import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
-import com.jetbrains.pluginverifier.usages.util.findEffectiveMemberAnnotation
+import com.jetbrains.pluginverifier.usages.annotation.AnnotationResolver
+import com.jetbrains.pluginverifier.usages.annotation.isMemberEffectivelyAnnotatedWith
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 
 /**
@@ -15,8 +15,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
  */
 abstract class ExperimentalApiUsage : ApiUsage()
 
-fun ClassFileMember.isExperimentalApi(resolver: Resolver): Boolean =
-  findEffectiveExperimentalAnnotation(resolver) != null
+fun ClassFileMember.isExperimentalApi(classResolver: Resolver): Boolean =
+  isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver)
 
-fun ClassFileMember.findEffectiveExperimentalAnnotation(resolver: Resolver): MemberAnnotation? =
-  findEffectiveMemberAnnotation("org/jetbrains/annotations/ApiStatus\$Experimental", resolver)
+private val experimentalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Experimental")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.experimental
 
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.pluginverifier.results.location.Location
 import com.jetbrains.pluginverifier.usages.ApiUsage
 import com.jetbrains.pluginverifier.usages.annotation.AnnotationResolver
 import com.jetbrains.pluginverifier.usages.annotation.isMemberEffectivelyAnnotatedWith
@@ -15,7 +16,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
  */
 abstract class ExperimentalApiUsage : ApiUsage()
 
-fun ClassFileMember.isExperimentalApi(classResolver: Resolver): Boolean =
-  isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver)
+fun ClassFileMember.isExperimentalApi(classResolver: Resolver, usageLocation: Location): Boolean =
+  isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver, location)
 
 private val experimentalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Experimental")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.experimental
@@ -11,7 +11,11 @@ import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.ApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.util.isFromVerifiedPlugin
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
-import com.jetbrains.pluginverifier.verifiers.resolution.*
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
 class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: ExperimentalApiRegistrar) : ApiUsageProcessor {
@@ -20,7 +24,7 @@ class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: Experi
     resolvedMember: ClassFileMember,
     context: VerificationContext,
     usageLocation: Location
-  ) = resolvedMember.isExperimentalApi(context.classResolver)
+  ) = resolvedMember.isExperimentalApi(context.classResolver, usageLocation)
     && resolvedMember.containingClassFile.classFileOrigin != usageLocation.containingClass.classFileOrigin
 
   override fun processClassReference(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalMethodOverridingProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalMethodOverridingProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.experimental
@@ -10,7 +10,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Method
 
 class ExperimentalMethodOverridingProcessor(private val experimentalApiRegistrar: ExperimentalApiRegistrar) : MethodOverridingProcessor {
   override fun processMethodOverriding(method: Method, overriddenMethod: Method, context: VerificationContext) {
-    if (overriddenMethod.isExperimentalApi(context.classResolver)) {
+    if (overriddenMethod.isExperimentalApi(context.classResolver, usageLocation = method.location)) {
       experimentalApiRegistrar.registerExperimentalApiUsage(
         ExperimentalMethodOverridden(
           overriddenMethod.location,

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsage.kt
@@ -1,10 +1,11 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.internal
 
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.pluginverifier.results.location.Location
 import com.jetbrains.pluginverifier.usages.ApiUsage
 import com.jetbrains.pluginverifier.usages.annotation.AnnotationResolver
 import com.jetbrains.pluginverifier.usages.annotation.isMemberEffectivelyAnnotatedWith
@@ -15,9 +16,10 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
  */
 abstract class InternalApiUsage : ApiUsage()
 
-fun ClassFileMember.isInternalApi(resolver: Resolver): Boolean =
-  isMemberEffectivelyAnnotatedWith(internalApiStatusResolver, resolver) ||
-    isMemberEffectivelyAnnotatedWith(intellijInternalApiResolver, resolver)
+fun ClassFileMember.isInternalApi(resolver: Resolver, location: Location): Boolean =
+  isMemberEffectivelyAnnotatedWith(internalApiStatusResolver, resolver, location) ||
+    isMemberEffectivelyAnnotatedWith(intellijInternalApiResolver, resolver, location)
+
 
 private val internalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Internal")
 private val intellijInternalApiResolver = AnnotationResolver("com/intellij/openapi/util/IntellijInternalApi")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsage.kt
@@ -6,7 +6,8 @@ package com.jetbrains.pluginverifier.usages.internal
 
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.pluginverifier.usages.ApiUsage
-import com.jetbrains.pluginverifier.usages.util.isMemberEffectivelyAnnotatedWith
+import com.jetbrains.pluginverifier.usages.annotation.AnnotationResolver
+import com.jetbrains.pluginverifier.usages.annotation.isMemberEffectivelyAnnotatedWith
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 
 /**
@@ -15,5 +16,9 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 abstract class InternalApiUsage : ApiUsage()
 
 fun ClassFileMember.isInternalApi(resolver: Resolver): Boolean =
-  isMemberEffectivelyAnnotatedWith("org/jetbrains/annotations/ApiStatus\$Internal", resolver) ||
-    isMemberEffectivelyAnnotatedWith("com/intellij/openapi/util/IntellijInternalApi", resolver)
+  isMemberEffectivelyAnnotatedWith(internalApiStatusResolver, resolver) ||
+    isMemberEffectivelyAnnotatedWith(intellijInternalApiResolver, resolver)
+
+private val internalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Internal")
+private val intellijInternalApiResolver = AnnotationResolver("com/intellij/openapi/util/IntellijInternalApi")
+

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalApiUsageProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.internal
@@ -17,7 +17,12 @@ import com.jetbrains.pluginverifier.usages.util.isFromVerifiedPlugin
 import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
 import com.jetbrains.pluginverifier.verifiers.ProblemRegistrar
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
-import com.jetbrains.pluginverifier.verifiers.resolution.*
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.MethodResolver
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import com.jetbrains.pluginverifier.warnings.WarningRegistrar
 import org.objectweb.asm.tree.AbstractInsnNode
@@ -28,7 +33,7 @@ class InternalApiUsageProcessor(private val pluginVerificationContext: PluginVer
     resolvedMember: ClassFileMember,
     context: VerificationContext,
     usageLocation: Location
-  ): Boolean = resolvedMember.isInternalApi(context.classResolver)
+  ): Boolean = resolvedMember.isInternalApi(context.classResolver, usageLocation)
     && resolvedMember.containingClassFile.classFileOrigin != usageLocation.containingClass.classFileOrigin
 
   override fun processClassReference(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.internal
@@ -10,7 +10,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Method
 
 class InternalMethodOverridingProcessor(private val internalApiUsageRegistrar: InternalApiUsageRegistrar) : MethodOverridingProcessor {
   override fun processMethodOverriding(method: Method, overriddenMethod: Method, context: VerificationContext) {
-    if (overriddenMethod.isInternalApi(context.classResolver)) {
+    if (overriddenMethod.isInternalApi(context.classResolver, method.location)) {
       internalApiUsageRegistrar.registerInternalApiUsage(
         InternalMethodOverridden(
           overriddenMethod.location,

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/util/AnnotatedMemberUtil.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/util/AnnotatedMemberUtil.kt
@@ -4,12 +4,7 @@
 
 package com.jetbrains.pluginverifier.usages.util
 
-import com.jetbrains.plugin.structure.classes.resolvers.Resolver
-import com.jetbrains.pluginverifier.verifiers.hasAnnotation
-import com.jetbrains.pluginverifier.verifiers.resolution.BinaryClassName
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
-import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
 
 sealed class MemberAnnotation {
 
@@ -34,47 +29,3 @@ sealed class MemberAnnotation {
     override val annotationName: String
   ) : MemberAnnotation()
 }
-
-fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationName: String, resolver: Resolver): Boolean =
-  findEffectiveMemberAnnotation(annotationName, resolver) != null
-
-fun ClassFileMember.findEffectiveMemberAnnotation(annotationName: String, resolver: Resolver): MemberAnnotation? {
-  if (isDirectlyAnnotatedWith(annotationName)) {
-    return MemberAnnotation.AnnotatedDirectly(this, annotationName)
-  }
-
-  if (this !is ClassFile) {
-    val memberAnnotation = containingClassFile.findEffectiveMemberAnnotation(annotationName, resolver)
-    return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(containingClassFile, this, annotationName) }
-  }
-
-  if (name.endsWith("package-info")) {
-    return null
-  }
-
-  val enclosingClassName = enclosingClassName
-  // If enclosing class name is the same as the current class name the endless loop happens
-  // (since the same class will be resolved and findEffectiveMemberAnnotation call leads here)
-  if (enclosingClassName != null && enclosingClassName != this.name) {
-    val enclosingClass = resolver.resolveClassOrNull(enclosingClassName) ?: return null
-    val memberAnnotation = enclosingClass.findEffectiveMemberAnnotation(annotationName, resolver)
-    return memberAnnotation?.let { MemberAnnotation.AnnotatedViaContainingClass(enclosingClass, this, annotationName) }
-  }
-
-  val packageName = containingClassFile.packageName
-  if (packageName.isNotEmpty()) {
-    val packageInfoClass = resolver.resolveClassOrNull("$packageName/package-info")
-    if (packageInfoClass != null) {
-      return if (packageInfoClass.isDirectlyAnnotatedWith(annotationName)) {
-        MemberAnnotation.AnnotatedViaPackage(packageName, this, annotationName)
-      } else {
-        null
-      }
-    }
-  }
-
-  return null
-}
-
-private fun ClassFileMember.isDirectlyAnnotatedWith(annotationName: BinaryClassName): Boolean =
-  annotations.hasAnnotation(annotationName)


### PR DESCRIPTION
Log call stack including API element locations when tracking API usage of elements with:

- internal annotations
- experimental annotations

This allows to debug log the class/method/field locations including the corresponding JARs and directories.

It helps to address scenarios as split package declarations of multiple `package-info` or classpath resources that are scattered across multiple independent JARs.
