### PR TITLE
Unresolved com.intellij.modules.rider in the Rider IDE

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -48,7 +48,7 @@ class ProductInfoBasedIdeManager : IdeManager() {
     assertProductInfoPresent(idePath)
     try {
       val productInfo = productInfoParser.parse(idePath.productInfoJson)
-      val ideVersion = version ?: IdeVersion.createIdeVersion(productInfo.buildNumber)
+      val ideVersion = version ?: createIdeVersion(productInfo)
       return createIde(idePath, ideVersion, productInfo)
     } catch (e: ProductInfoParseException) {
       throw InvalidIdeException(idePath, e)
@@ -136,6 +136,15 @@ class ProductInfoBasedIdeManager : IdeManager() {
     .createBundledPlugin(pluginArtifactPath, ideVersion, descriptorPath)
     .withPath(pluginArtifactPath)
 
+  private fun createIdeVersion(productInfo: ProductInfo): IdeVersion {
+    val versionString = buildString {
+      with(productInfo) {
+        if (productCode.isNotEmpty()) append(productCode).append("-")
+        append(buildNumber)
+      }
+    }
+    return IdeVersion.createIdeVersion(versionString)
+  }
 
   private fun getResourceResolver(layoutComponent: LayoutComponent, idePath: Path): NamedResourceResolver? {
     return if (layoutComponent is LayoutComponent.Classpathable) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/BundledModulesResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/BundledModulesResolver.kt
@@ -24,7 +24,7 @@ class BundledModulesResolver(val idePath: Path, private val jarFileSystemProvide
 
   init {
     if (!moduleDescriptorsJarPath.exists()) {
-      throw InvalidIdeException("IDE path [$idePath] does not contain '$MODULES_DIR/$MODULES_DIR' file")
+      throw InvalidIdeException("IDE path [$idePath] does not contain '$MODULES_DIR/$MODULE_DESCRIPTORS_JAR' file")
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockRiderBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockRiderBuilder.kt
@@ -1,0 +1,72 @@
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.ide.IntelliJPlatformProduct.RIDER
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+private val IDE_VERSION = IdeVersion.createIdeVersion("RD-242.19533.58")
+
+class MockRiderBuilder (private val temporaryFolder: TemporaryFolder, private val ideVersion: IdeVersion = IDE_VERSION) {
+  private val ideRoot: Path by lazy {
+    temporaryFolder.newFolder(ideVersion.asString()).toPath()
+  }
+
+  private val platformPrefix: String = (IntelliJPlatformProduct.fromIdeVersion(ideVersion)?: RIDER).platformPrefix
+
+  fun buildIdeaDirectory() = buildDirectory(ideRoot) {
+    file("build.txt", ideVersion.asString())
+    file("product-info.json", productInfoJson())
+    dir("lib") {
+      zip("app-client.jar") {
+        dir("META-INF") {
+          file("${platformPrefix}Plugin.xml", platformLangPluginXml)
+        }
+      }
+    }
+    dir("modules") {
+      zip("module-descriptors.jar") {
+        // intentionally left empty as there are no modules
+      }
+    }
+  }
+
+  private fun productInfoJson(): String {
+    return """
+        {
+          "name": "JetBrains Rider",
+          "version": "2024.2",
+          "versionSuffix": "EAP 5",
+          "buildNumber": "242.19533.58",
+          "productCode": "RD",
+          "dataDirectoryName": "Rider2024.2",
+          "svgIconPath": "bin/rider.svg",
+          "productVendor": "JetBrains",
+          "launch": [],
+          "customProperties": [],
+          "bundledPlugins": [],
+          "modules": [
+            "com.intellij.modules.rider"
+          ],
+          "fileExtensions": [],
+          "layout": [
+            {
+              "name": "com.intellij.modules.rider",
+              "kind": "pluginAlias"
+            }
+          ]
+        }
+    """.trimIndent()
+  }
+
+  private val platformLangPluginXml: String
+    get() = """
+    <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+      <id>com.intellij</id>
+      <name>IDEA CORE</name>
+    
+      <module value="com.intellij.modules.rider"/>
+    </idea-plugin>        
+    """.trimIndent()
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -61,4 +61,24 @@ class ProductInfoBasedIdeManagerTest {
       assertEquals(4, definedModules.size)
     }
   }
+
+  @Test
+  fun `create nonIDEA IDE manager from mock IDE`() {
+    val ideManager = ProductInfoBasedIdeManager()
+    val ideRoot = MockRiderBuilder(temporaryFolder).buildIdeaDirectory()
+    val ide = ideManager.createIde(ideRoot)
+
+    val ideCore = ide.getPluginById("com.intellij")
+    assertNotNull(ideCore)
+    with(ideCore!!) {
+      with(definedModules) {
+        assertEquals(1, size)
+        assertEquals("com.intellij.modules.rider", definedModules.first())
+      }
+    }
+    val riderModule = ide.getPluginByModule("com.intellij.modules.rider")
+    assertNotNull(riderModule)
+    riderModule!!
+    assertTrue(ideCore.pluginId == riderModule.pluginId)
+  }
 }


### PR DESCRIPTION
This fix addresses an issue where the Plugin Verifier cannot resolve `com.intellij.modules.rider` modules in the Rider IDE.

In the Platform 2024.2+ layout, the Product Prefix was not properly resolved when using non-IDEA IDEs. This prefix is used to discover and resolve one of the Core Plugin descriptors.

For example, for JetBrains Rider, the Core Plugin descriptor resides in `lib/app.jar!META-INF/RiderPlugin.xml`, where `Rider` is derived from the Product Prefix.

This PR will extract the Product Prefix from the `product-info.json` and use it to correctly resolve the descriptor for the Core Plugin.

See [MP-6707](https://youtrack.jetbrains.com/issue/MP-6707)
See [PY-73342](https://youtrack.jetbrains.com/issue/PY-73342/Plugins-Compatibility-Check-com.github.copilot1.5.7.5758-Package-com.jetbrains.python-is-not-found)