### PR TITLE
YouTrack compatibility

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -151,12 +151,11 @@ class InvalidSemverVersion(
 
 class InvalidVersionRange(
   descriptorPath: String,
-  rangeName: String,
   since: String,
   until: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The compatibility range `$rangeName` [$since, $until] is empty."
+  detailedMessage = "The compatibility range [$since, $until] is empty."
 ) {
   override val level
     get() = Level.ERROR

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -137,7 +137,7 @@ class VendorCannotBeEmpty(
     get() = Level.ERROR
 }
 
-class InvalidSemverVersion(
+class InvalidSemverFormat(
   descriptorPath: String,
   versionName: String,
   version: String
@@ -158,5 +158,19 @@ class InvalidVersionRange(
   detailedMessage = "The compatibility range [$since, $until] is empty."
 ) {
   override val level
+    get() = Level.ERROR
+}
+
+class SemverComponentLimitExceeded(
+  descriptorPath: String,
+  componentName: String,
+  versionName: String,
+  version: String,
+  limit: Int
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The `$componentName` component of the `$versionName` semver version is too big [$version]. Max value is $limit."
+) {
+  override val level: Level
     get() = Level.ERROR
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -136,3 +136,28 @@ class VendorCannotBeEmpty(
   override val level
     get() = Level.ERROR
 }
+
+class InvalidSemverVersion(
+  descriptorPath: String,
+  versionName: String,
+  version: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The `$versionName` version should be formatted as semver [$version]."
+) {
+  override val level
+    get() = Level.ERROR
+}
+
+class InvalidVersionRange(
+  descriptorPath: String,
+  rangeName: String,
+  since: String,
+  until: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The compatibility range `$rangeName` [$since, $until] is empty."
+) {
+  override val level
+    get() = Level.ERROR
+}

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -143,7 +143,7 @@ class InvalidSemverFormat(
   version: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The `$versionName` version should be formatted as semver [$version]."
+  detailedMessage = "The `$versionName` version should be formatted as SemVer [$version]."
 ) {
   override val level
     get() = Level.ERROR
@@ -169,7 +169,7 @@ class SemverComponentLimitExceeded(
   limit: Int
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The `$componentName` component of the `$versionName` semver version is too big [$version]. Max value is $limit."
+  detailedMessage = "The `$componentName` component of the `$versionName` SemVer version is too big [$version]. Max value is $limit."
 ) {
   override val level: Level
     get() = Level.ERROR

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -88,7 +88,6 @@ data class FleetPluginDescriptor(
             fromSemver.isGreaterThan(toSemver) -> {
               problems.add(InvalidVersionRange(
                 descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
-                rangeName = "compatibleShipVersionRange",
                 since = compatibleShipVersionRange.from,
                 until = compatibleShipVersionRange.to
               ))

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -70,15 +70,28 @@ data class FleetPluginDescriptor(
           val toSemver = parseVersionOrNull(compatibleShipVersionRange.to)
           when {
             fromSemver == null -> {
-              problems.add(FleetInvalidShipVersion("from", compatibleShipVersionRange.from))
+              problems.add(InvalidSemverVersion(
+                descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+                versionName = "compatibleShipVersionRange.from",
+                version = compatibleShipVersionRange.from
+              ))
             }
 
             toSemver == null -> {
-              problems.add(FleetInvalidShipVersion("to", compatibleShipVersionRange.to))
+              problems.add(InvalidSemverVersion(
+                descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+                versionName = "compatibleShipVersionRange.to",
+                version = compatibleShipVersionRange.to
+              ))
             }
 
             fromSemver.isGreaterThan(toSemver) -> {
-              problems.add(FleetInvalidShipVersionRange(compatibleShipVersionRange.from, compatibleShipVersionRange.to))
+              problems.add(InvalidVersionRange(
+                descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+                rangeName = "compatibleShipVersionRange",
+                since = compatibleShipVersionRange.from,
+                until = compatibleShipVersionRange.to
+              ))
             }
 
             else -> {
@@ -166,25 +179,6 @@ private const val VERSION_MINOR_LENGTH = 13
 const val VERSION_MAJOR_PART_MAX_VALUE = 7449 // 1110100011001
 const val VERSION_MINOR_PART_MAX_VALUE = 1.shl(VERSION_MINOR_LENGTH) - 1 // 8191
 const val VERSION_PATCH_PART_MAX_VALUE = 1.shl(VERSION_PATCH_LENGTH) - 1 // 16383
-
-class FleetInvalidShipVersion(
-  versionName: String,
-  version: String
-) : InvalidDescriptorProblem(
-  descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
-  detailedMessage = "The `compatibleShipVersionRange.$versionName` version should be formatted as semver [$version]."
-) {
-  override val level
-    get() = Level.ERROR
-}
-
-class FleetInvalidShipVersionRange(from: String, to: String) : InvalidDescriptorProblem(
-  descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
-  detailedMessage = "The `compatibleShipVersionRange.from` build $from is greater than `compatibleShipVersionRange.to` build $to."
-) {
-  override val level
-    get() = Level.ERROR
-}
 
 class FleetErroneousShipVersion(
   versionName: String,

--- a/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
@@ -58,7 +58,11 @@ data class ToolboxPluginDescriptor(
       } else {
         val fromParsed = parseVersionOrNull(compatibleVersionRange.from)
         if (fromParsed == null) {
-          problems.add(ToolboxInvalidVersion("from", compatibleVersionRange.from))
+          problems.add(InvalidSemverVersion(
+            descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+            versionName = "compatibleVersionRange.from",
+            version = compatibleVersionRange.from
+          ))
         } else {
           problems.addAll(validateVersion("from", fromParsed))
         }
@@ -68,11 +72,20 @@ data class ToolboxPluginDescriptor(
       if (!compatibleVersionRange.to.isNullOrBlank()) {
         val toParsed = parseVersionOrNull(compatibleVersionRange.to)
         if (toParsed == null) {
-          problems.add(ToolboxInvalidVersion("to", compatibleVersionRange.to))
+          problems.add(InvalidSemverVersion(
+            descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+            versionName = "compatibleVersionRange.to",
+            version = compatibleVersionRange.to
+          ))
         } else {
           problems.addAll(validateVersion("to", toParsed))
           if (fromSemver != null && compatibleVersionRange.from != null && fromSemver.isGreaterThan(toParsed)) {
-            problems.add(ToolboxInvalidVersionRange(compatibleVersionRange.from, compatibleVersionRange.to))
+            problems.add(InvalidVersionRange(
+              descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+              rangeName = "compatibleVersionRange",
+              since = compatibleVersionRange.from,
+              until = compatibleVersionRange.to
+            ))
           }
         }
       }
@@ -152,21 +165,6 @@ const val VERSION_MAJOR_PART_MAX_VALUE = 7449 // 1110100011001
 const val VERSION_MINOR_PART_MAX_VALUE = 1.shl(VERSION_MINOR_LENGTH) - 1 // 8191
 const val VERSION_PATCH_PART_MAX_VALUE = 1.shl(VERSION_PATCH_LENGTH) - 1 // 1048575
 
-class ToolboxInvalidVersion(versionName: String, version: String) : InvalidDescriptorProblem(
-  descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
-  detailedMessage = "The `compatibleVersionRange.$versionName` version should be formatted as semver [$version]."
-) {
-  override val level
-    get() = Level.ERROR
-}
-
-class ToolboxInvalidVersionRange(from: String, to: String) : InvalidDescriptorProblem(
-  descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
-  detailedMessage = "The `compatibleVersionRange.from` build $from is greater than `compatibleVersionRange.to` build $to."
-) {
-  override val level
-    get() = Level.ERROR
-}
 
 class ToolboxErroneousVersion(
   versionName: String,

--- a/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
@@ -82,7 +82,6 @@ data class ToolboxPluginDescriptor(
           if (fromSemver != null && compatibleVersionRange.from != null && fromSemver.isGreaterThan(toParsed)) {
             problems.add(InvalidVersionRange(
               descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
-              rangeName = "compatibleVersionRange",
               since = compatibleVersionRange.from,
               until = compatibleVersionRange.to
             ))

--- a/intellij-plugin-structure/structure-youtrack/build.gradle.kts
+++ b/intellij-plugin-structure/structure-youtrack/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
   implementation(project(":structure-base"))
+  implementation(libs.semver4j)
 }

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
@@ -1,13 +1,11 @@
 package com.jetbrains.plugin.structure.youtrack
 
-import com.jetbrains.plugin.structure.base.problems.MAX_CHANGE_NOTES_LENGTH
-import com.jetbrains.plugin.structure.base.problems.MAX_NAME_LENGTH
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.validatePropertyLength
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.youtrack.YouTrackPluginManager.Companion.DESCRIPTOR_NAME
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppManifest
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppWidget
 import com.jetbrains.plugin.structure.youtrack.problems.*
+import com.vdurmont.semver4j.Semver
 
 
 private val ID_REGEX = "^([a-z\\d\\-._~]+)\$".toRegex()
@@ -36,6 +34,12 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
   if (manifest.changeNotes != null) {
     validatePropertyLength(DESCRIPTOR_NAME, "changeNotes", manifest.changeNotes, MAX_CHANGE_NOTES_LENGTH, problems)
   }
+
+  validateYouTrackRange(
+    minYouTrackVersion = manifest.minYouTrackVersion,
+    maxYouTrackVersion = manifest.maxYouTrackVersion,
+    problems = problems
+  )
 
   manifest.widgets?.let { widgets ->
     if (widgets.map { it.key }.toSet().size != widgets.size) {
@@ -82,4 +86,51 @@ private fun validateWidget(widget: YouTrackAppWidget, problems: MutableList<Plug
   if (widget.extensionPoint == null) {
     problems.add(WidgetManifestPropertyNotSpecified("extensionPoint", widget.key))
   }
+}
+
+private fun validateYouTrackRange(
+  minYouTrackVersion: String?,
+  maxYouTrackVersion: String?,
+  problems: MutableList<PluginProblem>
+) {
+  val since = getYouTrackVersionOrNull(
+    versionName = "minYouTrackVersion",
+    version = minYouTrackVersion,
+    problems = problems
+  )
+  val until = getYouTrackVersionOrNull(
+    versionName = "maxYouTrackVersion",
+    version = maxYouTrackVersion,
+    problems = problems
+  )
+
+  if (since == null || until == null) return
+
+  if (since.isGreaterThan(until)) {
+    problems.add(InvalidVersionRange(
+      descriptorPath = DESCRIPTOR_NAME,
+      since = minYouTrackVersion!!,
+      until = maxYouTrackVersion!!
+    ))
+  }
+}
+
+private fun getYouTrackVersionOrNull(
+  versionName: String,
+  version: String?,
+  problems: MutableList<PluginProblem>
+): Semver? {
+  if (version == null) return null
+
+  return runCatching {
+    Semver(version, Semver.SemverType.STRICT)
+  }.onFailure {
+    problems.add(
+      InvalidSemverVersion(
+        descriptorPath = DESCRIPTOR_NAME,
+        versionName = versionName,
+        version = version
+      )
+    )
+  }.getOrNull()
 }

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
@@ -2,6 +2,7 @@ package com.jetbrains.plugin.structure.youtrack
 
 import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.youtrack.YouTrackPluginManager.Companion.DESCRIPTOR_NAME
+import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppFields
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppManifest
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppWidget
 import com.jetbrains.plugin.structure.youtrack.problems.*
@@ -16,23 +17,23 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
   validateManifestName(manifest.name, problems)
 
   if (manifest.title.isNullOrBlank()) {
-    problems.add(ManifestPropertyNotSpecified("title"))
+    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE))
   }
 
   if (manifest.title != null) {
-    validatePropertyLength(DESCRIPTOR_NAME, "title", manifest.title, MAX_NAME_LENGTH, problems)
+    validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.TITLE, manifest.title, MAX_NAME_LENGTH, problems)
   }
 
   if (manifest.description.isNullOrBlank()) {
-    problems.add(ManifestPropertyNotSpecified("description"))
+    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION))
   }
 
   if (manifest.version.isNullOrBlank()) {
-    problems.add(ManifestPropertyNotSpecified("version"))
+    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.VERSION))
   }
 
   if (manifest.changeNotes != null) {
-    validatePropertyLength(DESCRIPTOR_NAME, "changeNotes", manifest.changeNotes, MAX_CHANGE_NOTES_LENGTH, problems)
+    validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.NOTES, manifest.changeNotes, MAX_CHANGE_NOTES_LENGTH, problems)
   }
 
   validateYouTrackRange(
@@ -53,7 +54,7 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
 
 private fun validateManifestName(name: String?, problems: MutableList<PluginProblem>) {
   if (name == null) {
-    problems.add(ManifestPropertyNotSpecified("name"))
+    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.NAME))
     return
   }
 
@@ -62,7 +63,7 @@ private fun validateManifestName(name: String?, problems: MutableList<PluginProb
     return
   }
 
-  validatePropertyLength(DESCRIPTOR_NAME, "name", name, MAX_NAME_LENGTH, problems)
+  validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.NAME, name, MAX_NAME_LENGTH, problems)
 
   if (!ID_REGEX.matches(name)) {
     problems.add(UnsupportedSymbolsAppNameProblem())
@@ -80,11 +81,11 @@ private fun validateWidget(widget: YouTrackAppWidget, problems: MutableList<Plug
   }
 
   if (widget.indexPath == null) {
-    problems.add(WidgetManifestPropertyNotSpecified("indexPath", widget.key))
+    problems.add(WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.INDEX_PATH, widget.key))
   }
 
   if (widget.extensionPoint == null) {
-    problems.add(WidgetManifestPropertyNotSpecified("extensionPoint", widget.key))
+    problems.add(WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.EXTENSION_POINT, widget.key))
   }
 }
 
@@ -94,12 +95,12 @@ private fun validateYouTrackRange(
   problems: MutableList<PluginProblem>
 ) {
   val since = getYouTrackVersionOrNull(
-    versionName = "minYouTrackVersion",
+    versionName = YouTrackAppFields.Manifest.SINCE,
     version = minYouTrackVersion,
     problems = problems
   )
   val until = getYouTrackVersionOrNull(
-    versionName = "maxYouTrackVersion",
+    versionName = YouTrackAppFields.Manifest.UNTIL,
     version = maxYouTrackVersion,
     problems = problems
   )

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/YouTrackVersionUtils.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/YouTrackVersionUtils.kt
@@ -21,7 +21,7 @@ object YouTrackVersionUtils {
     val semanticVersion = getSemverFromString(youTrackVersion)
 
     return semanticVersion.run {
-      major.toLong().shl(VERSION_PATCH_LENGTH + VERSION_MINOR_LENGTH) + minor.toLong().shl(VERSION_PATCH_LENGTH) + patch
+      major.toLong() * (VERSION_PATCH_LENGTH * VERSION_MINOR_LENGTH) + minor.toLong() * VERSION_PATCH_LENGTH + patch
     }
   }
 

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/YouTrackVersionUtils.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/YouTrackVersionUtils.kt
@@ -1,0 +1,31 @@
+package com.jetbrains.plugin.structure.youtrack
+
+import com.vdurmont.semver4j.Semver
+
+/*
+  YouTrack version is in semver format, where:
+    - `MAJOR` is the year,
+    - `MINOR` is the release within that year,
+    - `PATCH` is a build number.
+
+  For instance, `2024.3.35000`.
+ */
+object YouTrackVersionUtils {
+  const val MAX_MAJOR_VALUE = 3000
+  const val VERSION_MINOR_LENGTH = 100
+  const val VERSION_PATCH_LENGTH = 1000000
+
+  fun versionAsLong(youTrackVersion: String?): Long? {
+    if (youTrackVersion == null) return null
+
+    val semanticVersion = getSemverFromString(youTrackVersion)
+
+    return semanticVersion.run {
+      major.toLong().shl(VERSION_PATCH_LENGTH + VERSION_MINOR_LENGTH) + minor.toLong().shl(VERSION_PATCH_LENGTH) + patch
+    }
+  }
+
+  fun getSemverFromString(youTrackVersion: String): Semver {
+    return Semver(youTrackVersion, Semver.SemverType.STRICT)
+  }
+}

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/bean/YouTrackAppFields.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/bean/YouTrackAppFields.kt
@@ -1,0 +1,31 @@
+package com.jetbrains.plugin.structure.youtrack.bean
+
+object YouTrackAppFields {
+  object Manifest {
+    const val NAME = "name"
+    const val TITLE = "title"
+    const val VERSION = "version"
+    const val DESCRIPTION = "description"
+    const val URL = "url"
+    const val ICON = "icon"
+    const val ICON_DARK = "iconDark"
+    const val SINCE = "minYouTrackVersion"
+    const val UNTIL = "maxYouTrackVersion"
+    const val NOTES = "changeNotes"
+    const val VENDOR = "vendor"
+    const val WIDGETS = "widgets"
+  }
+
+  object Vendor {
+    const val NAME = "name"
+    const val URL = "url"
+    const val EMAIL = "email"
+  }
+
+  object Widget {
+    const val KEY = "key"
+    const val EXTENSION_POINT = "extensionPoint"
+    const val INDEX_PATH = "indexPath"
+  }
+}
+

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/bean/YouTrackAppManifest.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/bean/YouTrackAppManifest.kt
@@ -6,65 +6,65 @@ import com.fasterxml.jackson.annotation.JsonProperty
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class YouTrackAppManifest(
 
-  @JsonProperty("name")
+  @JsonProperty(YouTrackAppFields.Manifest.NAME)
   val name: String? = null,
 
-  @JsonProperty("title")
+  @JsonProperty(YouTrackAppFields.Manifest.TITLE)
   val title: String? = null,
 
-  @JsonProperty("version")
+  @JsonProperty(YouTrackAppFields.Manifest.VERSION)
   val version: String? = null,
 
-  @JsonProperty("description")
+  @JsonProperty(YouTrackAppFields.Manifest.DESCRIPTION)
   val description: String? = null,
 
-  @JsonProperty("url")
+  @JsonProperty(YouTrackAppFields.Manifest.URL)
   val url: String? = null,
 
-  @JsonProperty("icon")
+  @JsonProperty(YouTrackAppFields.Manifest.ICON)
   val icon: String? = null,
 
-  @JsonProperty("iconDark")
+  @JsonProperty(YouTrackAppFields.Manifest.ICON_DARK)
   val iconDark: String? = null,
 
-  @JsonProperty("minYouTrackVersion")
+  @JsonProperty(YouTrackAppFields.Manifest.SINCE)
   val minYouTrackVersion: String? = null,
 
-  @JsonProperty("maxYouTrackVersion")
+  @JsonProperty(YouTrackAppFields.Manifest.UNTIL)
   val maxYouTrackVersion: String? = null,
 
-  @JsonProperty("changeNotes")
+  @JsonProperty(YouTrackAppFields.Manifest.NOTES)
   val changeNotes: String? = null,
 
-  @JsonProperty("vendor")
+  @JsonProperty(YouTrackAppFields.Manifest.VENDOR)
   val vendor: YouTrackAppVendor? = null,
 
-  @JsonProperty("widgets")
+  @JsonProperty(YouTrackAppFields.Manifest.WIDGETS)
   val widgets: List<YouTrackAppWidget>? = null
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class YouTrackAppWidget(
 
-  @JsonProperty("key")
+  @JsonProperty(YouTrackAppFields.Widget.KEY)
   val key: String? = null,
 
-  @JsonProperty("extensionPoint")
+  @JsonProperty(YouTrackAppFields.Widget.EXTENSION_POINT)
   val extensionPoint: String? = null,
 
-  @JsonProperty("indexPath")
+  @JsonProperty(YouTrackAppFields.Widget.INDEX_PATH)
   val indexPath: String? = null,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class YouTrackAppVendor(
 
-  @JsonProperty("name")
+  @JsonProperty(YouTrackAppFields.Vendor.NAME)
   val name: String? = null,
 
-  @JsonProperty("url")
+  @JsonProperty(YouTrackAppFields.Vendor.URL)
   val url: String? = null,
 
-  @JsonProperty("email")
+  @JsonProperty(YouTrackAppFields.Vendor.EMAIL)
   val email: String? = null
 )

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/problems/YouTrackPluginErrors.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/problems/YouTrackPluginErrors.kt
@@ -2,9 +2,10 @@ package com.jetbrains.plugin.structure.youtrack.problems
 
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.youtrack.YouTrackPluginManager.Companion.DESCRIPTOR_NAME
+import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppFields
 
 open class InvalidAppNameProblem(message: String) : InvalidDescriptorProblem(
-  descriptorPath = "name",
+  descriptorPath = YouTrackAppFields.Manifest.NAME,
   detailedMessage = message
 ) {
   override val level
@@ -37,7 +38,7 @@ open class WidgetManifestPropertyNotSpecified(propertyName: String, widgetKey: S
 }
 
 open class InvalidWidgetKeyProblem(message: String) : InvalidDescriptorProblem(
-  descriptorPath = "key",
+  descriptorPath = YouTrackAppFields.Widget.KEY,
   detailedMessage = message
 ) {
   override val level
@@ -51,7 +52,7 @@ class UnsupportedSymbolsWidgetKeyProblem(key: String) : InvalidWidgetKeyProblem(
 
 open class WidgetKeyNotSpecified : InvalidDescriptorProblem(
   descriptorPath = DESCRIPTOR_NAME,
-  detailedMessage = "Widget property 'key' is not specified."
+  detailedMessage = "Widget property '${YouTrackAppFields.Widget.KEY}' is not specified."
 ) {
   override val level
     get() = Level.ERROR
@@ -59,7 +60,7 @@ open class WidgetKeyNotSpecified : InvalidDescriptorProblem(
 
 open class WidgetKeyIsNotUnique : InvalidDescriptorProblem(
   descriptorPath = DESCRIPTOR_NAME,
-  detailedMessage = "Widget property 'key' is not unique."
+  detailedMessage = "Widget property '${YouTrackAppFields.Widget.KEY}' is not unique."
 ) {
   override val level
     get() = Level.ERROR

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -92,25 +92,61 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `compatibility range is valid`() {
-    checkInvalidPlugin(InvalidSemverVersion(
+    checkInvalidPlugin(InvalidSemverFormat(
       descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
       versionName = "compatibleShipVersionRange.from",
       version = "123"
     )) {
       it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "123"))
     }
-    checkInvalidPlugin(InvalidSemverVersion(
+    checkInvalidPlugin(InvalidSemverFormat(
       descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
       versionName = "compatibleShipVersionRange.to",
       version = "123"
     )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "123")) }
 
-    checkInvalidPlugin(FleetErroneousShipVersion("from", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
-    checkInvalidPlugin(FleetErroneousShipVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "7450.1.2")) }
-    checkInvalidPlugin(FleetErroneousShipVersion("from", "minor", "0.8192.2", limit = VERSION_MINOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "0.8192.2")) }
-    checkInvalidPlugin(FleetErroneousShipVersion("to", "minor", "1.8192.2", limit = VERSION_MINOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "1.8192.2")) }
-    checkInvalidPlugin(FleetErroneousShipVersion("from", "patch", "1.2.16384", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.2.16384")) }
-    checkInvalidPlugin(FleetErroneousShipVersion("to", "patch", "1.1000.16384", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "1.1000.16384")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "major",
+      versionName = "compatibleShipVersionRange.from",
+      version = "7450.1.2",
+      limit = FleetShipVersionRange.VERSION_MAJOR_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "major",
+      versionName = "compatibleShipVersionRange.to",
+      version = "7450.1.2",
+      limit = FleetShipVersionRange.VERSION_MAJOR_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "7450.1.2")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "minor",
+      versionName = "compatibleShipVersionRange.from",
+      version = "0.8192.2",
+      limit = FleetShipVersionRange.VERSION_MINOR_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "0.8192.2")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "minor",
+      versionName = "compatibleShipVersionRange.to",
+      version = "1.8192.2",
+      limit = FleetShipVersionRange.VERSION_MINOR_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "1.8192.2")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "patch",
+      versionName = "compatibleShipVersionRange.from",
+      version = "1.2.16384",
+      limit = FleetShipVersionRange.VERSION_PATCH_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.2.16384")) }
+    checkInvalidPlugin(SemverComponentLimitExceeded(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      componentName = "patch",
+      versionName = "compatibleShipVersionRange.to",
+      version = "1.1000.16384",
+      limit = FleetShipVersionRange.VERSION_PATCH_PART_MAX_VALUE
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "1.1000.16384")) }
 
     checkInvalidPlugin(InvalidVersionRange(
       descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -114,7 +114,6 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
     checkInvalidPlugin(InvalidVersionRange(
       descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
-      rangeName = "compatibleShipVersionRange",
       since = "1.1000.1",
       until = "1.1000.0"
     )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -1,9 +1,6 @@
 package com.jetbrains.plugin.structure.fleet.mock
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.InvalidPluginIDProblem
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.fleet.*
 import com.jetbrains.plugin.structure.fleet.problems.createIncorrectFleetPluginFile
@@ -95,8 +92,18 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `compatibility range is valid`() {
-    checkInvalidPlugin(FleetInvalidShipVersion("from", "123")) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "123")) }
-    checkInvalidPlugin(FleetInvalidShipVersion("to", "123")) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "123")) }
+    checkInvalidPlugin(InvalidSemverVersion(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      versionName = "compatibleShipVersionRange.from",
+      version = "123"
+    )) {
+      it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "123"))
+    }
+    checkInvalidPlugin(InvalidSemverVersion(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      versionName = "compatibleShipVersionRange.to",
+      version = "123"
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "123")) }
 
     checkInvalidPlugin(FleetErroneousShipVersion("from", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
     checkInvalidPlugin(FleetErroneousShipVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "7450.1.2")) }
@@ -105,7 +112,12 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
     checkInvalidPlugin(FleetErroneousShipVersion("from", "patch", "1.2.16384", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.2.16384")) }
     checkInvalidPlugin(FleetErroneousShipVersion("to", "patch", "1.1000.16384", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(to = "1.1000.16384")) }
 
-    checkInvalidPlugin(FleetInvalidShipVersionRange(from = "1.1000.1", to = "1.1000.0")) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }
+    checkInvalidPlugin(InvalidVersionRange(
+      descriptorPath = FleetPluginManager.DESCRIPTOR_NAME,
+      rangeName = "compatibleShipVersionRange",
+      since = "1.1000.1",
+      until = "1.1000.0"
+    )) { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }
 
     checkValidPlugin { it.copy(compatibleShipVersionRange = it.compatibleShipVersionRange!!.copy(from = "7449.8191.16383", to = "7449.8191.16383")) }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
@@ -79,14 +79,14 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `compatibility range is valid`() {
-    checkInvalidPlugin(InvalidSemverVersion(
+    checkInvalidPlugin(InvalidSemverFormat(
       descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
       versionName = "compatibleVersionRange.from",
       version = "123"
     )) {
       it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "123"))
     }
-    checkInvalidPlugin(InvalidSemverVersion(
+    checkInvalidPlugin(InvalidSemverFormat(
       descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
       versionName = "compatibleVersionRange.to",
       version = "123"
@@ -94,12 +94,77 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
       it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "123"))
     }
 
-    checkInvalidPlugin(listOf(ToolboxErroneousVersion("from", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE), ToolboxErroneousVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE))) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
-    checkInvalidPlugin(ToolboxErroneousVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "7450.1.2")) }
-    checkInvalidPlugin(ToolboxErroneousVersion("from", "minor", "0.8192.2", limit = VERSION_MINOR_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "0.8192.2")) }
-    checkInvalidPlugin(ToolboxErroneousVersion("to", "minor", "1.8192.2", limit = VERSION_MINOR_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "1.8192.2")) }
-    checkInvalidPlugin(ToolboxErroneousVersion("from", "patch", "1.2.1048577", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.2.1048577")) }
-    checkInvalidPlugin(ToolboxErroneousVersion("to", "patch", "1.1000.1048577", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "1.1000.1048577")) }
+    checkInvalidPlugin(listOf(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "major",
+        versionName = "compatibleVersionRange.from",
+        version = "7450.1.2",
+        limit = ToolboxVersionRange.VERSION_MAJOR_PART_MAX_VALUE
+      ),
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "major",
+        versionName = "compatibleVersionRange.to",
+        version = "7450.1.2",
+        limit = ToolboxVersionRange.VERSION_MAJOR_PART_MAX_VALUE
+      )
+    )) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
+    checkInvalidPlugin(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "major",
+        versionName = "compatibleVersionRange.to",
+        version = "7450.1.2",
+        limit = ToolboxVersionRange.VERSION_MAJOR_PART_MAX_VALUE
+      )
+    ) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "7450.1.2"))
+    }
+    checkInvalidPlugin(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "minor",
+        versionName = "compatibleVersionRange.from",
+        version = "0.8192.2",
+        limit = ToolboxVersionRange.VERSION_MINOR_PART_MAX_VALUE
+      )
+    ) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "0.8192.2"))
+    }
+    checkInvalidPlugin(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "minor",
+        versionName = "compatibleVersionRange.to",
+        version = "1.8192.2",
+        limit = ToolboxVersionRange.VERSION_MINOR_PART_MAX_VALUE
+      )
+    ) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "1.8192.2"))
+    }
+    checkInvalidPlugin(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "patch",
+        versionName = "compatibleVersionRange.from",
+        version = "1.2.1048577",
+        limit = ToolboxVersionRange.VERSION_PATCH_PART_MAX_VALUE
+      )
+    ) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.2.1048577"))
+    }
+    checkInvalidPlugin(
+      SemverComponentLimitExceeded(
+        descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+        componentName = "patch",
+        versionName = "compatibleVersionRange.to",
+        version = "1.1000.1048577",
+        limit = ToolboxVersionRange.VERSION_PATCH_PART_MAX_VALUE
+      )
+    ) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "1.1000.1048577"))
+    }
 
     checkInvalidPlugin(InvalidVersionRange(
       descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
@@ -1,9 +1,6 @@
 package com.jetbrains.plugin.structure.toolbox.mock
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.InvalidPluginIDProblem
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.mocks.BasePluginManagerTest
 import com.jetbrains.plugin.structure.rules.FileSystemType
@@ -82,8 +79,20 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `compatibility range is valid`() {
-    checkInvalidPlugin(ToolboxInvalidVersion("from", "123")) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "123")) }
-    checkInvalidPlugin(ToolboxInvalidVersion("to", "123")) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "123")) }
+    checkInvalidPlugin(InvalidSemverVersion(
+      descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+      versionName = "compatibleVersionRange.from",
+      version = "123"
+    )) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "123"))
+    }
+    checkInvalidPlugin(InvalidSemverVersion(
+      descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+      versionName = "compatibleVersionRange.to",
+      version = "123"
+    )) {
+      it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "123"))
+    }
 
     checkInvalidPlugin(listOf(ToolboxErroneousVersion("from", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE), ToolboxErroneousVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE))) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "7450.1.2", to = "7450.1.2")) }
     checkInvalidPlugin(ToolboxErroneousVersion("to", "major", "7450.1.2", limit = VERSION_MAJOR_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "7450.1.2")) }
@@ -92,7 +101,12 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
     checkInvalidPlugin(ToolboxErroneousVersion("from", "patch", "1.2.1048577", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.2.1048577")) }
     checkInvalidPlugin(ToolboxErroneousVersion("to", "patch", "1.1000.1048577", limit = VERSION_PATCH_PART_MAX_VALUE)) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(to = "1.1000.1048577")) }
 
-    checkInvalidPlugin(ToolboxInvalidVersionRange(from = "1.1000.1", to = "1.1000.0")) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }
+    checkInvalidPlugin(InvalidVersionRange(
+      descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+      rangeName = "compatibleVersionRange",
+      since = "1.1000.1",
+      until = "1.1000.0"
+    )) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }
 
     checkValidPlugin { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "7449.8191.1048575", to = "7449.8191.1048575")) }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
@@ -103,7 +103,6 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
 
     checkInvalidPlugin(InvalidVersionRange(
       descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
-      rangeName = "compatibleVersionRange",
       since = "1.1000.1",
       until = "1.1000.0"
     )) { it.copy(compatibleVersionRange = it.compatibleVersionRange!!.copy(from = "1.1000.1", to = "1.1000.0")) }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -129,6 +129,33 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
     ) { it.copy(widgets = widgets) }
   }
 
+  @Test
+  fun `invalid youtrack versions`() {
+    checkInvalidPlugin(
+      InvalidSemverVersion(
+        descriptorPath = YouTrackPluginManager.DESCRIPTOR_NAME,
+        versionName = "minYouTrackVersion",
+        version = "123"
+      ),
+      InvalidSemverVersion(
+        descriptorPath = YouTrackPluginManager.DESCRIPTOR_NAME,
+        versionName = "maxYouTrackVersion",
+        version = "456"
+      )
+    ) { it.copy(minYouTrackVersion = "123", maxYouTrackVersion = "456") }
+  }
+
+  @Test
+  fun `invalid youtrack versions range`() {
+    checkInvalidPlugin(
+      InvalidVersionRange(
+        descriptorPath = YouTrackPluginManager.DESCRIPTOR_NAME,
+        since = "123.12.1",
+        until = "12.12.1"
+      )
+    ) { it.copy(minYouTrackVersion = "123.12.1", maxYouTrackVersion = "12.12.1") }
+  }
+
   private fun checkInvalidPlugin(vararg expectedProblems: PluginProblem, modify: (YouTrackAppManifest) -> YouTrackAppManifest) {
     val manifestJson = getMockPluginFileContent("manifest.json")
     val manifest = modify(jacksonObjectMapper().readValue(manifestJson, YouTrackAppManifest::class.java))

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.mocks.BasePluginManagerTest
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import com.jetbrains.plugin.structure.youtrack.YouTrackPlugin
 import com.jetbrains.plugin.structure.youtrack.YouTrackPluginManager
+import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppFields
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppManifest
 import com.jetbrains.plugin.structure.youtrack.bean.YouTrackAppWidget
 import com.jetbrains.plugin.structure.youtrack.problems.*
@@ -51,42 +52,42 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `invalid app name`() {
-    checkInvalidPlugin(ManifestPropertyNotSpecified("name")) { it.copy(name = null) }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.NAME)) { it.copy(name = null) }
     checkInvalidPlugin(AppNameIsBlank()) { it.copy(name = "") }
     checkInvalidPlugin(UnsupportedSymbolsAppNameProblem()) { it.copy(name = "hello world") }
   }
 
   @Test
   fun `invalid app title`() {
-    checkInvalidPlugin(ManifestPropertyNotSpecified("title")) { it.copy(title = null) }
-    checkInvalidPlugin(ManifestPropertyNotSpecified("title")) { it.copy(title = "") }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE)) { it.copy(title = null) }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE)) { it.copy(title = "") }
   }
 
   @Test
   fun `app title is too long`() {
     var longTitle = "a"
     repeat(MAX_NAME_LENGTH) { longTitle += "a" }
-    val expectedProblem = TooLongPropertyValue("manifest.json", "title", longTitle.length, MAX_NAME_LENGTH)
+    val expectedProblem = TooLongPropertyValue("manifest.json", YouTrackAppFields.Manifest.TITLE, longTitle.length, MAX_NAME_LENGTH)
     checkInvalidPlugin(expectedProblem) { it.copy(title = longTitle) }
   }
 
   @Test
   fun `invalid app description`() {
-    checkInvalidPlugin(ManifestPropertyNotSpecified("description")) { it.copy(description = null) }
-    checkInvalidPlugin(ManifestPropertyNotSpecified("description")) { it.copy(description = "") }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION)) { it.copy(description = null) }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION)) { it.copy(description = "") }
   }
 
   @Test
   fun `invalid app version`() {
-    checkInvalidPlugin(ManifestPropertyNotSpecified("version")) { it.copy(version = null) }
-    checkInvalidPlugin(ManifestPropertyNotSpecified("version")) { it.copy(version = "") }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.VERSION)) { it.copy(version = null) }
+    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.VERSION)) { it.copy(version = "") }
   }
 
   @Test
   fun `app changeNotes is too long`() {
     var longChangeNotes = "a"
     repeat(MAX_CHANGE_NOTES_LENGTH) { longChangeNotes += "a" }
-    val expectedProblem = TooLongPropertyValue("manifest.json", "changeNotes", longChangeNotes.length, MAX_CHANGE_NOTES_LENGTH)
+    val expectedProblem = TooLongPropertyValue("manifest.json", YouTrackAppFields.Manifest.NOTES, longChangeNotes.length, MAX_CHANGE_NOTES_LENGTH)
     checkInvalidPlugin(expectedProblem) { it.copy(changeNotes = longChangeNotes) }
   }
 
@@ -115,8 +116,8 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
   fun `invalid widget indexPath`() {
     val widgets = listOf(widget.copy(key = "1", indexPath = null), widget.copy(key = "2", indexPath = null), widget)
     checkInvalidPlugin(
-      WidgetManifestPropertyNotSpecified("indexPath", "1"),
-      WidgetManifestPropertyNotSpecified("indexPath", "2")
+      WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.INDEX_PATH, "1"),
+      WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.INDEX_PATH, "2")
     ) { it.copy(widgets = widgets) }
   }
 
@@ -124,8 +125,8 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
   fun `invalid widget extensionPoint`() {
     val widgets = listOf(widget.copy(key = "1", extensionPoint = null), widget.copy(key = "2", extensionPoint = null), widget)
     checkInvalidPlugin(
-      WidgetManifestPropertyNotSpecified("extensionPoint", "1"),
-      WidgetManifestPropertyNotSpecified("extensionPoint", "2")
+      WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.EXTENSION_POINT, "1"),
+      WidgetManifestPropertyNotSpecified(YouTrackAppFields.Widget.EXTENSION_POINT, "2")
     ) { it.copy(widgets = widgets) }
   }
 
@@ -134,12 +135,12 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
     checkInvalidPlugin(
       InvalidSemverVersion(
         descriptorPath = YouTrackPluginManager.DESCRIPTOR_NAME,
-        versionName = "minYouTrackVersion",
+        versionName = YouTrackAppFields.Manifest.SINCE,
         version = "123"
       ),
       InvalidSemverVersion(
         descriptorPath = YouTrackPluginManager.DESCRIPTOR_NAME,
-        versionName = "maxYouTrackVersion",
+        versionName = YouTrackAppFields.Manifest.UNTIL,
         version = "456"
       )
     ) { it.copy(minYouTrackVersion = "123", maxYouTrackVersion = "456") }


### PR DESCRIPTION
In the branch, I moved semver validation errors from `fleet` and `toolbox` packages to `base` and reused them for `youtrack` version validation. Also, the method to get `long` from the YouTube version was added.