### PR TITLE
Fix NPE on delegate calls in OverrideOnly checks

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
@@ -23,8 +23,7 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
                      invocationInstruction: AbstractInsnNode,
                      callerMethod: Method,
                      context: VerificationContext): Boolean = with(context.classResolver) {
-    val isCallingAllowedMethod = isInvokedMethodAllowed(callerMethod, invokedMethod, invocationInstruction)
-    if (!isCallingAllowedMethod) {
+    if (!isInvokedMethodAllowed(callerMethod, invokedMethod, invocationInstruction)) {
       return false
     }
 


### PR DESCRIPTION
`DelegateCallOnOverrideOnlyUsageFilter` that checks for delegate calls on methods with `@OverrideOnly` might fail when a delegate is `super`.

Filter out such method calls immediately, as `SuperclassCallOnOverrideOnlyUsageFilter` might be applied only in the later stages of API usage filtering.

See [MP-6724](https://youtrack.jetbrains.com/issue/MP-6724) Plugin Verifier: NPE on delegate calls in OverrideOnly Checks