### PR TITLE
Dependency graph resolves modules in the 2024.2 layout

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
@@ -43,6 +43,7 @@ internal class ModuleFactory(private val moduleLoader: LayoutComponentLoader, pr
         IdeModule
           .clone(moduleLoadingResult.plugin, moduleName)
           .apply {
+            definedModules += moduleName
             classpath += classpathProvider.getClasspath(moduleName).map { idePath.resolve(it) }
             moduleDependencies += moduleDescriptor.dependencies
             resources += moduleDescriptor.resources


### PR DESCRIPTION
When creating dependency graph, resolve modules in the 2024.2.

Treat `IdeModule` as a plugin that treats itself as a module, in the same vein as if it was declared in the `<module>` element in the descriptor.

This fixes reports of failed module/plugin resolutions in the dependency report, such as:

```
(failed) module intellij.platform.vcs.impl: Plugins declaring module 'intellij.platform.vcs.impl' are not found in JetBrains Marketplace https://plugins.jetbrains.com
| +--- (optional) com.intellij.java:242.19533.56
```

This resolves the situation in the `BundledPluginsRepository` which discovers plugin by the module ID (`findPluginByModule`). Since many bundled plugins now pose as platform modules, the bundled plugin that is both module and a plugin is now discovered with the same algorithm as the original bundled plugins which are not modules yet.

See [MP-6704](https://youtrack.jetbrains.com/issue/MP-6704) Plugin Verifier: Reports do not show properly resolved dependencies