### PR TITLE
Add unit test for `OverrideOnly` checks

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
@@ -29,8 +29,9 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
     }
 
     val callMethod = invocationInstruction.narrow<MethodInsnNode>() ?: return false
-    val loadMethodParameter = callMethod.previousInstruction<VarInsnNode>() ?: return false
-    val getDelegateField = loadMethodParameter.previousInstruction<FieldInsnNode>() ?: return false
+    val loadMethodParameter = callMethod.previousOf<VarInsnNode>() ?: return false
+    if (loadMethodParameter.isLoadThisReferenceOnOperandStack()) return false
+    val getDelegateField = loadMethodParameter.previousOf<FieldInsnNode>() ?: return false
 
     val delegateBinaryClassName = getDelegateField.fieldClass ?: return false
     val delegateClassNode = when (val classResolution = resolveClass(delegateBinaryClassName)) {
@@ -90,4 +91,19 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
 
   private val AbstractInsnNode.isStatic: Boolean
     get() = opcode == Opcodes.INVOKESTATIC
+
+  private fun VarInsnNode.isLoadThisReferenceOnOperandStack(): Boolean {
+    // see JLS§2.6.1: On instance method invocation, local variable 0 is always used to pass `this` in Java
+    return opcode == Opcodes.ALOAD && `var` == 0
+  }
+
+  private fun AbstractInsnNode.previousNodes() =
+    generateSequence(this.previous) {
+      it.previous
+    }
+
+  private inline fun <reified T : AbstractInsnNode> AbstractInsnNode.previousOf(): T? =
+    previousNodes()
+      .firstOrNull { it is T }
+      ?.narrow()
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
@@ -97,13 +97,13 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
     return opcode == Opcodes.ALOAD && `var` == 0
   }
 
-  private fun AbstractInsnNode.previousNodes() =
-    generateSequence(this.previous) {
+  private val AbstractInsnNode.previousNodes
+    get() = generateSequence(this.previous) {
       it.previous
     }
 
   private inline fun <reified T : AbstractInsnNode> AbstractInsnNode.previousOf(): T? =
-    previousNodes()
+    previousNodes
       .firstOrNull { it is T }
       ?.narrow()
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilter.kt
@@ -78,10 +78,6 @@ class DelegateCallOnOverrideOnlyUsageFilter : ApiUsageFilter {
     && !invocationInstruction.isStatic
     && !isCallOfSuperMethod(callerMethod, invokedMethod, invocationInstruction)
 
-  private inline fun <reified T : AbstractInsnNode> AbstractInsnNode?.previousInstruction(): T? {
-    return this?.previous?.narrow<T>()
-  }
-
   private inline fun <reified T : AbstractInsnNode> AbstractInsnNode.narrow(): T? {
     return if (this is T) this else null
   }

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/ClearCountingContainer.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/ClearCountingContainer.java
@@ -1,8 +1,6 @@
 package mock.plugin.overrideOnly;
 
-import java.util.Vector;
-
-public class ClearCountingVector extends Vector<String> {
+public class ClearCountingContainer extends Container {
     private int clearCount = 0;
 
     @Override

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/ClearCountingVector.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/ClearCountingVector.java
@@ -1,0 +1,13 @@
+package mock.plugin.overrideOnly;
+
+import java.util.Vector;
+
+public class ClearCountingVector extends Vector<String> {
+    private int clearCount = 0;
+
+    @Override
+    public void clear() {
+        super.clear();
+        clearCount++;
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/Container.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/Container.java
@@ -1,0 +1,7 @@
+package mock.plugin.overrideOnly;
+
+public class Container {
+    public void clear() {
+        // do nothing
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
@@ -1,6 +1,11 @@
 package mock.plugin.overrideOnly;
 
 public class PackageInvokingBox {
+    /*expected(DEPRECATED)
+    Deprecated method java.lang.Package.getPackage(String) invocation
+
+    Deprecated method java.lang.Package.getPackage(java.lang.String name) : java.lang.Package is invoked in mock.plugin.overrideOnly.PackageInvokingBox.getPackage(String) : Package
+    */
     @SuppressWarnings("deprecation")
     public Package getPackage(String pkg) {
         return Package.getPackage(pkg);

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
@@ -1,5 +1,6 @@
 package mock.plugin.overrideOnly;
 
+@SuppressWarnings("unused")
 public class PackageInvokingBox {
     /*expected(DEPRECATED)
     Deprecated method java.lang.Package.getPackage(String) invocation

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/PackageInvokingBox.java
@@ -1,0 +1,8 @@
+package mock.plugin.overrideOnly;
+
+public class PackageInvokingBox {
+    @SuppressWarnings("deprecation")
+    public Package getPackage(String pkg) {
+        return Package.getPackage(pkg);
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockVerificationContext.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockVerificationContext.kt
@@ -1,0 +1,28 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.plugin.structure.classes.resolvers.EmptyResolver
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.usages.ApiUsageProcessor
+import com.jetbrains.pluginverifier.verifiers.ProblemRegistrar
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.packages.DefaultPackageFilter
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
+import com.jetbrains.pluginverifier.warnings.WarningRegistrar
+
+class MockVerificationContext : VerificationContext {
+  override val classResolver = EmptyResolver
+
+  override val externalClassesPackageFilter = DefaultPackageFilter(emptyList())
+
+  override val problemRegistrar = object : ProblemRegistrar {
+    override fun registerProblem(problem: CompatibilityProblem) {
+      // NO-OP
+    }
+  }
+  override val warningRegistrar = object : WarningRegistrar {
+    override fun registerCompatibilityWarning(warning: CompatibilityWarning) {
+      // NO-OP
+    }
+  }
+  override val apiUsageProcessors = emptyList<ApiUsageProcessor>()
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
@@ -9,8 +9,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
 import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.MethodAsm
 import com.jetbrains.pluginverifier.verifiers.resolution.toBinaryClassName
-import org.junit.Assert
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.objectweb.asm.ClassReader
@@ -39,16 +38,12 @@ class DelegateCallOnOverrideOnlyUsageFilterTest {
   fun `invocation of super as delegate is intentionally ignored`() {
     val className = "mock.plugin.overrideOnly.ClearCountingContainer"
     val clearMethod = ClearCountingContainerNode().loadMethod(CLEAR_METHOD, NO_PARAMS_RETURN_VOID_DESCRIPTOR)
-    if (clearMethod == null) {
-      fail("Unable to find '$CLEAR_METHOD' method on the $className")
-    }
+    assertNotNull("Unable to find '$CLEAR_METHOD' method on the $className", clearMethod)
     clearMethod!!
 
     val containerFqn = "mock.plugin.overrideOnly.Container"
     val containerClearMethodAsm = ContainerNode().loadMethod(CLEAR_METHOD, NO_PARAMS_RETURN_VOID_DESCRIPTOR)
-    if (containerClearMethodAsm == null) {
-      fail("Unable to find '$CLEAR_METHOD' method on the $className")
-    }
+    assertNotNull("Unable to find '$CLEAR_METHOD' method on the $className", containerClearMethodAsm)
     containerClearMethodAsm!!
 
     val superClearInstruction = clearMethod.findInvocation(containerFqn.toBinaryClassName(), CLEAR_METHOD, NO_PARAMS_RETURN_VOID_DESCRIPTOR)
@@ -56,31 +51,27 @@ class DelegateCallOnOverrideOnlyUsageFilterTest {
     superClearInstruction!!
 
     val isAllowed = filter.allow(containerClearMethodAsm, superClearInstruction, clearMethod, verificationContext)
-    Assert.assertFalse(isAllowed)
+    assertFalse(isAllowed)
   }
 
   @Test
   fun `invocation of similarly named static method is ignored`() {
     val className = "mock.plugin.overrideOnly.PackageInvokingBox"
-    val method = PackageInvokingBoxNode().loadMethod(GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
-    if (method == null) {
-      fail("Unable to find '$CLEAR_METHOD' method on the $className")
-    }
-    method!!
+    val getPackageMethodAsm = PackageInvokingBoxNode().loadMethod(GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
+    assertNotNull("Unable to find '$CLEAR_METHOD' method on the $className", getPackageMethodAsm)
+    getPackageMethodAsm!!
 
     val targetClassName = "java.lang.Package"
-    val instruction = method.findInvocation(targetClassName.toBinaryClassName(), GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
-    if (instruction == null) fail("Unable to find '$GET_PACKAGE_METHOD' method on the $className")
-    instruction!!
+    val getPackageInstruction = getPackageMethodAsm.findInvocation(targetClassName.toBinaryClassName(), GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
+    if (getPackageInstruction == null) fail("Unable to find '$GET_PACKAGE_METHOD' method on the $className")
+    getPackageInstruction!!
 
-    val targetMethod = loadMethod(targetClassName, GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
-    if (targetMethod == null) {
-      fail("Unable to find '$GET_PACKAGE_METHOD' method on the $targetClassName")
-    }
-    targetMethod!!
+    val getPackageTargetMethodAsm = loadMethod(targetClassName, GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
+    assertNotNull("Unable to find '$GET_PACKAGE_METHOD' method on the $targetClassName", getPackageTargetMethodAsm)
+    getPackageTargetMethodAsm!!
 
-    val isAllowed = filter.allow(targetMethod, instruction, method, verificationContext)
-    Assert.assertFalse(isAllowed)
+    val isAllowed = filter.allow(getPackageTargetMethodAsm, getPackageInstruction, getPackageMethodAsm, verificationContext)
+    assertFalse(isAllowed)
   }
 
   private fun MethodAsm.findInvocation(

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
@@ -6,42 +6,88 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
 import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.MethodAsm
 import com.jetbrains.pluginverifier.verifiers.resolution.toBinaryClassName
+import org.junit.Assert
 import org.junit.Assert.fail
 import org.junit.Test
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodInsnNode
 
+
 private const val NO_PARAMS_RETURN_VOID_DESCRIPTOR = "()V"
+private const val STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR = "(Ljava/lang/String;)Ljava/lang/Package;"
+
+private const val CLEAR_METHOD = "clear"
+private const val GET_PACKAGE_METHOD = "getPackage"
+
 class DelegateCallOnOverrideOnlyUsageFilterTest {
   @Test
   fun `invocation of super as delegate is intentionally ignored`() {
     val context = MockVerificationContext()
     val filter = DelegateCallOnOverrideOnlyUsageFilter()
 
-    val className = "mock.plugin.overrideOnly.ClearCountingVector"
-    val clearMethodAsm = loadMethod(className, "clear", NO_PARAMS_RETURN_VOID_DESCRIPTOR)
+    val className = "mock.plugin.overrideOnly.ClearCountingContainer"
+    val clearMethodAsm = ClearCountingContainerNode().loadMethod(CLEAR_METHOD, NO_PARAMS_RETURN_VOID_DESCRIPTOR)
     if (clearMethodAsm == null) {
-      fail("Unable to find 'clear' method on the $className")
+      fail("Unable to find '$CLEAR_METHOD' method on the $className")
     }
     clearMethodAsm!!
 
-    val vectorFqn = "java.util.Vector"
-    val vectorClearMethodAsm = loadMethod(vectorFqn, "clear", NO_PARAMS_RETURN_VOID_DESCRIPTOR)
-    if (vectorClearMethodAsm == null) {
-      fail("Unable to find 'clear' method on the $className")
+    val containerFqn = "mock.plugin.overrideOnly.Container"
+    val containerClearMethodAsm = ContainerNode().loadMethod(CLEAR_METHOD, NO_PARAMS_RETURN_VOID_DESCRIPTOR)
+    if (containerClearMethodAsm == null) {
+      fail("Unable to find '$CLEAR_METHOD' method on the $className")
     }
-    vectorClearMethodAsm!!
+    containerClearMethodAsm!!
 
     val superClearInstruction = clearMethodAsm.asmNode.instructions.find { it is MethodInsnNode
-      && it.name == "clear"
-      && it.owner == vectorFqn.toBinaryClassName()
+      && it.name == CLEAR_METHOD
+      && it.owner == containerFqn.toBinaryClassName()
       && it.desc == NO_PARAMS_RETURN_VOID_DESCRIPTOR
     }
-    if (superClearInstruction == null) fail("Unable to find 'clear' method on the $className")
+    if (superClearInstruction == null) fail("Unable to find '$CLEAR_METHOD' method on the $className")
     superClearInstruction!!
 
-    filter.allow(vectorClearMethodAsm, superClearInstruction, clearMethodAsm, context)
+    val isAllowed = filter.allow(containerClearMethodAsm, superClearInstruction, clearMethodAsm, context)
+    Assert.assertFalse(isAllowed)
+  }
+
+  @Test
+  fun `invocation of similarly named static method is ignored`() {
+    val context = MockVerificationContext()
+    val filter = DelegateCallOnOverrideOnlyUsageFilter()
+
+    val className = "mock.plugin.overrideOnly.PackageInvokingBox"
+    val method = PackageInvokingBoxNode().loadMethod(GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
+    if (method == null) {
+      fail("Unable to find '$CLEAR_METHOD' method on the $className")
+    }
+    method!!
+
+    val targetClassName = "java.lang.Package"
+    val instruction = method.asmNode.instructions.find {
+      it is MethodInsnNode
+        && it.name == GET_PACKAGE_METHOD
+        && it.owner == targetClassName.toBinaryClassName()
+        && it.desc == STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR
+    }
+    if (instruction == null) fail("Unable to find '$GET_PACKAGE_METHOD' method on the $className")
+    instruction!!
+
+    val targetMethod = loadMethod(targetClassName, GET_PACKAGE_METHOD, STRING_PARAM_RETURN_PACKAGE_DESCRIPTOR)
+    if (targetMethod == null) {
+      fail("Unable to find '$GET_PACKAGE_METHOD' method on the $targetClassName")
+    }
+    targetMethod!!
+
+    val isAllowed = filter.allow(targetMethod, instruction, method, context)
+    Assert.assertFalse(isAllowed)
+  }
+
+
+  private fun ClassNode.loadMethod(methodName: String, methodDescriptor: String): MethodAsm? {
+    val classFile = ClassFileAsm(this, TestClasspathFileOrigin)
+    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor }
   }
 
   private fun loadMethod(className: FullyQualifiedClassName, methodName: String, methodDescriptor: String): MethodAsm? {
@@ -64,4 +110,5 @@ class DelegateCallOnOverrideOnlyUsageFilterTest {
   private object TestClasspathFileOrigin : FileOrigin {
     override val parent: FileOrigin? = null
   }
+
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
@@ -1,0 +1,67 @@
+package com.jetbrains.pluginverifier.usages.overrideOnly
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.pluginverifier.tests.mocks.MockVerificationContext
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
+import com.jetbrains.pluginverifier.verifiers.resolution.MethodAsm
+import com.jetbrains.pluginverifier.verifiers.resolution.toBinaryClassName
+import org.junit.Assert.fail
+import org.junit.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodInsnNode
+
+private const val NO_PARAMS_RETURN_VOID_DESCRIPTOR = "()V"
+class DelegateCallOnOverrideOnlyUsageFilterTest {
+  @Test
+  fun `invocation of super as delegate is intentionally ignored`() {
+    val context = MockVerificationContext()
+    val filter = DelegateCallOnOverrideOnlyUsageFilter()
+
+    val className = "mock.plugin.overrideOnly.ClearCountingVector"
+    val clearMethodAsm = loadMethod(className, "clear", NO_PARAMS_RETURN_VOID_DESCRIPTOR)
+    if (clearMethodAsm == null) {
+      fail("Unable to find 'clear' method on the $className")
+    }
+    clearMethodAsm!!
+
+    val vectorFqn = "java.util.Vector"
+    val vectorClearMethodAsm = loadMethod(vectorFqn, "clear", NO_PARAMS_RETURN_VOID_DESCRIPTOR)
+    if (vectorClearMethodAsm == null) {
+      fail("Unable to find 'clear' method on the $className")
+    }
+    vectorClearMethodAsm!!
+
+    val superClearInstruction = clearMethodAsm.asmNode.instructions.find { it is MethodInsnNode
+      && it.name == "clear"
+      && it.owner == vectorFqn.toBinaryClassName()
+      && it.desc == NO_PARAMS_RETURN_VOID_DESCRIPTOR
+    }
+    if (superClearInstruction == null) fail("Unable to find 'clear' method on the $className")
+    superClearInstruction!!
+
+    filter.allow(vectorClearMethodAsm, superClearInstruction, clearMethodAsm, context)
+  }
+
+  private fun loadMethod(className: FullyQualifiedClassName, methodName: String, methodDescriptor: String): MethodAsm? {
+    val classFile = getClassFile(className)
+    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor }
+  }
+
+  private fun getClassFile(className: FullyQualifiedClassName): ClassFileAsm {
+    val classNode = loadClass(className)
+    return ClassFileAsm(classNode, TestClasspathFileOrigin)
+  }
+
+  private fun loadClass(className: FullyQualifiedClassName): ClassNode {
+    val classNode = ClassNode()
+    val classReader = ClassReader(className)
+    classReader.accept(classNode, 0)
+    return classNode
+  }
+
+  private object TestClasspathFileOrigin : FileOrigin {
+    override val parent: FileOrigin? = null
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/Dumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/Dumps.kt
@@ -102,7 +102,7 @@ private fun dumpClearCountingContainer(): ByteArray {
   return classWriter.toByteArray()
 }
 
-internal fun dumpContainer(): ByteArray {
+private fun dumpContainer(): ByteArray {
   val classWriter = ClassWriter(0)
   var methodVisitor: MethodVisitor
 
@@ -150,7 +150,7 @@ internal fun dumpContainer(): ByteArray {
   return classWriter.toByteArray()
 }
 
-fun dumpPackageInvokingBox(): ByteArray {
+private fun dumpPackageInvokingBox(): ByteArray {
   val classWriter = ClassWriter(0)
   var methodVisitor: MethodVisitor
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/Dumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/Dumps.kt
@@ -1,0 +1,216 @@
+@file:Suppress("TestFunctionName")
+
+package com.jetbrains.pluginverifier.usages.overrideOnly
+
+import com.jetbrains.pluginverifier.tests.bytecode.createClassNode
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.ClassNode
+
+
+internal fun ClearCountingContainerNode(): ClassNode = dumpClearCountingContainer().createClassNode()
+internal fun ContainerNode(): ClassNode = dumpContainer().createClassNode()
+internal fun PackageInvokingBoxNode(): ClassNode = dumpPackageInvokingBox().createClassNode()
+
+private fun dumpClearCountingContainer(): ByteArray {
+  val classWriter = ClassWriter(0)
+  var fieldVisitor: FieldVisitor
+  var methodVisitor: MethodVisitor
+
+  classWriter.visit(
+    V11,
+    ACC_PUBLIC or ACC_SUPER,
+    "mock/plugin/overrideOnly/ClearCountingContainer",
+    null,
+    "mock/plugin/overrideOnly/Container",
+    null
+  )
+
+  classWriter.visitSource("ClearCountingContainer.java", null)
+
+  run {
+    fieldVisitor = classWriter.visitField(ACC_PRIVATE, "clearCount", "I", null, null)
+    fieldVisitor.visitEnd()
+  }
+  run {
+    methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(3, label0)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitMethodInsn(INVOKESPECIAL, "mock/plugin/overrideOnly/Container", "<init>", "()V", false)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLineNumber(4, label1)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitInsn(ICONST_0)
+    methodVisitor.visitFieldInsn(PUTFIELD, "mock/plugin/overrideOnly/ClearCountingContainer", "clearCount", "I")
+    methodVisitor.visitInsn(RETURN)
+    val label2 = Label()
+    methodVisitor.visitLabel(label2)
+    methodVisitor.visitLocalVariable(
+      "this",
+      "Lmock/plugin/overrideOnly/ClearCountingContainer;",
+      null,
+      label0,
+      label2,
+      0
+    )
+    methodVisitor.visitMaxs(2, 1)
+    methodVisitor.visitEnd()
+  }
+  run {
+    methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "clear", "()V", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(8, label0)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitMethodInsn(INVOKESPECIAL, "mock/plugin/overrideOnly/Container", "clear", "()V", false)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLineNumber(9, label1)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitInsn(DUP)
+    methodVisitor.visitFieldInsn(GETFIELD, "mock/plugin/overrideOnly/ClearCountingContainer", "clearCount", "I")
+    methodVisitor.visitInsn(ICONST_1)
+    methodVisitor.visitInsn(IADD)
+    methodVisitor.visitFieldInsn(PUTFIELD, "mock/plugin/overrideOnly/ClearCountingContainer", "clearCount", "I")
+    val label2 = Label()
+    methodVisitor.visitLabel(label2)
+    methodVisitor.visitLineNumber(10, label2)
+    methodVisitor.visitInsn(RETURN)
+    val label3 = Label()
+    methodVisitor.visitLabel(label3)
+    methodVisitor.visitLocalVariable(
+      "this",
+      "Lmock/plugin/overrideOnly/ClearCountingContainer;",
+      null,
+      label0,
+      label3,
+      0
+    )
+    methodVisitor.visitMaxs(3, 1)
+    methodVisitor.visitEnd()
+  }
+  classWriter.visitEnd()
+
+  return classWriter.toByteArray()
+}
+
+internal fun dumpContainer(): ByteArray {
+  val classWriter = ClassWriter(0)
+  var methodVisitor: MethodVisitor
+
+  classWriter.visit(
+    V11,
+    ACC_PUBLIC or ACC_SUPER,
+    "mock/plugin/overrideOnly/Container",
+    null,
+    "java/lang/Object",
+    null
+  )
+
+  classWriter.visitSource("Container.java", null)
+
+  run {
+    methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(3, label0)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+    methodVisitor.visitInsn(RETURN)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLocalVariable("this", "Lmock/plugin/overrideOnly/Container;", null, label0, label1, 0)
+    methodVisitor.visitMaxs(1, 1)
+    methodVisitor.visitEnd()
+  }
+  run {
+    methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "clear", "()V", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(6, label0)
+    methodVisitor.visitInsn(RETURN)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLocalVariable("this", "Lmock/plugin/overrideOnly/Container;", null, label0, label1, 0)
+    methodVisitor.visitMaxs(0, 1)
+    methodVisitor.visitEnd()
+  }
+  classWriter.visitEnd()
+
+  return classWriter.toByteArray()
+}
+
+fun dumpPackageInvokingBox(): ByteArray {
+  val classWriter = ClassWriter(0)
+  var methodVisitor: MethodVisitor
+
+  classWriter.visit(
+    V11,
+    ACC_PUBLIC or ACC_SUPER,
+    "mock/plugin/overrideOnly/PackageInvokingBox",
+    null,
+    "java/lang/Object",
+    null
+  )
+
+  classWriter.visitSource("PackageInvokingBox.java", null)
+
+  run {
+    methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(3, label0)
+    methodVisitor.visitVarInsn(ALOAD, 0)
+    methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+    methodVisitor.visitInsn(RETURN)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLocalVariable("this", "Lmock/plugin/overrideOnly/PackageInvokingBox;", null, label0, label1, 0)
+    methodVisitor.visitMaxs(1, 1)
+    methodVisitor.visitEnd()
+  }
+  run {
+    methodVisitor =
+      classWriter.visitMethod(ACC_PUBLIC, "getPackage", "(Ljava/lang/String;)Ljava/lang/Package;", null, null)
+    methodVisitor.visitCode()
+    val label0 = Label()
+    methodVisitor.visitLabel(label0)
+    methodVisitor.visitLineNumber(6, label0)
+    methodVisitor.visitVarInsn(ALOAD, 1)
+    methodVisitor.visitMethodInsn(
+      INVOKESTATIC,
+      "java/lang/Package",
+      "getPackage",
+      "(Ljava/lang/String;)Ljava/lang/Package;",
+      false
+    )
+    methodVisitor.visitInsn(ARETURN)
+    val label1 = Label()
+    methodVisitor.visitLabel(label1)
+    methodVisitor.visitLocalVariable(
+      "this",
+      "Lmock/plugin/overrideOnly/PackageInvokingBox;",
+      null,
+      label0,
+      label1,
+      0
+    )
+    methodVisitor.visitLocalVariable("pkg", "Ljava/lang/String;", null, label0, label1, 1)
+    methodVisitor.visitMaxs(1, 2)
+    methodVisitor.visitEnd()
+  }
+  classWriter.visitEnd()
+
+  return classWriter.toByteArray()
+}


### PR DESCRIPTION
Add unit tests for cornercases:

- static method invocation: when a method invokes a `static` method with exactly the same name and exactly the same descriptor on another class
- `super` method invocation: when a method just plainly invokes a parent method

See #1111 and #1112