### PR TITLE
Add modules of v2 plugin to `definedModules`

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -186,6 +186,7 @@ internal class PluginCreator private constructor(
           }
         }
         plugin.modulesDescriptors.add(ModuleDescriptor(moduleName, module.dependencies, module, configurationFile))
+        plugin.definedModules.add(moduleName)
 
         mergeContent(module)
       }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/DefinedModulesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/DefinedModulesTest.kt
@@ -1,0 +1,189 @@
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.Test
+import java.nio.file.Paths
+import org.junit.Assert.assertEquals
+
+class DefinedModulesTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
+
+    private val mockPluginRoot = Paths.get(this::class.java.getResource("/python-plugin").toURI())
+    private val metaInfDir = mockPluginRoot.resolve("META-INF")
+
+    @Test
+    fun `python defined modules`() {
+        val plugin = buildPluginSuccess(emptyList()) {
+            buildZipFile(temporaryFolder.newFile("plugin.zip")) {
+                dir("python") {
+                    dir("lib") {
+                        zip("plugin.jar") {
+                            dir("META-INF", metaInfDir)
+                            file(
+                                "intellij.commandInterface.xml",
+                                mockPluginRoot.resolve("intellij.commandInterface.xml")
+                            )
+                            file("intellij.django.core.xml", mockPluginRoot.resolve("intellij.django.core.xml"))
+                            file("intellij.jinja.xml", mockPluginRoot.resolve("intellij.jinja.xml"))
+                            file("intellij.jupyter.core.xml", mockPluginRoot.resolve("intellij.jupyter.core.xml"))
+                            file(
+                                "intellij.platform.commercial.verifier.xml",
+                                mockPluginRoot.resolve("intellij.platform.commercial.verifier.xml")
+                            )
+                            file(
+                                "intellij.python.community.deprecated.extensions.xml",
+                                mockPluginRoot.resolve("intellij.python.community.deprecated.extensions.xml")
+                            )
+                            file(
+                                "intellij.python.community.impl.community_only.xml",
+                                mockPluginRoot.resolve("intellij.python.community.impl.community_only.xml")
+                            )
+                            file(
+                                "intellij.python.community.impl.huggingFace.xml",
+                                mockPluginRoot.resolve("intellij.python.community.impl.huggingFace.xml")
+                            )
+                            file(
+                                "intellij.python.community.impl.poetry.xml",
+                                mockPluginRoot.resolve("intellij.python.community.impl.poetry.xml")
+                            )
+                            file(
+                                "intellij.python.community.impl.xml",
+                                mockPluginRoot.resolve("intellij.python.community.impl.xml")
+                            )
+                            file(
+                                "intellij.python.community.plugin.impl.xml",
+                                mockPluginRoot.resolve("intellij.python.community.plugin.impl.xml")
+                            )
+                            file(
+                                "intellij.python.community.plugin.java.xml",
+                                mockPluginRoot.resolve("intellij.python.community.plugin.java.xml")
+                            )
+                            file(
+                                "intellij.python.concurrencyVisualizer.xml",
+                                mockPluginRoot.resolve("intellij.python.concurrencyVisualizer.xml")
+                            )
+                            file(
+                                "intellij.python.copyright.xml",
+                                mockPluginRoot.resolve("intellij.python.copyright.xml")
+                            )
+                            file(
+                                "intellij.python.djangoDbConfig.xml",
+                                mockPluginRoot.resolve("intellij.python.djangoDbConfig.xml")
+                            )
+                            file("intellij.python.docker.xml", mockPluginRoot.resolve("intellij.python.docker.xml"))
+                            file(
+                                "intellij.python.duplicatesDetection.xml",
+                                mockPluginRoot.resolve("intellij.python.duplicatesDetection.xml")
+                            )
+                            file(
+                                "intellij.python.endpoints.xml",
+                                mockPluginRoot.resolve("intellij.python.endpoints.xml")
+                            )
+                            file(
+                                "intellij.python.featuresTrainer.xml",
+                                mockPluginRoot.resolve("intellij.python.featuresTrainer.xml")
+                            )
+                            file("intellij.python.gherkin.xml", mockPluginRoot.resolve("intellij.python.gherkin.xml"))
+                            file("intellij.python.grazie.xml", mockPluginRoot.resolve("intellij.python.grazie.xml"))
+                            file(
+                                "intellij.python.javascript.debugger.xml",
+                                mockPluginRoot.resolve("intellij.python.javascript.debugger.xml")
+                            )
+                            file(
+                                "intellij.python.langInjection.xml",
+                                mockPluginRoot.resolve("intellij.python.langInjection.xml")
+                            )
+                            file("intellij.python.markdown.xml", mockPluginRoot.resolve("intellij.python.markdown.xml"))
+                            file(
+                                "intellij.python.plugin.java.xml",
+                                mockPluginRoot.resolve("intellij.python.plugin.java.xml")
+                            )
+                            file("intellij.python.pro.js.xml", mockPluginRoot.resolve("intellij.python.pro.js.xml"))
+                            file(
+                                "intellij.python.pro.localization.xml",
+                                mockPluginRoot.resolve("intellij.python.pro.localization.xml")
+                            )
+                            file("intellij.python.profiler.xml", mockPluginRoot.resolve("intellij.python.profiler.xml"))
+                            file("intellij.python.pyramid.xml", mockPluginRoot.resolve("intellij.python.pyramid.xml"))
+                            file(
+                                "intellij.python.pytestBdd.xml",
+                                mockPluginRoot.resolve("intellij.python.pytestBdd.xml")
+                            )
+                            file(
+                                "intellij.python.remoteInterpreter.xml",
+                                mockPluginRoot.resolve("intellij.python.remoteInterpreter.xml")
+                            )
+                            file(
+                                "intellij.python.reStructuredText.xml",
+                                mockPluginRoot.resolve("intellij.python.reStructuredText.xml")
+                            )
+                            file(
+                                "intellij.python.scientific.xml",
+                                mockPluginRoot.resolve("intellij.python.scientific.xml")
+                            )
+                            file(
+                                "intellij.python.templateLanguages.xml",
+                                mockPluginRoot.resolve("intellij.python.templateLanguages.xml")
+                            )
+                            file("intellij.python.terminal.xml", mockPluginRoot.resolve("intellij.python.terminal.xml"))
+                            file("intellij.python.uml.xml", mockPluginRoot.resolve("intellij.python.uml.xml"))
+                            file("intellij.python.wsl.xml", mockPluginRoot.resolve("intellij.python.wsl.xml"))
+                            file("intellij.python.xml", mockPluginRoot.resolve("intellij.python.xml"))
+                            file("intellij.template.lang.core.xml", mockPluginRoot.resolve("intellij.template.lang.core.xml"))
+                            file("intellij.python.endpointsHttpclient.xml", mockPluginRoot.resolve("intellij.python.endpointsHttpclient.xml"))
+                            file("intellij.python.endpointsMicroservicesUI.xml", mockPluginRoot.resolve("intellij.python.endpointsMicroservicesUI.xml"))
+                        }
+                    }
+                }
+            }
+        }
+
+        val expectedModules = listOf(
+            "com.intellij.modules.python",
+            "com.intellij.modules.python.scientific",
+            "intellij.commandInterface",
+            "intellij.django.core",
+            "intellij.jinja",
+            "intellij.python",
+            "intellij.python.community.deprecated.extensions",
+            "intellij.python.community.impl",
+            "intellij.python.community.impl.huggingFace",
+            "intellij.python.community.impl.poetry",
+            "intellij.python.community.plugin.impl",
+            "intellij.python.community.plugin.java",
+            "intellij.python.concurrencyVisualizer",
+            "intellij.python.copyright",
+            "intellij.python.djangoDbConfig",
+            "intellij.python.docker",
+            "intellij.python.duplicatesDetection",
+            "intellij.python.endpoints",
+            "intellij.python.endpointsHttpclient",
+            "intellij.python.endpointsMicroservicesUI",
+            "intellij.python.featuresTrainer",
+            "intellij.python.gherkin",
+            "intellij.python.grazie",
+            "intellij.python.javascript.debugger",
+            "intellij.python.langInjection",
+            "intellij.python.markdown",
+            "intellij.python.plugin.java",
+            "intellij.python.pro.js",
+            "intellij.python.pro.localization",
+            "intellij.python.profiler",
+            "intellij.python.pyramid",
+            "intellij.python.pytestBdd",
+            "intellij.python.reStructuredText",
+            "intellij.python.remoteInterpreter",
+            "intellij.python.scientific",
+            "intellij.python.templateLanguages",
+            "intellij.python.terminal",
+            "intellij.python.uml",
+            "intellij.python.wsl",
+            "intellij.template.lang.core",
+        )
+        val modules = plugin.definedModules
+        assertEquals(expectedModules.size, modules.size)
+        expectedModules.forEach {
+            assert(modules.contains(it)) { "There is no module $it" }
+        }
+    }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
@@ -1,0 +1,22 @@
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.Assert.assertEquals
+import java.nio.file.Path
+
+abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
+    override fun createManager(extractDirectory: Path): IdePluginManager =
+        IdePluginManager.createManager(extractDirectory)
+
+    protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
+        val pluginFile = pluginFileBuilder()
+        val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
+        val (plugin, warnings) = successResult
+        assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
+        assertEquals(pluginFile, plugin.originalFile)
+        return plugin
+    }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -1,24 +1,24 @@
 package com.jetbrains.plugin.structure.mocks
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.classes.resolvers.*
 import com.jetbrains.plugin.structure.intellij.classes.locator.PluginFileOrigin
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
-import com.jetbrains.plugin.structure.intellij.plugin.*
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.plugin.PluginXmlUtil.getAllClassesReferencedFromXml
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*
 import org.junit.Test
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
 
-class MockPluginsV2Test(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
+class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
   private val mockPluginRoot = Paths.get(this::class.java.getResource("/mock-plugin-v2").toURI())
   private val metaInfDir = mockPluginRoot.resolve("META-INF")
   private val v2ModuleFile = mockPluginRoot.resolve("intellij.v2.module.xml")
@@ -35,18 +35,6 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : BasePluginManagerTest<
       listOf(PluginDescriptorIsNotFound("../intellij.v2.missing.xml"))
     )
   )
-
-  private fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFileBuilder: () -> Path): IdePlugin {
-    val pluginFile = pluginFileBuilder()
-    val successResult = createPluginSuccessfully(pluginFile)
-    val (plugin, warnings) = successResult
-    assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
-    assertEquals(pluginFile, plugin.originalFile)
-    return plugin
-  }
-
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
 
   @Test
   fun `single jar file`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -2,16 +2,9 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
-import com.jetbrains.plugin.structure.classes.resolvers.DirectoryFileOrigin
-import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
-import com.jetbrains.plugin.structure.classes.resolvers.JarFileResolver
-import com.jetbrains.plugin.structure.classes.resolvers.JarOrZipFileOrigin
-import com.jetbrains.plugin.structure.classes.resolvers.ResolutionResult
-import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.classes.resolvers.*
 import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExtensionKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.PluginFileOrigin
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
@@ -21,21 +14,16 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.plugin.PluginXmlUtil.getAllClassesReferencedFromXml
-import com.jetbrains.plugin.structure.intellij.problems.DuplicatedDependencyWarning
-import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyDescriptorResolutionProblem
-import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsMultipleFiles
-import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsSingleJarInRoot
-import com.jetbrains.plugin.structure.intellij.problems.UnexpectedPluginZipStructure
+import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*
 import org.junit.Test
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
 import java.util.*
 
-class MockPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
+class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
   private val mockPluginRoot = Paths.get(this::class.java.getResource("/mock-plugin").toURI())
   private val metaInfDir = mockPluginRoot.resolve("META-INF")
 
@@ -60,18 +48,6 @@ class MockPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<Id
     ),
     DuplicatedDependencyWarning("duplicatedDependencyId"),
   )
-
-  private fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
-    val pluginFile = pluginFileBuilder()
-    val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
-    val (plugin, warnings) = successResult
-    assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
-    assertEquals(pluginFile, plugin.originalFile)
-    return plugin
-  }
-
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
 
   @Test
   fun `single jar file`() {

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonParser.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonParser.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonPsi.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonPsi.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonPsiImpl.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonPsiImpl.xml
@@ -1,0 +1,7 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <xi:include href="/META-INF/PythonSyntaxCore.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSdk.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSdk.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSyntax.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSyntax.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSyntaxCore.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/PythonSyntaxCore.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/jupyter-core.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/jupyter-core.xml
@@ -1,0 +1,5 @@
+<!-- Jupyter language -->
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/plugin.xml
@@ -1,0 +1,64 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" url="https://confluence.jetbrains.com/display/PYH/" package="PythonId">
+  <!-- Python Prof plugin installed both on IU and PyCharm Prof -->
+
+  <id>Pythonid</id>
+
+  <version>241.18034.62</version>
+
+  <idea-version since-build="241.18034" until-build="241.*"/>
+  <name>Python</name>
+
+  <description><![CDATA[
+The Python plug-in provides smart editing for Python scripts. The feature set of the plugin
+ corresponds to PyCharm IDE Professional Edition.
+<br>
+<a href="https://blog.jetbrains.com/pycharm">PyCharm blog</a><br>
+<a href="https://forum.jetbrains.com/forum/PyCharm">Discussion forum</a><br>
+<a href="https://youtrack.jetbrains.com/issues/PY">Issue tracker</a><br>
+]]></description>
+
+  <vendor url="https://www.jetbrains.com/pycharm/">JetBrains</vendor>
+  <!-- Declare that we support python -->
+  <module value="com.intellij.modules.python"/>
+  <module value="com.intellij.modules.python.scientific"/>
+  <!-- Part shared with community -->
+  <xi:include href="/META-INF/python-v2-core-plugin-content-include.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
+  <!-- and pro part -->
+  <dependencies>
+    <module name="intellij.notebooks.ui"/>
+    <module name="intellij.notebooks.visualization"/>
+    <plugin id="com.intellij.modules.python-pro-capable"/> <!-- Only enable plugin if IDe supports python pro -->
+    <plugin id="com.intellij.modules.ultimate"/>
+    <plugin id="org.toml.lang"/><!-- intellij.python.community.imp doesn't work without it -->
+  </dependencies>
+
+  <content>
+    <module name="intellij.python.scientific"/>
+    <module name="intellij.python.plugin.java"/> <!-- Java for IU -->
+    <module name="intellij.django.core"/> <!-- Django core part -->
+    <module name="intellij.jinja"/> <!-- Jinja is a template lang -->
+    <module name="intellij.python.concurrencyVisualizer"/>
+    <module name="intellij.python.djangoDbConfig"/>
+    <module name="intellij.python.docker"/>
+    <module name="intellij.python.duplicatesDetection"/>
+    <module name="intellij.python.endpoints"/>
+    <module name="intellij.python.endpointsHttpclient"/>
+    <module name="intellij.python.endpointsMicroservicesUI"/>
+    <module name="intellij.python.gherkin"/>
+    <module name="intellij.python.javascript.debugger"/>
+    <module name="intellij.python.profiler"/>
+    <module name="intellij.python.pyramid"/>
+    <module name="intellij.python.pytestBdd"/>
+    <module name="intellij.python.remoteInterpreter"/>
+    <module name="intellij.python.uml"/>
+    <module name="intellij.python.wsl"/>
+    <module name="intellij.python.pro.js"/>
+    <module name="intellij.python.pro.localization"/>
+    <module name="intellij.python.templateLanguages"/>
+    <module name="intellij.python"/> <!-- Closed-source python -->
+    <module name="intellij.template.lang.core"/>
+    <module name="intellij.python.community.deprecated.extensions"/><!-- backward comp -->
+  </content>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/python-v2-core-plugin-content-include.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/META-INF/python-v2-core-plugin-content-include.xml
@@ -1,0 +1,20 @@
+<idea-plugin>
+  <!--This is not a module, but a part of `plugin.xml` to be included. Only content could be shared for now-->
+
+  <!--These modules are used both in Python Community and Prof-->
+  <content>
+    <module name="intellij.commandInterface"/> <!-- used by Django in Prof, by some plugins in community -->
+    <module name="intellij.python.community.impl"/> <!-- The whole open-source part of Python support -->
+    <module name="intellij.python.community.impl.poetry"/>
+    <module name="intellij.python.community.impl.huggingFace"/>
+    <module name="intellij.python.community.plugin.impl"/><!--Python for any IDE except PyCharm -->
+    <module name="intellij.python.community.plugin.java"/><!-- Python for Java IDE -->
+    <module name="intellij.python.copyright"/>
+    <module name="intellij.python.featuresTrainer"/>
+    <module name="intellij.python.grazie"/>
+    <module name="intellij.python.langInjection"/>
+    <module name="intellij.python.markdown"/>
+    <module name="intellij.python.reStructuredText"/>
+    <module name="intellij.python.terminal"/>
+  </content>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.commandInterface.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.commandInterface.xml
@@ -1,0 +1,12 @@
+<idea-plugin package="com.intellij.commandInterface">
+  <dependencies>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+  </dependencies>
+  <!--
+   Extension points to support gnu command line language.
+   See {@link com.intellij.commandInterface.commandLine}
+  -->
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.django.core.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.django.core.xml
@@ -1,0 +1,11 @@
+<idea-plugin package="com.jetbrains.django">
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <module name="intellij.jinja"/>
+    <module name="intellij.template.lang.core"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.jinja.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.jinja.xml
@@ -1,0 +1,9 @@
+<idea-plugin package="com.intellij.jinja">
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.template.lang.core"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.jupyter.core.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.jupyter.core.xml
@@ -1,0 +1,3 @@
+<idea-plugin package="com.intellij.jupyter.core" xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="/META-INF/jupyter-core.xml"/>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.platform.commercial.verifier.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.platform.commercial.verifier.xml
@@ -1,0 +1,4 @@
+<!-- package is not specific, but it cannot be changed due to backward compatibility,
+ and package anyway is not used in our project for something else -->
+<idea-plugin package="com.intellij.ultimate">
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.deprecated.extensions.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.deprecated.extensions.xml
@@ -1,0 +1,7 @@
+<idea-plugin package="com.jetbrains.extensions">
+  <!--This module will be removed soon, do not use it-->
+  <dependencies>
+    <plugin id="com.intellij.modules.lang"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.community_only.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.community_only.xml
@@ -1,0 +1,9 @@
+<!-- Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<idea-plugin package="com.intellij.python.community.impl.community_only">
+  <!--Community only, never professional: both plugin and DS -->
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.huggingFace.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.huggingFace.xml
@@ -1,0 +1,7 @@
+<idea-plugin package="com.intellij.python.community.impl.huggingFace">
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.poetry.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.poetry.xml
@@ -1,0 +1,8 @@
+<idea-plugin package="com.intellij.python.community.impl.poetry">
+  <dependencies>
+    <plugin id="org.toml.lang"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.impl.xml
@@ -1,0 +1,23 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude" package="com.jetbrains.python">
+  <!--Part of both: community and prof -->
+
+  <dependencies>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="org.toml.lang"/>
+  </dependencies>
+
+  <resource-bundle>messages.PyBundle</resource-bundle>
+
+
+  <xi:include href="/META-INF/PythonParser.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/PythonPsi.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/PythonPsiImpl.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/PythonSdk.xml" xpointer="xpointer(/idea-plugin/*)"/>
+  <xi:include href="/META-INF/PythonSyntax.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.plugin.impl.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.plugin.impl.xml
@@ -1,0 +1,13 @@
+<idea-plugin package="com.intellij.python.community.plugin.impl">
+  <!--Plugin for other (not PyCharm) IDEs, including IU-->
+  <dependencies>
+    <!--Any IDE but NOT PyCharm-->
+    <plugin id="com.intellij.modules.python-in-non-pycharm-ide-capable"/>
+
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.plugin.java.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.community.plugin.java.xml
@@ -1,0 +1,15 @@
+<idea-plugin package="com.intellij.python.community.plugin.java">
+  <!--For IU or IC-->
+  <dependencies>
+    <!-- Supports Java -->
+    <plugin id="com.intellij.java"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python.community.plugin.impl"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.concurrencyVisualizer.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.concurrencyVisualizer.xml
@@ -1,0 +1,9 @@
+<idea-plugin package="com.intellij.python.concurrencyVisualizer">
+  <dependencies>
+    <module name="intellij.profiler.common"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.copyright.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.copyright.xml
@@ -1,0 +1,8 @@
+<idea-plugin package="com.intellij.python.copyright">
+  <dependencies>
+    <plugin id="com.intellij.copyright"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij.copyright">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.djangoDbConfig.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.djangoDbConfig.xml
@@ -1,0 +1,13 @@
+<idea-plugin package="com.intellij.python.djangoDbConfig">
+  <dependencies>
+    <plugin id="com.intellij.modules.database.core"/>
+    <plugin id="com.intellij.modules.database"/>
+    <plugin id="intellij.python.django"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+    <module name="intellij.django.core"/>
+    <module name="intellij.jinja"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.docker.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.docker.xml
@@ -1,0 +1,14 @@
+<idea-plugin package="com.intellij.python.docker">
+  <dependencies>
+    <module name="intellij.clouds.docker.remoteRun"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python.remoteInterpreter"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.duplicatesDetection.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.duplicatesDetection.xml
@@ -1,0 +1,11 @@
+<idea-plugin package="com.intellij.python.duplicatesDetection">
+  <dependencies>
+    <plugin id="com.intellij.modules.duplicatesDetector"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpoints.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpoints.xml
@@ -1,0 +1,11 @@
+<idea-plugin package="com.intellij.python.endpoints">
+  <dependencies>
+    <module name="intellij.python.community.impl"/> <!-- The whole open-source part of Python support -->
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpointsHttpclient.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpointsHttpclient.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.python.endpointsHttpclient">
+  <dependencies>
+    <module name="intellij.python.endpoints"/>
+    <plugin id="com.jetbrains.restClient"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij.python.endpoints">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpointsMicroservicesUI.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.endpointsMicroservicesUI.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.python.endpointsMicroservicesUI">
+  <dependencies>
+    <module name="intellij.python.endpoints"/>
+    <plugin id="com.intellij.microservices.ui"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij.python.endpoints">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.featuresTrainer.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.featuresTrainer.xml
@@ -1,0 +1,8 @@
+<idea-plugin package="com.intellij.python.featuresTrainer">
+  <dependencies>
+    <plugin id="training"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="training">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.gherkin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.gherkin.xml
@@ -1,0 +1,15 @@
+<idea-plugin package="com.intellij.python.gherkin">
+  <dependencies>
+    <plugin id="gherkin"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+    <module name="intellij.django.core"/>
+  </dependencies>
+  <!-- Inject Gherkin -->
+  <extensions defaultExtensionNs="org.jetbrains.plugins.cucumber.steps">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.grazie.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.grazie.xml
@@ -1,0 +1,8 @@
+<idea-plugin package="com.intellij.python.grazie">
+<dependencies>
+  <plugin id="tanvd.grazi"/>
+  <module name="intellij.python.community.impl"/>
+</dependencies>
+  <extensions defaultExtensionNs="com.intellij.grazie">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.javascript.debugger.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.javascript.debugger.xml
@@ -1,0 +1,9 @@
+<idea-plugin package="com.intellij.python.javascript.debugger">
+  <dependencies>
+    <plugin id="JavaScriptDebugger"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+  </dependencies>
+  <extensions defaultExtensionNs="org.jetbrains">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.langInjection.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.langInjection.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.python.langInjection">
+  <dependencies>
+    <plugin id="org.intellij.intelliLang"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="org.intellij.intelliLang">
+  </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.markdown.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.markdown.xml
@@ -1,0 +1,8 @@
+<idea-plugin package="com.intellij.python.markdown">
+  <dependencies>
+    <plugin id="org.intellij.plugins.markdown"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="org.intellij.markdown">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.plugin.java.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.plugin.java.xml
@@ -1,0 +1,16 @@
+<idea-plugin package="com.intellij.python.plugin.java">
+  <!-- Python of Idea Ultimate -->
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python.community.plugin.java"/>
+    <module name="intellij.python"/>
+
+    <plugin id="com.intellij.java"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.python-in-non-pycharm-ide-capable"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pro.js.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pro.js.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.python.pro.js">
+  <dependencies>
+    <plugin id="JavaScript"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <module name="intellij.template.lang.core"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pro.localization.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pro.localization.xml
@@ -1,0 +1,12 @@
+<idea-plugin package="com.intellij.python.pro.localization">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.localization"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+    <module name="intellij.jinja"/>
+    <module name="intellij.django.core"/>
+    <module name="intellij.template.lang.core"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.profiler.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.profiler.xml
@@ -1,0 +1,16 @@
+<idea-plugin package="com.intellij.python.profiler">
+
+  <dependencies>
+    <plugin id="com.intellij.diagram"/>
+    <module name="intellij.profiler.asyncOne"/>
+    <module name="intellij.profiler.common"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.intellij.python.profiler">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pyramid.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pyramid.xml
@@ -1,0 +1,16 @@
+<idea-plugin package="com.intellij.python.pyramid">
+  <dependencies>
+    <module name="intellij.python.community.impl"/> <!-- The whole open-source part of Python support -->
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <module name="intellij.python.templateLanguages"/>
+    <module name="intellij.template.lang.core"/>
+    <module name="intellij.django.core"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pytestBdd.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.pytestBdd.xml
@@ -1,0 +1,15 @@
+<idea-plugin package="com.intellij.python.pytestBdd">
+  <dependencies>
+    <plugin id="gherkin"/>
+    <module name="intellij.python.gherkin"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+  <extensions defaultExtensionNs="org.jetbrains.plugins.cucumber.steps">
+  </extensions>
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.reStructuredText.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.reStructuredText.xml
@@ -1,0 +1,15 @@
+<idea-plugin package="com.intellij.python.reStructuredText">
+  <dependencies>
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.python"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.intellij.spellchecker">
+  </extensions>
+
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.remoteInterpreter.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.remoteInterpreter.xml
@@ -1,0 +1,17 @@
+<idea-plugin package="com.intellij.python.remoteInterpreter">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.remote-run"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+  <extensions defaultExtensionNs="RemoteRun">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.jetbrains.plugins.remotesdk">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.scientific.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.scientific.xml
@@ -1,0 +1,17 @@
+<idea-plugin package="com.intellij.python.scientific">
+  <dependencies>
+    <module name="intellij.python.community.impl"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="intellij.grid.impl"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.jetbrains.python.debugger">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.templateLanguages.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.templateLanguages.xml
@@ -1,0 +1,16 @@
+<idea-plugin package="com.intellij.python.templateLanguages">
+  <dependencies>
+    <module name="intellij.python.community.impl"/> <!-- The whole open-source part of Python support -->
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <module name="intellij.jinja"/>
+    <module name="intellij.template.lang.core"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.terminal.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.terminal.xml
@@ -1,0 +1,12 @@
+<idea-plugin package="com.intellij.python.terminal">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.terminal"/>
+    <module name="intellij.python.community.impl"/>
+  </dependencies>
+  <extensions defaultExtensionNs="org.jetbrains.plugins.terminal">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.intellij"/>
+
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.uml.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.uml.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.python.uml">
+<dependencies>
+  <plugin id="com.intellij.diagram"/>
+  <module name="intellij.python.community.impl"/>
+  <module name="intellij.python"/>
+</dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.wsl.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.wsl.xml
@@ -1,0 +1,13 @@
+<idea-plugin package="com.intellij.python.wsl">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.wsl.remoteSdk"/>
+    <module name="intellij.python.community.impl"/>
+    <module name="intellij.python.remoteInterpreter"/>
+    <plugin id="org.jetbrains.plugins.remote-run"/>
+  </dependencies>
+  <!-- Inject WSL -->
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.python.xml
@@ -1,0 +1,24 @@
+<idea-plugin package="com.intellij.python.pro">
+<!-- Python PRO only features, used both in fleet, Pycharm and plugin -->
+  <dependencies>
+    <module name="intellij.django.core"/> <!-- Django language -->
+    <module name="intellij.jinja"/>
+    <module name="intellij.python.community.impl"/> <!-- The whole open-source part of Python support -->
+    <module name="intellij.template.lang.core"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <plugin id="com.intellij.modules.platform"/>
+    <module name="intellij.commandInterface"/>  <!-- for django console -->
+    <module name="intellij.python.endpoints"/>
+    <module name="intellij.python.pyramid"/>
+    <module name="intellij.python.templateLanguages"/>
+  </dependencies>
+
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+
+  <extensions defaultExtensionNs="Pythonid">
+  </extensions>
+
+  <extensions defaultExtensionNs="com.jetbrains.python.debugger">
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.template.lang.core.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/python-plugin/intellij.template.lang.core.xml
@@ -1,0 +1,10 @@
+<idea-plugin package="com.intellij.template.lang.core">
+  <dependencies>
+    <plugin id="com.intellij.modules.platform"/>
+    <plugin id="com.intellij.modules.lang"/>
+    <module name="intellij.python.community.impl"/> <!-- Because of PSI -->
+
+  </dependencies>
+  <extensions defaultExtensionNs="com.intellij">
+  </extensions>
+</idea-plugin>


### PR DESCRIPTION
Since the modules of which the plugin v2 contains are the modules it defines, we need to add them to definedModules for correct compatibility calculation.

See this issue for more details [MP-6595](https://youtrack.jetbrains.com/issue/MP-6595) Support definedModules for v2 plugins. Use the python plugin content as a mock plugin for test, since it's the plugin we have in issue.