### PR TITLE
Add check of release date in the future

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -598,7 +598,10 @@ internal class PluginCreator private constructor(
       registerProblem(PropertyNotSpecified("release-date", descriptorPath))
     } else {
       try {
-        LocalDate.parse(releaseDate, releaseDateFormatter)
+        val date = LocalDate.parse(releaseDate, releaseDateFormatter)
+        if (date > LocalDate.now().plusDays(5)) {
+          registerProblem(ReleaseDateInFuture(descriptorPath))
+        }
       } catch (e: DateTimeParseException) {
         registerProblem(ReleaseDateWrongFormat(descriptorPath))
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -193,6 +193,14 @@ class ReleaseDateWrongFormat(descriptorPath: String) : InvalidDescriptorProblem(
     get() = Level.ERROR
 }
 
+class ReleaseDateInFuture(descriptorPath: String) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The <release-date> parameter must be set to a date that is no more than five days in the future from today's date."
+) {
+  override val level
+    get() = Level.ERROR
+}
+
 class UnableToFindTheme(descriptorPath: String, themePath: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
   detailedMessage = "The theme description file cannot be found by the path '$themePath'. Ensure the theme description " +

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -69,6 +69,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
     XIncludeResolutionErrors::class,
     TooLongPropertyValue::class,
     ReleaseDateWrongFormat::class,
+    ReleaseDateInFuture::class,
     UnableToFindTheme::class,
     UnableToReadTheme::class,
     OptionalDependencyDescriptorCycleProblem::class,

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -17,6 +17,7 @@
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported": "warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning"
+    "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseDateInFuture": "warning"
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -1,18 +1,7 @@
 package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
-import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
-import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
-import com.jetbrains.plugin.structure.base.problems.NotBoolean
-import com.jetbrains.plugin.structure.base.problems.NotNumber
-import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
-import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
-import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
-import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.simpleName
@@ -28,6 +17,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
   private val DEFAULT_TEMPLATE_NAMES = setOf("Plugin display name here", "My Framework Support", "Template", "Demo")
@@ -812,6 +803,18 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       },
       listOf(
         NotBoolean("optional", "plugin.xml")
+      )
+    )
+
+    val releaseDateInFuture = LocalDate.now().plusMonths(1)
+    val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+    val releaseDateInFutureString = releaseDateInFuture.format(formatter)
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        productDescriptor = """<product-descriptor code="ABC" release-date="$releaseDateInFutureString" release-version="12"/>"""
+      },
+      listOf(
+        ReleaseDateInFuture("plugin.xml")
       )
     )
   }


### PR DESCRIPTION
Move the check of release-date for paid plugins to Structure checks, and remap it to warning for JetBrains plugins as was asked in the issue [MP-6696](https://youtrack.jetbrains.com/issue/MP-6696)