### PR TITLE
Remap plugin problems when resolving plugin dependencies

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -131,7 +131,7 @@ class ProductInfoBasedIdeManager : IdeManager() {
   ): PluginWithArtifactPathResult {
     return IdePluginManager
       .createManager(pathResolver)
-      .createBundledModule(pluginArtifactPath, ideVersion, descriptorName)
+      .createBundledModule(pluginArtifactPath, ideVersion, descriptorName, bundledPluginCreationResultResolver)
       .withPath(pluginArtifactPath)
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -792,9 +792,11 @@ internal class PluginCreator private constructor(
       return false
     }
     val invalidPlugin = newInvalidPlugin(bean, document)
-    return problemResolver.classify(invalidPlugin, problems).any {
-      it.level == ERROR
-    }
+    return problemResolver
+      .classify(invalidPlugin, problems)
+      .filter {
+        it.level == ERROR
+      }.notEmpty(context = bean)
   }
 
   private fun validateId(plugin: PluginBean) {
@@ -948,6 +950,19 @@ internal class PluginCreator private constructor(
 
   private val PluginCreationSuccess<IdePlugin>.problems: List<PluginProblem>
     get() = warnings + unacceptableWarnings
+
+  private fun List<PluginProblem>.notEmpty(context: PluginBean): Boolean {
+    return if (isEmpty()) {
+      false
+    } else {
+      if (LOG.isDebugEnabled) {
+        val errorMsg = joinToString()
+        LOG.debug("Plugin '${context.id}' has $size error(s): $errorMsg")
+      }
+      true
+    }
+  }
+
 }
 
 private fun PluginCreationResult<IdePlugin>.add(telemetry: PluginTelemetry): PluginCreationResult<IdePlugin> {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
@@ -7,6 +7,7 @@ package com.jetbrains.pluginverifier.dependencies.resolution
 import com.jetbrains.pluginverifier.misc.retry
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.dependency.DependencyPluginRepository
 
 /**
  * [DependencyFinder] that searches for the dependency in the [PluginRepository].
@@ -14,10 +15,12 @@ import com.jetbrains.pluginverifier.repository.PluginRepository
  * if multiple versions are available.
  */
 class RepositoryDependencyFinder(
-  private val pluginRepository: PluginRepository,
+  pluginRepository: PluginRepository,
   private val pluginVersionSelector: PluginVersionSelector,
   private val pluginDetailsCache: PluginDetailsCache
 ) : DependencyFinder {
+
+  private val pluginRepository = DependencyPluginRepository(pluginRepository)
 
   override val presentableName
     get() = pluginRepository.toString()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
@@ -33,7 +33,7 @@ abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path)
 
   override fun providePluginDetails(pluginInfo: PluginInfo, pluginFileLock: FileLock) =
     pluginFileLock.closeOnException {
-      with(createPlugin(pluginFileLock)) {
+      with(createPlugin(pluginInfo, pluginFileLock)) {
         when (this) {
           is PluginCreationSuccess<IdePlugin> -> {
             readPluginClasses(
@@ -85,6 +85,6 @@ abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path)
     }
   }
 
-  protected fun createPlugin(pluginFileLock: FileLock) =
+  protected open fun createPlugin(pluginInfo: PluginInfo, pluginFileLock: FileLock) =
     idePluginManager.createPlugin(pluginFileLock.file)
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
@@ -33,7 +33,7 @@ abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path)
 
   override fun providePluginDetails(pluginInfo: PluginInfo, pluginFileLock: FileLock) =
     pluginFileLock.closeOnException {
-      with(idePluginManager.createPlugin(pluginFileLock.file)) {
+      with(createPlugin(pluginFileLock)) {
         when (this) {
           is PluginCreationSuccess<IdePlugin> -> {
             readPluginClasses(
@@ -84,4 +84,7 @@ abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path)
       PluginDetailsProvider.Result.InvalidPlugin(pluginInfo, listOf(UnableToReadPluginFile(message)))
     }
   }
+
+  protected fun createPlugin(pluginFileLock: FileLock) =
+    idePluginManager.createPlugin(pluginFileLock.file)
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/AbstractPluginDetailsProvider.kt
@@ -24,7 +24,7 @@ import java.nio.file.Path
  * uses the [extractDirectory] for extracting `.zip`-ped plugins.
  */
 abstract class AbstractPluginDetailsProvider(private val extractDirectory: Path) : PluginDetailsProvider {
-  private val idePluginManager = IdePluginManager.createManager(extractDirectory)
+  protected val idePluginManager = IdePluginManager.createManager(extractDirectory)
 
   private val IdePlugin.problems: List<PluginProblem>
     get() = if (this is StructurallyValidated) this.problems else emptyList()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
@@ -1,11 +1,17 @@
 package com.jetbrains.pluginverifier.plugin
 
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExtensionKey
 import com.jetbrains.plugin.structure.intellij.classes.plugin.BundledPluginClassesFinder
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.files.FileLock
 import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPluginInfo
+import com.jetbrains.pluginverifier.repository.repositories.dependency.DependencyPluginInfo
 import java.nio.file.Path
 
 /**
@@ -16,11 +22,22 @@ import java.nio.file.Path
 class DefaultPluginDetailsProvider(extractDirectory: Path) : AbstractPluginDetailsProvider(extractDirectory) {
   private val nonBundledPluginDetailsProvider: PluginDetailsProviderImpl = PluginDetailsProviderImpl(extractDirectory)
 
+  private val dependencyProblemResolver: PluginCreationResultResolver =
+    JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
+
   override fun readPluginClasses(pluginInfo: PluginInfo, idePlugin: IdePlugin): IdePluginClassesLocations {
     return if (pluginInfo is BundledPluginInfo) {
       BundledPluginClassesFinder.findPluginClasses(idePlugin, additionalKeys = listOf(CompileServerExtensionKey))
     } else {
       nonBundledPluginDetailsProvider.readPluginClasses(pluginInfo, idePlugin)
+    }
+  }
+
+  override fun createPlugin(pluginInfo: PluginInfo, pluginFileLock: FileLock): PluginCreationResult<IdePlugin> {
+    return if (pluginInfo is DependencyPluginInfo) {
+      idePluginManager.createPlugin(pluginFileLock.file, validateDescriptor = false, problemResolver = dependencyProblemResolver)
+    } else {
+      super.createPlugin(pluginInfo, pluginFileLock)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
@@ -4,8 +4,8 @@
 
 package com.jetbrains.pluginverifier.plugin
 
-import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.WithIdePlugin
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntry
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntryResult
 import com.jetbrains.pluginverifier.repository.cache.createSizeLimitedResourceCache
@@ -13,10 +13,8 @@ import com.jetbrains.pluginverifier.repository.cleanup.SizeWeight
 import com.jetbrains.pluginverifier.repository.provider.ProvideResult
 import com.jetbrains.pluginverifier.repository.provider.ResourceProvider
 import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPluginInfo
-import com.jetbrains.pluginverifier.repository.repositories.custom.CustomPluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.dependency.DependencyPluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginInfo
-import com.jetbrains.pluginverifier.repository.repositories.marketplace.UpdateInfo
 
 /**
  * This cache is intended to open and cache [PluginDetails] for
@@ -90,8 +88,8 @@ private class PluginDetailsResourceProvider(
   }
 
   private fun provideDependencyDetails(dependency: DependencyPluginInfo): ProvideResult<PluginDetailsProvider.Result> {
-    val unwrappedPlugin = dependency.idePlugin
     val unwrappedPluginInfo = dependency.pluginInfo
+    val unwrappedPlugin = (unwrappedPluginInfo as? WithIdePlugin)?.idePlugin
     return if (unwrappedPlugin != null) {
       pluginDetailsProvider.providePluginDetails(unwrappedPluginInfo, unwrappedPlugin).provided
     } else {
@@ -114,19 +112,7 @@ private class PluginDetailsResourceProvider(
     }
   }
 
-  private val DependencyPluginInfo.idePlugin: IdePlugin?
-    get() {
-      return when (pluginInfo) {
-        is BundledPluginInfo -> pluginInfo.idePlugin
-        is LocalPluginInfo -> pluginInfo.idePlugin
-        is CustomPluginInfo -> null
-        is UpdateInfo -> null
-        else -> null
-      }
-    }
-
   private val PluginDetailsProvider.Result.provided
     get() = ProvideResult.Provided(this)
-
 
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
@@ -89,6 +89,18 @@ private class PluginDetailsResourceProvider(
       .provideDetails(pluginInfo)
   }
 
+  private fun provideDependencyDetails(dependency: DependencyPluginInfo): ProvideResult<PluginDetailsProvider.Result> {
+    val unwrappedPlugin = dependency.idePlugin
+    val unwrappedPluginInfo = dependency.pluginInfo
+    return if (unwrappedPlugin != null) {
+      pluginDetailsProvider.providePluginDetails(unwrappedPluginInfo, unwrappedPlugin).provided
+    } else {
+      pluginFileProvider
+        .getPluginFile(unwrappedPluginInfo)
+        .provideDetails(dependency)
+    }
+  }
+
   private fun PluginFileProvider.Result.provideDetails(pluginInfo: PluginInfo): ProvideResult<PluginDetailsProvider.Result> {
     return when (this) {
       is PluginFileProvider.Result.Found -> {
@@ -99,18 +111,6 @@ private class PluginDetailsResourceProvider(
 
       is PluginFileProvider.Result.NotFound -> ProvideResult.NotFound(reason)
       is PluginFileProvider.Result.Failed -> ProvideResult.Failed(reason, error)
-    }
-  }
-
-  private fun provideDependencyDetails(dependency: DependencyPluginInfo): ProvideResult<PluginDetailsProvider.Result> {
-    val unwrappedPlugin = dependency.idePlugin
-    val unwrappedPluginInfo = dependency.pluginInfo
-    return if (unwrappedPlugin != null) {
-      pluginDetailsProvider.providePluginDetails(unwrappedPluginInfo, unwrappedPlugin).provided
-    } else {
-      pluginFileProvider
-        .getPluginFile(unwrappedPluginInfo)
-        .provideDetails(dependency)
     }
   }
 

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
@@ -23,8 +23,8 @@ import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginInf
  */
 class SizeLimitedPluginDetailsCache(
   cacheSize: Int,
-  val pluginFileProvider: PluginFileProvider,
-  val pluginDetailsProvider: PluginDetailsProvider
+  pluginFileProvider: PluginFileProvider,
+  pluginDetailsProvider: PluginDetailsProvider
 ) : PluginDetailsCache {
 
   private val internalCache = createSizeLimitedResourceCache(

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/WithIdePlugin.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/WithIdePlugin.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.repository
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+
+/**
+ * Indicates a [plugin info][PluginInfo] that contains a resolved [IDE Plugin][IdePlugin].
+ */
+interface WithIdePlugin {
+  val idePlugin: IdePlugin
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/bundled/BundledPluginInfo.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/bundled/BundledPluginInfo.kt
@@ -7,6 +7,7 @@ package com.jetbrains.pluginverifier.repository.repositories.bundled
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.WithIdePlugin
 import java.io.ObjectInputStream
 import java.util.*
 
@@ -15,7 +16,7 @@ import java.util.*
  */
 class BundledPluginInfo(
   val ideVersion: IdeVersion,
-  val idePlugin: IdePlugin
+  override val idePlugin: IdePlugin
 ) : PluginInfo(
   idePlugin.pluginId!!,
   idePlugin.pluginName ?: idePlugin.pluginId!!,
@@ -23,7 +24,7 @@ class BundledPluginInfo(
   idePlugin.sinceBuild,
   idePlugin.untilBuild,
   idePlugin.vendor
-) {
+), WithIdePlugin {
 
   private fun writeReplace(): Any = throw UnsupportedOperationException("Bundled plugins cannot be serialized")
 

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginInfo.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginInfo.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+package com.jetbrains.pluginverifier.repository.repositories.dependency
+
+import com.jetbrains.pluginverifier.repository.PluginInfo
+
+/**
+ * Plugin information that is resolved as a plugin dependency.
+ */
+class DependencyPluginInfo(val pluginInfo: PluginInfo) : PluginInfo(
+  pluginInfo.pluginId,
+  pluginInfo.pluginName,
+  pluginInfo.version,
+  pluginInfo.sinceBuild,
+  pluginInfo.untilBuild,
+  pluginInfo.vendor
+)

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginRepository.kt
@@ -12,7 +12,7 @@ import com.jetbrains.pluginverifier.repository.PluginRepository
  * Repository wrapping another repository while mapping plugins into [dependencies][DependencyPluginInfo].
  */
 class DependencyPluginRepository(private val delegateRepository: PluginRepository) : PluginRepository {
-  override val presentableName: String = "Plugin Dependency repository"
+  override val presentableName: String = "${delegateRepository.presentableName} (used for plugin dependencies)"
 
   override fun getLastCompatiblePlugins(ideVersion: IdeVersion): List<PluginInfo> =
     delegateRepository.getLastCompatiblePlugins(ideVersion).asDependencies()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginRepository.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/dependency/DependencyPluginRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.repository.repositories.dependency
+
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.PluginRepository
+
+/**
+ * Repository wrapping another repository while mapping plugins into [dependencies][DependencyPluginInfo].
+ */
+class DependencyPluginRepository(private val delegateRepository: PluginRepository) : PluginRepository {
+  override val presentableName: String = "Plugin Dependency repository"
+
+  override fun getLastCompatiblePlugins(ideVersion: IdeVersion): List<PluginInfo> =
+    delegateRepository.getLastCompatiblePlugins(ideVersion).asDependencies()
+
+  override fun getLastCompatibleVersionOfPlugin(ideVersion: IdeVersion, pluginId: String): PluginInfo? =
+    delegateRepository.getLastCompatibleVersionOfPlugin(ideVersion, pluginId).asDependency()
+
+  override fun getAllVersionsOfPlugin(pluginId: String): List<PluginInfo> =
+    delegateRepository.getAllVersionsOfPlugin(pluginId).asDependencies()
+
+  override fun getPluginsDeclaringModule(moduleId: String, ideVersion: IdeVersion?): List<PluginInfo> =
+    delegateRepository.getPluginsDeclaringModule(moduleId, ideVersion).asDependencies()
+
+  private fun List<PluginInfo>.asDependencies(): List<DependencyPluginInfo> = map { DependencyPluginInfo(it) }
+
+  private fun PluginInfo?.asDependency(): PluginInfo? = this?.let { DependencyPluginInfo(it) }
+
+}
+
+

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginInfo.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginInfo.kt
@@ -6,6 +6,7 @@ package com.jetbrains.pluginverifier.repository.repositories.local
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.WithIdePlugin
 import java.io.ObjectInputStream
 
 /**
@@ -14,7 +15,7 @@ import java.io.ObjectInputStream
  * @see [LocalPluginRepository]
  */
 class LocalPluginInfo(
-  val idePlugin: IdePlugin
+  override val idePlugin: IdePlugin
 ) : PluginInfo(
   idePlugin.pluginId!!,
   idePlugin.pluginName ?: idePlugin.pluginId!!,
@@ -22,7 +23,7 @@ class LocalPluginInfo(
   idePlugin.sinceBuild,
   idePlugin.untilBuild,
   idePlugin.vendor
-) {
+), WithIdePlugin {
 
   val definedModules: Set<String>
     get() = idePlugin.definedModules

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
@@ -1,0 +1,118 @@
+package com.jetbrains.pluginverifier.plugin.resolution
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
+import com.jetbrains.plugin.structure.intellij.problems.ReleaseDateInFuture
+import com.jetbrains.plugin.structure.jar.META_INF
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
+import com.jetbrains.pluginverifier.dependencies.resolution.LastVersionSelector
+import com.jetbrains.pluginverifier.dependencies.resolution.RepositoryDependencyFinder
+import com.jetbrains.pluginverifier.plugin.DefaultPluginDetailsProvider
+import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
+import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+class DependencyDiscoveryTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `plugin dependencies are resolved`() {
+    val pluginV1 = PluginInfo("somePlugin", "Some Plugin", "1.0.0")
+    val pluginV2 = PluginInfo("somePlugin", "Some Plugin", "2.0.0")
+    val dependency = PluginInfo("aDependency", "Dependency", "1.0.0")
+
+    val pluginV1JarPath = temporaryFolder.createJarPath(pluginV1).also {
+      buildPluginWithDescriptor(it) {
+        pluginV1.getPluginXml(v1Dependencies = listOf("aDependency"))
+      }
+    }
+
+    val pluginV2JarPath = temporaryFolder.createJarPath(pluginV2).also {
+      buildPluginWithDescriptor(it) {
+        pluginV2.getPluginXml(v1Dependencies = listOf("aDependency")) {
+          append("""
+            <product-descriptor 
+              code="MOCKPLUGIN" 
+              release-version="1" 
+              release-date="99991212" />
+          """.trimIndent())
+        }
+      }
+    }
+
+    val dependencyPath = temporaryFolder.createJarPath(dependency).also {
+      buildPluginWithDescriptor(it) {
+        dependency.getPluginXml()
+      }
+    }
+
+    val repository = InMemoryPluginRepository.create(pluginV1, pluginV2)
+    val versionSelector = LastVersionSelector()
+    val fileProvider = InMemoryPluginFileProvider().apply {
+      this[pluginV1] = pluginV1JarPath
+      this[pluginV2] = pluginV2JarPath
+      this[dependency] = dependencyPath
+    }
+    val detailsProvider = DefaultPluginDetailsProvider(temporaryFolder.newFolder("plugin-cache").toPath())
+    val detailsCache = SizeLimitedPluginDetailsCache(Int.MAX_VALUE, fileProvider, detailsProvider)
+
+    val dependencyFinder = RepositoryDependencyFinder(repository, versionSelector, detailsCache)
+
+    val result = dependencyFinder.findPluginDependency("somePlugin", isModule = false)
+    assertTrue(result is DependencyFinder.Result.DetailsProvided)
+    val detailsProvided = result as DependencyFinder.Result.DetailsProvided
+    assertTrue(detailsProvided.pluginDetailsCacheResult is PluginDetailsCache.Result.Provided)
+    val cacheResult = detailsProvided.pluginDetailsCacheResult as PluginDetailsCache.Result.Provided
+    with(cacheResult.pluginDetails) {
+      with(pluginWarnings) {
+        assertEquals(2, size)
+        assertTrue(hasUnwrappedProblem<NoModuleDependencies>())
+        assertTrue(hasUnwrappedProblem<ReleaseDateInFuture>())
+      }
+      with(idePlugin.dependencies) {
+        assertEquals(1, size)
+        assertEquals("aDependency", first().id)
+      }
+    }
+  }
+
+  private fun buildPluginWithDescriptor(pluginArtifactPath: Path, pluginXmlContent: ContentBuilder.() -> String): Path =
+    buildZipFile(pluginArtifactPath) {
+      dir(META_INF) {
+        file(PLUGIN_XML) {
+          pluginXmlContent()
+        }
+      }
+    }
+
+  private fun PluginInfo.getPluginXml(
+    v1Dependencies: List<String> = emptyList(),
+    additionalContents: StringBuilder.() -> Unit = {}
+  ): String {
+    val v1DependenciesString = v1Dependencies.joinToString("\n") { "<depends>$it</depends>" }
+    val additionalString = StringBuilder().apply {
+      additionalContents()
+    }
+    return """
+        <idea-plugin>
+          <id>$pluginId</id>
+          <name>$pluginName</name>
+          <version>$version</version>
+          <vendor email="vendor@vendor.com" url="url">$vendor</vendor>
+          $v1DependenciesString
+          $additionalString
+        </idea-plugin>
+        """.trimIndent()
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginFileProvider.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginFileProvider.kt
@@ -1,0 +1,36 @@
+package com.jetbrains.pluginverifier.plugin.resolution
+
+import com.jetbrains.pluginverifier.plugin.PluginFileProvider
+import com.jetbrains.pluginverifier.plugin.PluginFileProvider.Result.Found
+import com.jetbrains.pluginverifier.plugin.PluginFileProvider.Result.NotFound
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.files.IdleFileLock
+import java.nio.file.Path
+import java.util.*
+
+class InMemoryPluginFileProvider : PluginFileProvider {
+  private val mapping = TreeMap<PluginInfo, Path>(pluginInfoComparator)
+
+  override fun getPluginFile(pluginInfo: PluginInfo) =
+    mapping[pluginInfo]
+      ?.let { Found(IdleFileLock(it)) }
+      ?: NotFound("Not found ${pluginInfo.fqn()}.")
+
+  operator fun set(pluginInfo: PluginInfo, path: Path) {
+    mapping[pluginInfo] = path
+  }
+
+  private val pluginInfoComparator: Comparator<PluginInfo>
+    get() {
+      return Comparator { info1, info2 ->
+        val i1 = info1.fqn()
+        val i2 = info2.fqn()
+        i1.compareTo(i2)
+      }
+    }
+
+  private fun PluginInfo?.fqn(): String {
+    if (this == null) return ""
+    return "${pluginId}:${version}"
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginFileProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginFileProviderTest.kt
@@ -1,0 +1,43 @@
+package com.jetbrains.pluginverifier.plugin.resolution
+
+import com.jetbrains.pluginverifier.plugin.PluginFileProvider.Result.Found
+import com.jetbrains.pluginverifier.plugin.PluginFileProvider.Result.NotFound
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class InMemoryPluginFileProviderTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private val plugin = PluginInfo("somePlugin", "Some Plugin", "1.0.0")
+  private val dependency = PluginInfo("aDependency", "Dependency", "1.0.0")
+
+  private lateinit var provider: InMemoryPluginFileProvider
+
+  @Before
+  fun setUp() {
+    provider = InMemoryPluginFileProvider()
+    provider[plugin] = temporaryFolder.createJarPath(plugin)
+    provider[dependency] = temporaryFolder.createJarPath(dependency)
+  }
+
+  @Test
+  fun `existing plugins are resolved`() {
+    val pluginResult = provider.getPluginFile(plugin)
+    assert(pluginResult is Found)
+
+    val dependencyResult = provider.getPluginFile(dependency)
+    assert(dependencyResult is Found)
+  }
+
+  @Test
+  fun `unknown plugin is resolved as not found`() {
+    val randomPlugin = PluginInfo("randomPlugin", "Random Plugin", "1.0.0")
+
+    val pluginResult = provider.getPluginFile(randomPlugin)
+    assert(pluginResult is NotFound)
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginRepository.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/InMemoryPluginRepository.kt
@@ -1,0 +1,41 @@
+package com.jetbrains.pluginverifier.plugin.resolution
+
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.PluginRepository
+
+class InMemoryPluginRepository : PluginRepository{
+  override val presentableName: String = "In-Memory Plugin Repository"
+
+  private val plugins = mutableListOf<PluginInfo>()
+
+  override fun getLastCompatiblePlugins(ideVersion: IdeVersion): List<PluginInfo> {
+    return plugins.toList()
+  }
+
+  override fun getLastCompatibleVersionOfPlugin(ideVersion: IdeVersion, pluginId: String): PluginInfo? {
+    return plugins.lastOrNull { it.pluginId == pluginId }
+  }
+
+  override fun getAllVersionsOfPlugin(pluginId: String): List<PluginInfo> {
+    return plugins.filter { it.pluginId == pluginId }
+  }
+
+  override fun getPluginsDeclaringModule(moduleId: String, ideVersion: IdeVersion?): List<PluginInfo> {
+    throw UnsupportedOperationException("Not implemented")
+  }
+
+  operator fun plusAssign(pluginInfo: PluginInfo) {
+    plugins += pluginInfo
+  }
+
+  companion object {
+    fun create(vararg plugins: PluginInfo): InMemoryPluginRepository {
+      return InMemoryPluginRepository().apply {
+        plugins.forEach {
+          this += it
+        }
+      }
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/Resolutions.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/Resolutions.kt
@@ -1,0 +1,27 @@
+package com.jetbrains.pluginverifier.plugin.resolution
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.unwrapped
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+internal fun TemporaryFolder.createJarPath(plugin: PluginInfo): Path {
+  val jarFileName = with(plugin) {
+    "${pluginId}-${version}.jar"
+  }
+  return newFile(jarFileName).toPath()
+}
+
+@Suppress("TestFunctionName")
+internal fun PluginInfo(id: String, name: String, version: String, vendor: String = "JetBrains"): PluginInfo {
+  return object : PluginInfo(id, name, version, sinceBuild = null, untilBuild = null, vendor = vendor) {
+    // intentionally blank
+  }
+}
+
+internal inline fun <reified T : PluginProblem> List<PluginProblem>.hasUnwrappedProblem(): Boolean =
+  map {
+    it.unwrapped
+  }.filterIsInstance<T>()
+    .isNotEmpty()


### PR DESCRIPTION
Plugin dependencies that are resolved as standard Platform plugins might contain problems. 

Some plugins, including those from JetBrains, may have problems leading to error-level plugin problems. In such cases, these plugins are not resolved as dependencies, which can result in unexpected reports of missing dependencies, even when they are actually available.

- Introduce a new `PluginInfo` type: `DependencyPluginInfo` that wraps any other plugin info. This indicates a plugin that will be resolved as a dependency.
- Introduce a repository that delegates to other repositories and treats the results as `DependencyPluginInfo` instances.
- Make corresponding `PluginInfo` instances aware of the `IdePlugin` via explicit interface when appropriate
- `AbstractPluginDetailsProvider` allows to customize the creation of the plugin on the subclass-level.
- `DefaultPluginDetailsProvider` and `SizeLimitedPluginDetailsCache` are dependency-aware. They are using different strategy when resolving plugin as a dependency. More relaxed plugin problem rules are put in place.