### PR TITLE
Fix NPE on static delegate calls in OverrideOnly checks

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
@@ -28,12 +28,9 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
       return false
     }
 
-    var ins = invocationInstruction
-    val callMethod = ins.narrow<MethodInsnNode>() ?: return false
-    ins = ins.previous
-    val loadMethodParameter = ins.narrow<VarInsnNode>() ?: return false
-    ins = ins.previous
-    val getDelegateField = ins.narrow<FieldInsnNode>() ?: return false
+    val callMethod = invocationInstruction.narrow<MethodInsnNode>() ?: return false
+    val loadMethodParameter = callMethod.previousInstruction<VarInsnNode>() ?: return false
+    val getDelegateField = loadMethodParameter.previousInstruction<FieldInsnNode>() ?: return false
 
     val delegateBinaryClassName = getDelegateField.fieldClass ?: return false
     val delegateClassNode = when (val classResolution = resolveClass(delegateBinaryClassName)) {
@@ -79,6 +76,10 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
     // static methods with @OverrideOnly do not make sense due to shadowing
     && !invocationInstruction.isStatic
     && !isCallOfSuperMethod(callerMethod, invokedMethod, invocationInstruction)
+
+  private inline fun <reified T : AbstractInsnNode> AbstractInsnNode?.previousInstruction(): T? {
+    return this?.previous?.narrow<T>()
+  }
 
   private inline fun <reified T : AbstractInsnNode> AbstractInsnNode.narrow(): T? {
     return if (this is T) this else null


### PR DESCRIPTION
`DelegateCallOnOverrideOnlyUsageFilter` that checks for delegate calls on methods with `@OverrideOnly` might fail when there is a similar method invocation, but with `static` modifier.

Invoking `static` methods with `@OverrideOnly` is contraintuitive as this leads to method shadowing.

See [MP-6724](https://youtrack.jetbrains.com/issue/MP-6724) 