### PR TITLE
Set proper File Origins for bundled plugins

### DIFF
--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.ide.classes
 
 import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.plugin.structure.ide.Ide
+import java.nio.file.Path
 
 sealed class IdeFileOrigin : FileOrigin {
   override val parent: FileOrigin? = null
@@ -15,7 +16,7 @@ sealed class IdeFileOrigin : FileOrigin {
   data class SourceLibDirectory(override val ide: Ide) : IdeAwareFileOrigin(ide)
   data class CompiledModule(override val ide: Ide, val moduleName: String) : IdeAwareFileOrigin(ide)
 
-  class BundledPlugin() : IdeFileOrigin()
+  class BundledPlugin(val pluginFile: Path) : IdeFileOrigin()
 
   abstract class IdeAwareFileOrigin(open val ide: Ide): IdeFileOrigin()
 }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.ide.classes
 
 import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import java.nio.file.Path
 
 sealed class IdeFileOrigin : FileOrigin {
@@ -16,7 +17,7 @@ sealed class IdeFileOrigin : FileOrigin {
   data class SourceLibDirectory(override val ide: Ide) : IdeAwareFileOrigin(ide)
   data class CompiledModule(override val ide: Ide, val moduleName: String) : IdeAwareFileOrigin(ide)
 
-  class BundledPlugin(val pluginFile: Path) : IdeFileOrigin()
+  class BundledPlugin(val pluginFile: Path, val idePlugin: IdePlugin) : IdeFileOrigin()
 
   abstract class IdeAwareFileOrigin(open val ide: Ide): IdeFileOrigin()
 }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeFileOrigin.kt
@@ -10,10 +10,12 @@ import com.jetbrains.plugin.structure.ide.Ide
 sealed class IdeFileOrigin : FileOrigin {
   override val parent: FileOrigin? = null
 
-  abstract val ide: Ide
+  data class IdeLibDirectory(override val ide: Ide) : IdeAwareFileOrigin(ide)
+  data class RepositoryLibrary(override val ide: Ide) : IdeAwareFileOrigin(ide)
+  data class SourceLibDirectory(override val ide: Ide) : IdeAwareFileOrigin(ide)
+  data class CompiledModule(override val ide: Ide, val moduleName: String) : IdeAwareFileOrigin(ide)
 
-  data class IdeLibDirectory(override val ide: Ide) : IdeFileOrigin()
-  data class RepositoryLibrary(override val ide: Ide) : IdeFileOrigin()
-  data class SourceLibDirectory(override val ide: Ide) : IdeFileOrigin()
-  data class CompiledModule(override val ide: Ide, val moduleName: String) : IdeFileOrigin()
+  class BundledPlugin() : IdeFileOrigin()
+
+  abstract class IdeAwareFileOrigin(open val ide: Ide): IdeFileOrigin()
 }

--- a/intellij-plugin-structure/structure-intellij-classes/build.gradle.kts
+++ b/intellij-plugin-structure/structure-intellij-classes/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
   api(project(":structure-intellij"))
   api(project(":structure-classes"))
+  api(project(":structure-ide-classes"))
 }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/FileOriginProvider.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/FileOriginProvider.kt
@@ -1,0 +1,10 @@
+package com.jetbrains.plugin.structure.intellij.classes.locator
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import java.nio.file.Path
+
+fun interface FileOriginProvider {
+  fun getFileOrigin(idePlugin: IdePlugin, pluginFile: Path): FileOrigin
+}
+

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/JarPluginLocator.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/JarPluginLocator.kt
@@ -13,7 +13,10 @@ import java.nio.file.Path
 /**
  * Locates plugin classes located in a single JAR file.
  */
-class JarPluginLocator(private val readMode: Resolver.ReadMode) : ClassesLocator {
+class JarPluginLocator(
+  private val readMode: Resolver.ReadMode,
+  private val fileOriginProvider: FileOriginProvider = SingleJarFileOriginProvider
+) : ClassesLocator {
   override val locationKey: LocationKey = JarPluginKey
 
   /**
@@ -22,7 +25,7 @@ class JarPluginLocator(private val readMode: Resolver.ReadMode) : ClassesLocator
    */
   override fun findClasses(idePlugin: IdePlugin, pluginFile: Path): List<Resolver> {
     if (pluginFile.isJar()) {
-      return listOf(JarFileResolver(pluginFile, readMode, PluginFileOrigin.SingleJar(idePlugin)))
+      return listOf(JarFileResolver(pluginFile, readMode, fileOriginProvider.getFileOrigin(idePlugin, pluginFile)))
     }
     return emptyList()
   }
@@ -32,4 +35,8 @@ object JarPluginKey : LocationKey {
   override val name: String = "jar"
 
   override fun getLocator(readMode: Resolver.ReadMode) = JarPluginLocator(readMode)
+}
+
+object SingleJarFileOriginProvider: FileOriginProvider {
+  override fun getFileOrigin(idePlugin: IdePlugin, pluginFile: Path) = PluginFileOrigin.SingleJar(idePlugin)
 }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibDirectoryLocator.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibDirectoryLocator.kt
@@ -4,21 +4,28 @@
 
 package com.jetbrains.plugin.structure.intellij.classes.locator
 
-import com.jetbrains.plugin.structure.base.utils.*
+import com.jetbrains.plugin.structure.base.utils.closeOnException
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.isZip
+import com.jetbrains.plugin.structure.base.utils.listFiles
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.classes.resolvers.buildDirectoriesResolvers
 import com.jetbrains.plugin.structure.classes.resolvers.buildJarOrZipFileResolvers
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import java.nio.file.Path
 
-class LibDirectoryLocator(private val readMode: Resolver.ReadMode) : ClassesLocator {
+class LibDirectoryLocator(
+  private val readMode: Resolver.ReadMode,
+  private val fileOriginProvider: FileOriginProvider = LibDirectoryOriginProvider
+) : ClassesLocator {
   override val locationKey = LibDirectoryKey
 
   override fun findClasses(idePlugin: IdePlugin, pluginFile: Path): List<Resolver> {
     val pluginLib = pluginFile.resolve("lib")
     val resolvers = arrayListOf<Resolver>()
     if (pluginLib.isDirectory) {
-      val libDirectoryOrigin = PluginFileOrigin.LibDirectory(idePlugin)
+      val libDirectoryOrigin = fileOriginProvider.getFileOrigin(idePlugin, pluginFile)
       val jarsOrZips = pluginLib.listFiles().filter { file -> file.isJar() || file.isZip() }
       val directories = pluginLib.listFiles().filter { file -> file.isDirectory }
       resolvers.closeOnException {
@@ -28,11 +35,14 @@ class LibDirectoryLocator(private val readMode: Resolver.ReadMode) : ClassesLoca
     }
     return resolvers
   }
-
 }
 
 object LibDirectoryKey : LocationKey {
   override val name: String = "lib directory"
 
   override fun getLocator(readMode: Resolver.ReadMode) = LibDirectoryLocator(readMode)
+}
+
+object LibDirectoryOriginProvider: FileOriginProvider {
+  override fun getFileOrigin(idePlugin: IdePlugin, pluginFile: Path) = PluginFileOrigin.LibDirectory(idePlugin)
 }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/BundledPluginClassesFinder.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/BundledPluginClassesFinder.kt
@@ -1,0 +1,40 @@
+package com.jetbrains.plugin.structure.intellij.classes.plugin
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.ide.classes.IdeFileOrigin
+import com.jetbrains.plugin.structure.intellij.classes.locator.FileOriginProvider
+import com.jetbrains.plugin.structure.intellij.classes.locator.JarPluginLocator
+import com.jetbrains.plugin.structure.intellij.classes.locator.LibDirectoryLocator
+import com.jetbrains.plugin.structure.intellij.classes.locator.LocationKey
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import java.nio.file.Path
+
+class BundledPluginClassesFinder {
+  companion object {
+    val LOCATION_KEYS = listOf(BundledPluginJarKey, BundledPluginDirectoryKey)
+
+    fun findPluginClasses(
+      idePlugin: IdePlugin,
+      additionalKeys: List<LocationKey> = emptyList()
+    ): IdePluginClassesLocations {
+      return IdePluginClassesFinder.fullyFindPluginClassesInExplicitLocations(idePlugin, LOCATION_KEYS + additionalKeys)
+    }
+  }
+
+  object BundledPluginJarKey : LocationKey {
+    override val name: String = "Bundled Plugin JAR"
+    override fun getLocator(readMode: Resolver.ReadMode) = JarPluginLocator(readMode, BundledPluginOriginator)
+  }
+
+  object BundledPluginDirectoryKey : LocationKey {
+    override val name: String = "Bundled Plugin Directory"
+    override fun getLocator(readMode: Resolver.ReadMode) = LibDirectoryLocator(readMode, BundledPluginOriginator)
+  }
+
+  object BundledPluginOriginator : FileOriginProvider {
+    override fun getFileOrigin(idePlugin: IdePlugin, pluginFile: Path): FileOrigin {
+      return IdeFileOrigin.BundledPlugin(pluginFile, idePlugin)
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
@@ -108,6 +108,14 @@ class IdePluginClassesFinder private constructor(
       return findPluginClasses(idePlugin, extractDirectory, readMode, additionalKeys)
     }
 
+    fun fullyFindPluginClassesInExplicitLocations(idePlugin: IdePlugin, locations: List<LocationKey>): IdePluginClassesLocations =
+      IdePluginClassesFinder(
+        idePlugin,
+        extractDirectory = Settings.EXTRACT_DIRECTORY.getAsPath().createDir(),
+        Resolver.ReadMode.FULL,
+        locations
+      ).findPluginClasses()
+
     private fun findPluginClasses(
       idePlugin: IdePlugin,
       extractDirectory: Path,

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
@@ -5,7 +5,14 @@
 package com.jetbrains.plugin.structure.intellij.classes.plugin
 
 import com.jetbrains.plugin.structure.base.plugin.Settings
-import com.jetbrains.plugin.structure.base.utils.*
+import com.jetbrains.plugin.structure.base.utils.checkIfInterrupted
+import com.jetbrains.plugin.structure.base.utils.closeLogged
+import com.jetbrains.plugin.structure.base.utils.closeOnException
+import com.jetbrains.plugin.structure.base.utils.createDir
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.isZip
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.ClassesDirectoryKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.JarPluginKey
@@ -16,7 +23,6 @@ import com.jetbrains.plugin.structure.intellij.extractor.PluginExtractor
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import java.io.Closeable
 import java.io.IOException
-import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -102,7 +108,7 @@ class IdePluginClassesFinder private constructor(
       return findPluginClasses(idePlugin, extractDirectory, readMode, additionalKeys)
     }
 
-    fun findPluginClasses(
+    private fun findPluginClasses(
       idePlugin: IdePlugin,
       extractDirectory: Path,
       readMode: Resolver.ReadMode = Resolver.ReadMode.FULL,

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -12,7 +12,7 @@ import com.jetbrains.pluginverifier.PluginVerifierMain.main
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
 import com.jetbrains.pluginverifier.output.OutputOptions
-import com.jetbrains.pluginverifier.plugin.PluginDetailsProviderImpl
+import com.jetbrains.pluginverifier.plugin.DefaultPluginDetailsProvider
 import com.jetbrains.pluginverifier.plugin.PluginFilesBank
 import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
 import com.jetbrains.pluginverifier.reporting.DirectoryBasedPluginVerificationReportage
@@ -116,7 +116,7 @@ object PluginVerifierMain {
 
     val pluginDownloadDirDiskSpaceSetting = getDiskSpaceSetting("plugin.verifier.cache.dir.max.space", 5L * 1024)
     val pluginFilesBank = PluginFilesBank.create(pluginRepository, downloadDirectory, pluginDownloadDirDiskSpaceSetting)
-    val pluginDetailsProvider = PluginDetailsProviderImpl(getPluginsExtractDirectory())
+    val pluginDetailsProvider = DefaultPluginDetailsProvider(getPluginsExtractDirectory())
 
     val reportageAggregator = LoggingPluginVerificationReportageAggregator()
     DirectoryBasedPluginVerificationReportage(reportageAggregator) { outputOptions.getTargetReportDirectory(it) }.use { reportage ->

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -343,7 +343,7 @@ class PluginVerifier(
  * Selectors of classes that constitute the plugin
  * class loader and of classes that should be verified.
  */
-private val classesSelectors = listOf(MainClassesSelector(), ExternalBuildClassesSelector())
+private val classesSelectors = listOf(MainClassesSelector.forPlugin(), ExternalBuildClassesSelector())
 
 fun IdePluginClassesLocations.createPluginResolver() =
   CompositeResolver.create(classesSelectors.flatMap { it.getClassLoader(this) })

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/MainClassesSelector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/MainClassesSelector.kt
@@ -22,6 +22,13 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginXmlUtil
  * b) the verification may produce false warnings since some libraries optionally depend on missing libraries.
  */
 class MainClassesSelector : ClassesSelector {
+class MainClassesSelector private constructor(private val locationKeys: List<LocationKey>) : ClassesSelector {
+
+  companion object {
+    fun forPlugin(): MainClassesSelector {
+      return MainClassesSelector(IdePluginClassesFinder.MAIN_CLASSES_KEYS)
+    }
+  }
 
   /**
    * Selects the plugin's classes that can be referenced by the plugin and its dependencies.

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/BundledPluginClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/BundledPluginClassResolverProvider.kt
@@ -1,0 +1,17 @@
+package com.jetbrains.pluginverifier.resolution
+
+import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.pluginverifier.filtering.ExternalBuildClassesSelector
+import com.jetbrains.pluginverifier.filtering.MainClassesSelector
+import com.jetbrains.pluginverifier.plugin.PluginDetails
+
+class BundledPluginClassResolverProvider {
+    private val bundledClassesSelectors = listOf(MainClassesSelector.forBundledPlugin(), ExternalBuildClassesSelector())
+
+    fun getResolver(pluginDetails: PluginDetails): Resolver {
+      val classLocations = pluginDetails.pluginClassesLocations
+      return bundledClassesSelectors.flatMap { it.getClassLoader(classLocations) }
+        .let { CompositeResolver.create(it) }
+    }
+  }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SameOriginApiUsageFilter.kt
@@ -1,12 +1,14 @@
 package com.jetbrains.pluginverifier.usages
 
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.pluginverifier.results.location.ClassLocation
 
-class SameOriginApiUsageFilter : ClassLocationApiUsageFilter() {
+object SameOriginApiUsageFilter : ClassLocationApiUsageFilter() {
   override fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
     val usageOrigin = usageLocation.classFileOrigin
     val apiHostOrigin = apiLocation.classFileOrigin
-
-    return usageOrigin == apiHostOrigin
+    return invoke(usageOrigin, apiHostOrigin)
   }
+
+  operator fun invoke(usageOrigin: FileOrigin, apiHostOrigin: FileOrigin): Boolean = usageOrigin == apiHostOrigin
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SamePluginUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/SamePluginUsageFilter.kt
@@ -20,7 +20,8 @@ class SamePluginUsageFilter : ClassLocationApiUsageFilter() {
   override fun allow(usageLocation: ClassLocation, apiLocation: ClassLocation): Boolean {
     val usageOrigin = usageLocation.classFileOrigin
     val apiHostOrigin = apiLocation.classFileOrigin
-    return isInvocationWithinPlatform(usageOrigin, apiHostOrigin)
+    return isInvocationWithinSameOrigin(usageOrigin, apiHostOrigin)
+      || isInvocationWithinPlatform(usageOrigin, apiHostOrigin)
       || isInvocationWithinSamePlugin(usageOrigin, apiHostOrigin)
   }
 
@@ -30,4 +31,8 @@ class SamePluginUsageFilter : ClassLocationApiUsageFilter() {
   private fun isInvocationWithinPlatform(usageOrigin: FileOrigin, apiHostOrigin: FileOrigin) =
     apiHostOrigin.isOriginOfType<IdeFileOrigin>()
       && (usageOrigin == apiHostOrigin || usageOrigin.isOriginOfType<IdeFileOrigin>())
+
+  private fun isInvocationWithinSameOrigin(usageOrigin: FileOrigin, apiHostOrigin: FileOrigin): Boolean {
+    return SameOriginApiUsageFilter(usageOrigin, apiHostOrigin)
+  }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
@@ -9,7 +9,7 @@ import com.jetbrains.pluginverifier.results.reference.ClassReference
 import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.FilteringApiUsageProcessor
-import com.jetbrains.pluginverifier.usages.SameOriginApiUsageFilter
+import com.jetbrains.pluginverifier.usages.SamePluginUsageFilter
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
@@ -19,7 +19,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
 class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: ExperimentalApiRegistrar) : FilteringApiUsageProcessor(
-  SameOriginApiUsageFilter()
+  SamePluginUsageFilter()
 ) {
 
   private fun isExperimental(

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.closeLogged
+import com.jetbrains.plugin.structure.base.utils.closeOnException
+import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
+import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.StructurallyValidated
+import com.jetbrains.plugin.structure.intellij.problems.UnableToReadPluginFile
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.files.FileLock
+import java.nio.file.Path
+
+/**
+ * Baseline implementation of the [PluginDetailsProvider] that
+ * uses the [extractDirectory] for extracting `.zip`-ped plugins.
+ */
+abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path) : PluginDetailsProvider {
+  private val idePluginManager = IdePluginManager.createManager(extractDirectory)
+
+  private val IdePlugin.problems: List<PluginProblem>
+    get() = if (this is StructurallyValidated) this.problems else emptyList()
+
+  abstract fun readPluginClasses(pluginInfo: PluginInfo, idePlugin: IdePlugin): IdePluginClassesLocations
+
+  override fun providePluginDetails(pluginInfo: PluginInfo, pluginFileLock: FileLock) =
+    pluginFileLock.closeOnException {
+      with(idePluginManager.createPlugin(pluginFileLock.file)) {
+        when (this) {
+          is PluginCreationSuccess<IdePlugin> -> {
+            readPluginClasses(
+              pluginInfo,
+              plugin,
+              plugin.problems,
+              pluginFileLock
+            )
+          }
+
+          is PluginCreationFail<IdePlugin> -> {
+            pluginFileLock.closeLogged<FileLock?>()
+            PluginDetailsProvider.Result.InvalidPlugin(pluginInfo, errorsAndWarnings)
+          }
+        }
+      }
+    }
+
+  override fun providePluginDetails(
+    pluginInfo: PluginInfo,
+    idePlugin: IdePlugin
+  ): PluginDetailsProvider.Result {
+    return readPluginClasses(pluginInfo, idePlugin, idePlugin.problems, null)
+  }
+
+  private fun readPluginClasses(
+    pluginInfo: PluginInfo,
+    idePlugin: IdePlugin,
+    warnings: List<PluginProblem>,
+    pluginFileLock: FileLock?
+  ): PluginDetailsProvider.Result {
+    return try {
+      readPluginClasses(pluginInfo, idePlugin)
+        .let { pluginClassesLocations ->
+          PluginDetailsProvider.Result.Provided(
+            PluginDetails(
+              pluginInfo,
+              idePlugin,
+              warnings,
+              pluginClassesLocations,
+              pluginFileLock
+            )
+          )
+        }
+    } catch (e: Exception) {
+      e.rethrowIfInterrupted()
+      val message = e.message ?: e.javaClass.simpleName
+      PluginDetailsProvider.Result.InvalidPlugin(pluginInfo, listOf(UnableToReadPluginFile(message)))
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
@@ -1,0 +1,26 @@
+package com.jetbrains.pluginverifier.plugin
+
+import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExtensionKey
+import com.jetbrains.plugin.structure.intellij.classes.plugin.BundledPluginClassesFinder
+import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPluginInfo
+import java.nio.file.Path
+
+/**
+ * Provides plugin details with explicit support for bundled plugins that are provided by the Platform.
+ *
+ * Non-bundled plugins are handled by the delegate [PluginDetailsProviderImpl].
+ */
+class DefaultPluginDetailsProvider(extractDirectory: Path) : AbstractPluginDetailsProvider(extractDirectory) {
+  private val nonBundledPluginDetailsProvider: PluginDetailsProviderImpl = PluginDetailsProviderImpl(extractDirectory)
+
+  override fun readPluginClasses(pluginInfo: PluginInfo, idePlugin: IdePlugin): IdePluginClassesLocations {
+    return if (pluginInfo is BundledPluginInfo) {
+      BundledPluginClassesFinder.findPluginClasses(idePlugin, additionalKeys = listOf(CompileServerExtensionKey))
+    } else {
+      nonBundledPluginDetailsProvider.readPluginClasses(pluginInfo, idePlugin)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsProviderImpl.kt
@@ -61,24 +61,24 @@ class PluginDetailsProviderImpl(private val extractDirectory: Path) : PluginDeta
     warnings: List<PluginProblem>,
     pluginFileLock: FileLock?
   ): PluginDetailsProvider.Result {
-
-    val pluginClassesLocations = try {
-      IdePluginClassesFinder.findPluginClasses(idePlugin, additionalKeys = listOf(CompileServerExtensionKey))
+    return try {
+      IdePluginClassesFinder
+        .findPluginClasses(idePlugin, additionalKeys = listOf(CompileServerExtensionKey))
+        .let { pluginClassesLocations ->
+          PluginDetailsProvider.Result.Provided(
+            PluginDetails(
+              pluginInfo,
+              idePlugin,
+              warnings,
+              pluginClassesLocations,
+              pluginFileLock
+            ))
+        }
     } catch (e: Exception) {
       e.rethrowIfInterrupted()
       val message = e.message ?: e.javaClass.simpleName
-      return PluginDetailsProvider.Result.InvalidPlugin(pluginInfo, listOf(UnableToReadPluginFile(message)))
+      PluginDetailsProvider.Result.InvalidPlugin(pluginInfo, listOf(UnableToReadPluginFile(message)))
     }
-
-    return PluginDetailsProvider.Result.Provided(
-      PluginDetails(
-        pluginInfo,
-        idePlugin,
-        warnings,
-        pluginClassesLocations,
-        pluginFileLock
-      )
-    )
   }
 
   private val IdePlugin.problems: List<PluginProblem>

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationRunner.kt
@@ -15,7 +15,7 @@ import com.jetbrains.pluginverifier.filtering.ProblemsFilter
 import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
-import com.jetbrains.pluginverifier.plugin.PluginDetailsProviderImpl
+import com.jetbrains.pluginverifier.plugin.DefaultPluginDetailsProvider
 import com.jetbrains.pluginverifier.plugin.PluginFilesBank
 import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
 import com.jetbrains.pluginverifier.repository.cleanup.DiskSpaceSetting
@@ -40,7 +40,7 @@ class VerificationRunner {
     val tempFolder = Files.createTempDirectory("")
     tempFolder.toFile().deleteOnExit()
 
-    val pluginDetailsProvider = PluginDetailsProviderImpl(tempFolder)
+    val pluginDetailsProvider = DefaultPluginDetailsProvider(tempFolder)
     val pluginDetailsCache = SizeLimitedPluginDetailsCache(10, pluginFilesBank, pluginDetailsProvider)
     return IdeDescriptor.create(ide.idePath, jdkPath, null).use { ideDescriptor ->
       val externalClassesPackageFilter = OptionsParser.getExternalClassesPackageFilter(CmdOpts())

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/server/configuration/ServerContextConfiguration.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/server/configuration/ServerContextConfiguration.kt
@@ -11,7 +11,7 @@ import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.ide.IdeDescriptorsCache
 import com.jetbrains.pluginverifier.ide.IdeFilesBank
 import com.jetbrains.pluginverifier.ide.repositories.IdeRepository
-import com.jetbrains.pluginverifier.plugin.PluginDetailsProviderImpl
+import com.jetbrains.pluginverifier.plugin.DefaultPluginDetailsProvider
 import com.jetbrains.pluginverifier.plugin.PluginFilesBank
 import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
 import com.jetbrains.pluginverifier.repository.cleanup.DiskSpaceSetting
@@ -68,7 +68,7 @@ class ServerContextConfiguration(
 
     val pluginDownloadDirSpaceSetting = getPluginDownloadDirDiskSpaceSetting()
 
-    val pluginDetailsProvider = PluginDetailsProviderImpl(extractedPluginsDir)
+    val pluginDetailsProvider = DefaultPluginDetailsProvider(extractedPluginsDir)
     val pluginFilesBank = PluginFilesBank.create(pluginRepository, loadedPluginsDir, pluginDownloadDirSpaceSetting)
     val pluginDetailsCache = SizeLimitedPluginDetailsCache(PLUGIN_DETAILS_CACHE_SIZE, pluginFilesBank, pluginDetailsProvider)
 


### PR DESCRIPTION
Set proper `FileOrigin`s for bundled plugins.

Bundled plugin classes have been incorrectly marked as `FileOrigin` where they should have been more specifically: as an instance of `IdeFileOrigin`. This resolves multiple tricky corner-cases where class origins are not reported correctly as a part of the Platform.

This is an extension of #1120.

- Introduce `BundledPlugin` as a `FileOrigin`. This corresponds to an origin of classes that belong to the same bundled plugin. This helps to discriminate between class origins in the verification rules, especially those that detect Platform invocations from Plugin invocations.
- Allow customizable file origin resolution for JARs and `lib` directories. These have been originally set to `SingleJar` or `SingleLib`. Treating regular plugins and bundled plugins as the same source might not be enough in some scenarios. 
- Create a `BundledPluginClassFinder` that loads bundled plugin classes with correct origins.
- Support arbitrary origins for `MainClassesLocator` that has been hardwired to JARs and libs.
- Refactor `PluginDetailsProviderImpl`. 
* Introduce `DefaultPluginDetailsProvider` that supports bundled plugins with corresponding file origin resolution.
* Replace all `PluginDetailsProviderImpl` references with `DefaultPluginDetailsProvider` as a new bundle-supporting mechanism.

[MP-6729](https://youtrack.jetbrains.com/issue/MP-6729)
