### PR TITLE
Use simple condition for the same-JAR API Usage verifications

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/ClassLocationApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/ClassLocationApiUsageFilter.kt
@@ -1,0 +1,51 @@
+package com.jetbrains.pluginverifier.usages
+
+import com.jetbrains.pluginverifier.results.location.ClassLocation
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.results.reference.FieldReference
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import org.objectweb.asm.tree.AbstractInsnNode
+
+open class ClassLocationApiUsageFilter : ApiUsageFilter {
+  override fun allow(
+    classReference: ClassReference,
+    invocationTarget: ClassFile,
+    caller: ClassFileMember,
+    usageType: ClassUsageType,
+    context: VerificationContext
+  ): Boolean {
+    val usageHost = caller.location.containingClass
+    val apiHost = invocationTarget.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  override fun allow(
+    invokedMethod: Method,
+    invocationInstruction: AbstractInsnNode,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    val usageHost = callerMethod.location.containingClass
+    val apiHost = invokedMethod.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  override fun allow(
+    fieldReference: FieldReference,
+    resolvedField: Field,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    val apiHost = callerMethod.location.containingClass
+    val usageHost = resolvedField.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  open fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean = true
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
@@ -1,53 +1,9 @@
 package com.jetbrains.pluginverifier.usages
 
 import com.jetbrains.pluginverifier.results.location.ClassLocation
-import com.jetbrains.pluginverifier.results.reference.ClassReference
-import com.jetbrains.pluginverifier.results.reference.FieldReference
-import com.jetbrains.pluginverifier.verifiers.VerificationContext
-import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
-import com.jetbrains.pluginverifier.verifiers.resolution.Field
-import com.jetbrains.pluginverifier.verifiers.resolution.Method
-import org.objectweb.asm.tree.AbstractInsnNode
 
-class SameOriginApiUsageFilter : ApiUsageFilter {
-  override fun allow(
-    classReference: ClassReference,
-    invocationTarget: ClassFile,
-    caller: ClassFileMember,
-    usageType: ClassUsageType,
-    context: VerificationContext
-  ): Boolean {
-    val usageHost = caller.location.containingClass
-    val apiHost = invocationTarget.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  override fun allow(
-    invokedMethod: Method,
-    invocationInstruction: AbstractInsnNode,
-    callerMethod: Method,
-    context: VerificationContext
-  ): Boolean {
-    val usageHost = callerMethod.location.containingClass
-    val apiHost = invokedMethod.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  override fun allow(
-    fieldReference: FieldReference,
-    resolvedField: Field,
-    callerMethod: Method,
-    context: VerificationContext
-  ): Boolean {
-    val apiHost = callerMethod.location.containingClass
-    val usageHost = resolvedField.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  private fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
+class SameOriginApiUsageFilter : ClassLocationApiUsageFilter() {
+  override fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
     val usageOrigin = usageLocation.classFileOrigin
     val apiHostOrigin = apiLocation.classFileOrigin
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
@@ -1,0 +1,56 @@
+package com.jetbrains.pluginverifier.usages
+
+import com.jetbrains.pluginverifier.results.location.ClassLocation
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.results.reference.FieldReference
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import org.objectweb.asm.tree.AbstractInsnNode
+
+class SameOriginApiUsageFilter : ApiUsageFilter {
+  override fun allow(
+    classReference: ClassReference,
+    invocationTarget: ClassFile,
+    caller: ClassFileMember,
+    usageType: ClassUsageType,
+    context: VerificationContext
+  ): Boolean {
+    val usageHost = caller.location.containingClass
+    val apiHost = invocationTarget.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  override fun allow(
+    invokedMethod: Method,
+    invocationInstruction: AbstractInsnNode,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    val usageHost = callerMethod.location.containingClass
+    val apiHost = invokedMethod.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  override fun allow(
+    fieldReference: FieldReference,
+    resolvedField: Field,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    val apiHost = callerMethod.location.containingClass
+    val usageHost = resolvedField.location.containingClass
+    return allow(usageHost, apiHost)
+  }
+
+  private fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
+    val usageOrigin = usageLocation.classFileOrigin
+    val apiHostOrigin = apiLocation.classFileOrigin
+
+    return usageOrigin == apiHostOrigin
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SamePluginUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SamePluginUsageFilter.kt
@@ -9,16 +9,6 @@ import com.jetbrains.plugin.structure.classes.resolvers.isOriginOfType
 import com.jetbrains.plugin.structure.ide.classes.IdeFileOrigin
 import com.jetbrains.plugin.structure.intellij.classes.locator.PluginFileOrigin
 import com.jetbrains.pluginverifier.results.location.ClassLocation
-import com.jetbrains.pluginverifier.results.reference.ClassReference
-import com.jetbrains.pluginverifier.results.reference.FieldReference
-import com.jetbrains.pluginverifier.verifiers.VerificationContext
-import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
-import com.jetbrains.pluginverifier.verifiers.resolution.Field
-import com.jetbrains.pluginverifier.verifiers.resolution.Method
-import org.objectweb.asm.tree.AbstractInsnNode
 
 /**
  * API Usage filter that allows class usages, method invocations and field references
@@ -26,43 +16,8 @@ import org.objectweb.asm.tree.AbstractInsnNode
  *
  * This filter will ignore API usages that occur within the same plugin.
  */
-class SamePluginUsageFilter : ApiUsageFilter {
-
-  override fun allow(
-    classReference: ClassReference,
-    invocationTarget: ClassFile,
-    caller: ClassFileMember,
-    usageType: ClassUsageType,
-    context: VerificationContext
-  ): Boolean {
-    val usageHost = caller.location.containingClass
-    val apiHost = invocationTarget.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  override fun allow(
-    invokedMethod: Method,
-    invocationInstruction: AbstractInsnNode,
-    callerMethod: Method,
-    context: VerificationContext
-  ): Boolean {
-    val usageHost = callerMethod.location.containingClass
-    val apiHost = invokedMethod.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  override fun allow(
-    fieldReference: FieldReference,
-    resolvedField: Field,
-    callerMethod: Method,
-    context: VerificationContext
-  ): Boolean {
-    val apiHost = callerMethod.location.containingClass
-    val usageHost = resolvedField.location.containingClass
-    return allow(usageHost, apiHost)
-  }
-
-  private fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
+class SamePluginUsageFilter : ClassLocationApiUsageFilter() {
+  override fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
     val usageOrigin = usageLocation.classFileOrigin
     val apiHostOrigin = apiLocation.classFileOrigin
     return isInvocationWithinPlatform(usageOrigin, apiHostOrigin)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
@@ -9,7 +9,7 @@ import com.jetbrains.pluginverifier.results.reference.ClassReference
 import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.FilteringApiUsageProcessor
-import com.jetbrains.pluginverifier.usages.SamePluginUsageFilter
+import com.jetbrains.pluginverifier.usages.SameOriginApiUsageFilter
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
@@ -18,7 +18,9 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
-class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: ExperimentalApiRegistrar) : FilteringApiUsageProcessor(SamePluginUsageFilter()) {
+class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: ExperimentalApiRegistrar) : FilteringApiUsageProcessor(
+  SameOriginApiUsageFilter()
+) {
 
   private fun isExperimental(
     resolvedMember: ClassFileMember,

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/JvmModifiersOwner.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/JvmModifiersOwner.java
@@ -1,0 +1,10 @@
+package com.intellij.lang.jvm;
+
+/**
+ * COPIED FROM INTELLIJ COMMUNITY CODE
+ * and intentionally pruned to a minimalistic form to demonstrate Platform-to-Platform internal API calls.
+ *
+ */
+public interface JvmModifiersOwner {
+  // intentionally blank
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/JvmParameter.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/JvmParameter.java
@@ -1,0 +1,9 @@
+package com.intellij.lang.jvm;
+
+/**
+ * COPIED FROM INTELLIJ COMMUNITY CODE
+ * and intentionally pruned to a minimalistic form to demonstrate Platform-to-Platform API calls.
+ */
+public interface JvmParameter extends JvmModifiersOwner {
+
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/package-info.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/lang/jvm/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package com.intellij.lang.jvm;
+
+import org.jetbrains.annotations.ApiStatus.Experimental;

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/JvmModifiersOwner.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/JvmModifiersOwner.java
@@ -1,0 +1,10 @@
+package com.intellij.lang.jvm;
+
+/**
+ * COPIED FROM INTELLIJ COMMUNITY CODE
+ * and intentionally pruned to a minimalistic form to demonstrate Platform-to-Platform internal API calls.
+ *
+ */
+public interface JvmModifiersOwner {
+  // intentionally blank
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/JvmParameter.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/JvmParameter.java
@@ -1,0 +1,9 @@
+package com.intellij.lang.jvm;
+
+/**
+ * COPIED FROM INTELLIJ COMMUNITY CODE
+ * and intentionally pruned to a minimalistic form to demonstrate Platform-to-Platform API calls.
+ */
+public interface JvmParameter extends JvmModifiersOwner {
+
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/package-info.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/com/intellij/lang/jvm/package-info.java
@@ -1,0 +1,4 @@
+@Experimental
+package com.intellij.lang.jvm;
+
+import org.jetbrains.annotations.ApiStatus.Experimental;

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/platform/JvmParameterUsage.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/platform/JvmParameterUsage.java
@@ -1,0 +1,22 @@
+package mock.plugin.platform;
+
+import com.intellij.lang.jvm.JvmParameter;
+
+/*expected(EXPERIMENTAL)
+Experimental API interface com.intellij.lang.jvm.JvmParameter reference
+
+Experimental API interface com.intellij.lang.jvm.JvmParameter is referenced in mock.plugin.platform.JvmParameterUsage$1. This interface can be changed in a future release leading to incompatibilities
+*/
+/*expected(EXPERIMENTAL)
+Experimental API interface com.intellij.lang.jvm.JvmParameter reference
+
+Experimental API interface com.intellij.lang.jvm.JvmParameter is referenced in mock.plugin.platform.JvmParameterUsage.<init>(). This interface can be changed in a future release leading to incompatibilities
+*/
+public class JvmParameterUsage {
+
+    public JvmParameterUsage() {
+        JvmParameter param = new JvmParameter() {};
+        //noinspection ResultOfMethodCallIgnored
+        param.toString();
+    }
+}


### PR DESCRIPTION
Use simple condition for the same-JAR API Usage verifications. 

This condition is picked up from the previous implementation where it expects that both the API host ("invocation target") and the API usage ("call-site") reside in the same JAR or directory.

This is a fix for issue where even the Platform-to-Platform internal APi calls with `@Experimental` API status might be wrongly reported as cross-plugin call.

See [MP-6729](https://youtrack.jetbrains.com/issue/MP-6729)