### PR TITLE
Match problems in the plugin and problems in the creation result

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -84,7 +84,7 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
     (pluginId ?: pluginName ?: "<unknown plugin ID>") + (pluginVersion?.let { ":$it" } ?: "")
 
   companion object {
-    fun clone(old: IdePlugin, structureProblems: List<PluginProblem>): IdePlugin {
+    fun clone(old: IdePlugin, structureProblems: List<PluginProblem>, overrideStructureProblems: Boolean): IdePlugin {
       return IdePluginImpl().apply {
         pluginId = old.pluginId
         pluginName = old.pluginName
@@ -120,10 +120,11 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
         modulesDescriptors.addAll(old.modulesDescriptors)
         thirdPartyDependencies = old.thirdPartyDependencies.toMutableList()
         if (old is StructurallyValidated) {
-          if (structureProblems.isNotEmpty()) {
+          if (overrideStructureProblems) {
             problems.addAll(structureProblems)
           } else {
-            problems.addAll(old.problems)
+            val oldProblems = (structureProblems + old.problems).toSet()
+            problems.addAll(oldProblems)
           }
         }
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -942,7 +942,7 @@ internal class PluginCreator private constructor(
 
   private fun PluginCreationResult<IdePlugin>.reassignStructureProblems() =
     when (this) {
-      is PluginCreationSuccess -> copy(plugin = IdePluginImpl.clone(plugin, problems))
+      is PluginCreationSuccess -> copy(plugin = IdePluginImpl.clone(plugin, problems, overrideStructureProblems = true))
       is PluginCreationFail -> this
     }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
@@ -15,10 +15,28 @@ abstract class BasePluginTest {
   @JvmField
   val temporaryFolder = TemporaryFolder()
 
+  protected fun buildPluginWithResult(
+    problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
+    pluginContentBuilder: ContentBuilder.() -> Unit
+  ) = buildPluginWithResult(problemResolver, "plugin.jar", pluginContentBuilder)
+
   protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-                                      pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
-    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
-    val ideManager = IdePluginManager.createManager()
-    return ideManager.createPlugin(pluginFile, validateDescriptor = true, problemResolver = problemResolver)
+                                      pluginJarName: String,
+                                      pluginContentBuilder: ContentBuilder.() -> Unit
+  ): PluginCreationResult<IdePlugin> =
+    buildPluginWithResult(
+      problemResolver,
+      { IdePluginManager.createManager() },
+      pluginJarName,
+      pluginContentBuilder = pluginContentBuilder
+    )
+
+  protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
+                                      pluginManagerProvider: () -> IdePluginManager,
+                                      pluginJarName: String,
+                                      pluginContentBuilder: ContentBuilder.() -> Unit
+                                      ): PluginCreationResult<IdePlugin> {
+    val pluginFile = buildZipFile(temporaryFolder.newFile(pluginJarName).toPath(), pluginContentBuilder)
+    return pluginManagerProvider().createPlugin(pluginFile, validateDescriptor = true, problemResolver = problemResolver)
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
@@ -15,28 +15,20 @@ abstract class BasePluginTest {
   @JvmField
   val temporaryFolder = TemporaryFolder()
 
-  protected fun buildPluginWithResult(
-    problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-    pluginContentBuilder: ContentBuilder.() -> Unit
-  ) = buildPluginWithResult(problemResolver, "plugin.jar", pluginContentBuilder)
-
   protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-                                      pluginJarName: String,
                                       pluginContentBuilder: ContentBuilder.() -> Unit
   ): PluginCreationResult<IdePlugin> =
     buildPluginWithResult(
       problemResolver,
       { IdePluginManager.createManager() },
-      pluginJarName,
       pluginContentBuilder = pluginContentBuilder
     )
 
-  protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-                                      pluginManagerProvider: () -> IdePluginManager,
-                                      pluginJarName: String,
-                                      pluginContentBuilder: ContentBuilder.() -> Unit
+  private fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
+                                    pluginManagerProvider: () -> IdePluginManager,
+                                    pluginContentBuilder: ContentBuilder.() -> Unit
                                       ): PluginCreationResult<IdePlugin> {
-    val pluginFile = buildZipFile(temporaryFolder.newFile(pluginJarName).toPath(), pluginContentBuilder)
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
     return pluginManagerProvider().createPlugin(pluginFile, validateDescriptor = true, problemResolver = problemResolver)
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
@@ -16,19 +16,9 @@ abstract class BasePluginTest {
   val temporaryFolder = TemporaryFolder()
 
   protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-                                      pluginContentBuilder: ContentBuilder.() -> Unit
-  ): PluginCreationResult<IdePlugin> =
-    buildPluginWithResult(
-      problemResolver,
-      { IdePluginManager.createManager() },
-      pluginContentBuilder = pluginContentBuilder
-    )
-
-  private fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
-                                    pluginManagerProvider: () -> IdePluginManager,
-                                    pluginContentBuilder: ContentBuilder.() -> Unit
-                                      ): PluginCreationResult<IdePlugin> {
+                                      pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
-    return pluginManagerProvider().createPlugin(pluginFile, validateDescriptor = true, problemResolver = problemResolver)
+    val ideManager = IdePluginManager.createManager()
+    return ideManager.createPlugin(pluginFile, validateDescriptor = true, problemResolver = problemResolver)
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -55,6 +55,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
       }
     }
     assertTrue(result is PluginCreationSuccess)
+    assertMatchingPluginProblems(result as PluginCreationSuccess)
   }
 
   @Test
@@ -76,6 +77,8 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertTrue(result is PluginCreationSuccess)
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertEquals(1, pluginCreated.warnings.size)
     val reclassifiedPluginProblem = pluginCreated.warnings.first()
     assertEquals(PluginProblem.Level.WARNING, reclassifiedPluginProblem.level)
@@ -102,7 +105,10 @@ class ExistingPluginValidationTest : BasePluginTest() {
       }
     }
     assertTrue(result is PluginCreationSuccess)
+
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertEquals(1, pluginCreated.unacceptableWarnings.size)
     val reclassifiedPluginProblem = pluginCreated.unacceptableWarnings.first()
     assertEquals(PluginProblem.Level.UNACCEPTABLE_WARNING, reclassifiedPluginProblem.level)
@@ -128,13 +134,10 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertTrue(result is PluginCreationSuccess)
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertEquals(0, pluginCreated.warnings.size)
     assertEquals(0, pluginCreated.unacceptableWarnings.size)
-
-    assertTrue(result.plugin is StructurallyValidated)
-    with(result.plugin as StructurallyValidated) {
-      assertEquals(0, problems.size)
-    }
   }
 
   @Test
@@ -157,6 +160,8 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertTrue(result is PluginCreationSuccess)
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertEquals(0, pluginCreated.warnings.size)
     assertEquals(0, pluginCreated.unacceptableWarnings.size)
   }
@@ -192,6 +197,8 @@ class ExistingPluginValidationTest : BasePluginTest() {
       assertEquals(0, warnings.size)
       assertEquals(0, unacceptableWarnings.size)
     }
+
+    assertMatchingPluginProblems(result)
   }
 
   @Test
@@ -217,6 +224,8 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertThat("Plugin Creation Result must succeed", result, instanceOf(PluginCreationSuccess::class.java))
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertEquals(2, pluginCreated.warnings.size)
     val reclassifiedProblems = pluginCreated.warnings
       .filter { ReclassifiedPluginProblem::class.isInstance(it) }
@@ -239,6 +248,8 @@ class ExistingPluginValidationTest : BasePluginTest() {
     val result = buildPluginWithResult(remappingProblemResolver, pluginOf(header))
     assertThat("Plugin Creation Result must succeed", result, instanceOf(PluginCreationSuccess::class.java))
     val pluginCreated = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
+
     assertThat(pluginCreated.warnings, `is`(emptyList()))
   }
 
@@ -407,6 +418,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertThat(result, instanceOf(PluginCreationSuccess::class.java))
     val creationSuccess = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
 
     assertThat(creationSuccess.unacceptableWarnings.size, `is`(0))
     assertThat(creationSuccess.warnings.size, `is`(0))
@@ -446,6 +458,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
     assertThat(result, instanceOf(PluginCreationSuccess::class.java))
     val creationSuccess = result as PluginCreationSuccess
 
+    assertMatchingPluginProblems(result)
     assertThat(creationSuccess.unacceptableWarnings.size, `is`(0))
     // warning about ServiceExtensionPointPreload
     val warnings = creationSuccess.warnings
@@ -485,6 +498,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
     }
     assertThat(result, instanceOf(PluginCreationSuccess::class.java))
     val creationSuccess = result as PluginCreationSuccess
+    assertMatchingPluginProblems(result)
 
     assertThat(creationSuccess.unacceptableWarnings.size, `is`(0))
     assertThat(creationSuccess.warnings.size, `is`(1))
@@ -525,5 +539,15 @@ class ExistingPluginValidationTest : BasePluginTest() {
     val problemLevelMappingManager = levelRemappingFromClassPathJson()
     val levelRemappingDefinitionName = if (isExistingPlugin) EXISTING_PLUGIN_REMAPPING_SET else NEW_PLUGIN_REMAPPING_SET
     return problemLevelMappingManager.newDefaultResolver(levelRemappingDefinitionName)
+  }
+
+  private fun assertMatchingPluginProblems(pluginResult: PluginCreationSuccess<IdePlugin>) {
+    with(pluginResult) {
+      if (plugin is StructurallyValidated) {
+        val plugin = plugin as StructurallyValidated
+        val resultProblems = warnings + unacceptableWarnings
+        assertEquals(resultProblems, plugin.problems)
+      }
+    }
   }
 }


### PR DESCRIPTION
- Fix issue when `PluginCreationSuccess` contains an empty set of problems (due to remappings) and the plugin itself contains the original non-remapped problems.
- When cloning plugin, decide if the provided list of problems should override or append to the list of the plugin that should be cloned.
- Add tests that emulate JetBrains Marketplace setup of plugin problem remapping for existing plugins.

See [MP-6773](https://youtrack.jetbrains.com/issue/MP-6773) Plugin Verifier: Problems in the plugin and problems in the creation result do not match