### PR TITLE
Remap bundled plugin problems when using Platform 2024.2+ layout

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -196,7 +196,5 @@ class ProductInfoBasedIdeManager : IdeManager() {
     is PluginCreationSuccess -> Success(pluginArtifactPath, plugin)
     is PluginCreationFail -> Failure(pluginArtifactPath, errorsAndWarnings)
   }
-
-
 }
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -23,6 +23,9 @@ import com.jetbrains.plugin.structure.intellij.platform.ProductInfoParser
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.JarFilesResourceResolver
+import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.NamedResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
@@ -40,6 +43,12 @@ private val LOG: Logger = LoggerFactory.getLogger(ProductInfoBasedIdeManager::cl
 
 class ProductInfoBasedIdeManager : IdeManager() {
   private val productInfoParser = ProductInfoParser()
+
+  /**
+   * Problem level remapping used for bundled plugins.
+   */
+  private val bundledPluginCreationResultResolver: PluginCreationResultResolver
+    get() = JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
 
   @Throws(InvalidIdeException::class)
   override fun createIde(idePath: Path): Ide = createIde(idePath, VERSION_FROM_PRODUCT_INFO)
@@ -133,7 +142,7 @@ class ProductInfoBasedIdeManager : IdeManager() {
     ideVersion: IdeVersion
   ) = IdePluginManager
     .createManager(resourceResolver)
-    .createBundledPlugin(pluginArtifactPath, ideVersion, descriptorPath)
+    .createBundledPlugin(pluginArtifactPath, ideVersion, descriptorPath, bundledPluginCreationResultResolver)
     .withPath(pluginArtifactPath)
 
   private fun createIdeVersion(productInfo: ProductInfo): IdeVersion {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -185,7 +185,7 @@ class ProductInfoBasedIdeManager : IdeManager() {
 
   private fun PluginCreationResult<IdePlugin>.withPath(pluginArtifactPath: Path): PluginWithArtifactPathResult = when (this) {
     is PluginCreationSuccess -> Success(pluginArtifactPath, plugin)
-    is PluginCreationFail -> Failure(pluginArtifactPath)
+    is PluginCreationFail -> Failure(pluginArtifactPath, errorsAndWarnings)
   }
 
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
@@ -22,6 +22,17 @@ internal sealed class PluginWithArtifactPathResult(open val pluginArtifactPath: 
           idePath.relativize(it.pluginArtifactPath)
         }.joinToString(", ")
         log.atWarn().log("Following ${failures.size} plugins could not be created: $failedPluginPaths")
+        if (log.isDebugEnabled) {
+          buildString {
+            failures
+              .filterIsInstance<Failure>()
+              .forEach { (pluginArtifactPath, problems) ->
+                append("Unable to load '")
+                append(idePath.relativize(pluginArtifactPath)).append("': ")
+                append(problems.joinToString("\n* ", "\n* "))
+              }
+          }.let { log.debug(it) }
+        }
       }
     }
   }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.ide.layout
 
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import org.slf4j.Logger
 import java.nio.file.Path
@@ -8,7 +9,7 @@ internal sealed class PluginWithArtifactPathResult(open val pluginArtifactPath: 
   data class Success(override val pluginArtifactPath: Path, val plugin: IdePlugin) :
     PluginWithArtifactPathResult(pluginArtifactPath)
 
-  data class Failure(override val pluginArtifactPath: Path) : PluginWithArtifactPathResult(pluginArtifactPath)
+  data class Failure(override val pluginArtifactPath: Path, val pluginProblems: List<PluginProblem>) : PluginWithArtifactPathResult(pluginArtifactPath)
 
   companion object {
     internal fun logFailures(

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -117,11 +117,14 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
                 """
                   <idea-plugin>
                     <id>com.jetbrains.codeWithMe</id>
+                    <name>Code With Me</name>
+                    <vendor>JetBrains</vendor>
                     <version>242.20224.38</version>
                     <idea-version since-build="242.20224.38" until-build="242.20224.38" />
                     <!-- Intentionally set a release date in the future -->
                     <product-descriptor 
                       code="PCWMP" 
+                      release-version="2024200"
                       release-date="40000101" />
                   </idea-plugin>                                    
                 """.trimIndent()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -109,6 +109,27 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
           }
         }
       }
+      dir("cwm-plugin") {
+        dir("lib") {
+          zip("cwm-plugin.jar") {
+            dir("META-INF") {
+              file("plugin.xml") {
+                """
+                  <idea-plugin>
+                    <id>com.jetbrains.codeWithMe</id>
+                    <version>242.20224.38</version>
+                    <idea-version since-build="242.20224.38" until-build="242.20224.38" />
+                    <!-- Intentionally set a release date in the future -->
+                    <product-descriptor 
+                      code="PCWMP" 
+                      release-date="40000101" />
+                  </idea-plugin>                                    
+                """.trimIndent()
+              }
+            }
+          }
+        }
+      }
     }
   }
 
@@ -148,7 +169,14 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
               "classPath": [
                 "plugins/java/lib/modules/intellij.java.featuresTrainer.jar"
               ]
-            }            
+            },
+            {
+              "name": "com.jetbrains.codeWithMe",
+              "kind": "plugin",
+              "classPath": [
+                "plugins/cwm-plugin/lib/cwm-plugin.jar"
+              ]
+            }                      
           ]
         } 
     """.trimIndent()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
+import java.time.LocalDate
 
 class ProductInfoBasedIdeManagerTest {
 
@@ -26,7 +27,7 @@ class ProductInfoBasedIdeManagerTest {
     val ideManager = ProductInfoBasedIdeManager()
     val ide = ideManager.createIde(ideRoot)
 
-    assertEquals(4, ide.bundledPlugins.size)
+    assertEquals(5, ide.bundledPlugins.size)
     val uiPlugin = ide.getPluginById("intellij.notebooks.ui")
     assertNotNull(uiPlugin)
     assertTrue(uiPlugin is IdeModule)
@@ -59,6 +60,14 @@ class ProductInfoBasedIdeManagerTest {
     assertNotNull(ideCore)
     with(ideCore!!) {
       assertEquals(4, definedModules.size)
+    }
+
+    val codeWithMe = ide.getPluginById("com.jetbrains.codeWithMe")
+    assertNotNull(codeWithMe)
+    with(codeWithMe!!) {
+      assertNotNull(productDescriptor)
+      val productDescriptor = productDescriptor!!
+      assertEquals(LocalDate.of(4000, 1, 1), productDescriptor.releaseDate)
     }
   }
 


### PR DESCRIPTION
When constructing bundled plugins in the Platform 2024.2+ layout, the plugin problems should be properly remapped.
Otherwise, some bundled plugins cannot be loaded.

- Use the relaxed set of plugin problem verification that is used for JetBrains plugins.
- Apply them in the `ProductInfoBasedIdeManager` that is responsible for the Platform 2024.2+ layout.
- Resolve the `cwm-plugin` that is not being able to be loaded.
- Add it as a unit test sample.
- Improve debug logging on bundled plugins that cannot be loaded.

See [MP-6757](https://youtrack.jetbrains.com/issue/MP-6757) and [IJPL-158170](https://youtrack.jetbrains.com/issue/IJPL-158170).