### PR TITLE
Make `versionSuffix` attribute optional in `product-info.json`

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
@@ -12,7 +12,7 @@ import java.nio.file.Path
 data class ProductInfo(
   @JsonProperty("name") val name: String,
   @JsonProperty("version") val version: String,
-  @JsonProperty("versionSuffix") val versionSuffix: String,
+  @JsonProperty("versionSuffix") val versionSuffix: String?,
   @JsonProperty("buildNumber") val buildNumber: String,
   @JsonProperty("productCode") val productCode: String,
   @JsonProperty("dataDirectoryName") val dataDirectoryName: String,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -208,5 +208,9 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
 
   class ProductInfo {
     var versionSuffix: String? = "EAP"
+
+    fun omitVersionSuffix() {
+      versionSuffix = null
+    }
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -4,14 +4,14 @@ import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
 
-class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
+class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val folderSuffix: String = "") {
   private val ideRoot: Path by lazy {
-    temporaryFolder.newFolder("idea").toPath()
+    temporaryFolder.newFolder("idea$folderSuffix").toPath()
   }
 
-  fun buildIdeaDirectory() = buildDirectory(ideRoot) {
+  fun buildIdeaDirectory(productInfo: ProductInfo.() -> Unit = {}) = buildDirectory(ideRoot) {
     file("build.txt", "IU-242.10180.25")
-    file("product-info.json", productInfoJson())
+    file("product-info.json", productInfoJson(productInfo))
     dir("lib") {
       zip("app-client.jar") {
         dir("META-INF") {
@@ -136,54 +136,62 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
     }
   }
 
-  private fun productInfoJson(): String {
-    return """
-        {
-          "name": "IntelliJ IDEA",
-          "version": "2024.2",
-          "versionSuffix": "EAP",
-          "buildNumber": "242.10180.25",
-          "productCode": "IU",
-          "dataDirectoryName": "IntelliJIdea2024.2",
-          "svgIconPath": "bin/idea.svg",
-          "productVendor": "JetBrains",
-          "launch": [],
-          "bundledPlugins": [],
-          "modules": [],
-          "fileExtensions": [],
-          "layout": [
-            {
-              "name": "intellij.notebooks.ui",
-              "kind": "productModuleV2",
-              "classPath": [
-                "lib/modules/intellij.notebooks.ui.jar"
-              ]
-            },
-            {
-              "name": "intellij.notebooks.visualization",
-              "kind": "productModuleV2",
-              "classPath": [
-                "lib/modules/intellij.notebooks.visualization.jar"
-              ]
-            },
-            {
-              "name": "intellij.java.featuresTrainer",
-              "kind": "moduleV2",
-              "classPath": [
-                "plugins/java/lib/modules/intellij.java.featuresTrainer.jar"
-              ]
-            },
-            {
-              "name": "com.jetbrains.codeWithMe",
-              "kind": "plugin",
-              "classPath": [
-                "plugins/cwm-plugin/lib/cwm-plugin.jar"
-              ]
-            }                      
-          ]
-        } 
+  private fun productInfoJson(init: ProductInfo.() -> Unit = {}) = with(ProductInfo()) {
+    init()
+    """
+      {
+        "name": "IntelliJ IDEA",
+        "version": "2024.2",
+        $versionSuffixJson
+        "buildNumber": "242.10180.25",
+        "productCode": "IU",
+        "dataDirectoryName": "IntelliJIdea2024.2",
+        "svgIconPath": "bin/idea.svg",
+        "productVendor": "JetBrains",
+        "launch": [],
+        "bundledPlugins": [],
+        "modules": [],
+        "fileExtensions": [],
+        "layout": [
+          {
+            "name": "intellij.notebooks.ui",
+            "kind": "productModuleV2",
+            "classPath": [
+              "lib/modules/intellij.notebooks.ui.jar"
+            ]
+          },
+          {
+            "name": "intellij.notebooks.visualization",
+            "kind": "productModuleV2",
+            "classPath": [
+              "lib/modules/intellij.notebooks.visualization.jar"
+            ]
+          },
+          {
+            "name": "intellij.java.featuresTrainer",
+            "kind": "moduleV2",
+            "classPath": [
+              "plugins/java/lib/modules/intellij.java.featuresTrainer.jar"
+            ]
+          },
+          {
+            "name": "com.jetbrains.codeWithMe",
+            "kind": "plugin",
+            "classPath": [
+              "plugins/cwm-plugin/lib/cwm-plugin.jar"
+            ]
+          }                      
+        ]
+      } 
     """.trimIndent()
   }
+
+  private val ProductInfo.versionSuffixJson: String
+    get() = versionSuffix?.let {
+      """
+        "versionSuffix": "$it",
+      """.trimIndent()
+    } ?: ""
 
   private val platformLangPluginXml: String
     get() = """
@@ -197,4 +205,8 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder) {
       <module value="com.intellij.modules.externalSystem"/>
     </idea-plugin>        
     """.trimIndent()
+
+  class ProductInfo {
+    var versionSuffix: String? = "EAP"
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -7,7 +7,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
-import java.time.LocalDate
 
 class ProductInfoBasedIdeManagerTest {
 
@@ -26,7 +25,40 @@ class ProductInfoBasedIdeManagerTest {
   fun `create IDE manager from mock IDE`() {
     val ideManager = ProductInfoBasedIdeManager()
     val ide = ideManager.createIde(ideRoot)
+    assertIdeAndPluginsIsCreated(ide)
+  }
 
+  @Test
+  fun `create nonIDEA IDE manager from mock IDE`() {
+    val ideManager = ProductInfoBasedIdeManager()
+    val ideRoot = MockRiderBuilder(temporaryFolder).buildIdeaDirectory()
+    val ide = ideManager.createIde(ideRoot)
+
+    val ideCore = ide.getPluginById("com.intellij")
+    assertNotNull(ideCore)
+    with(ideCore!!) {
+      with(definedModules) {
+        assertEquals(1, size)
+        assertEquals("com.intellij.modules.rider", definedModules.first())
+      }
+    }
+    val riderModule = ide.getPluginByModule("com.intellij.modules.rider")
+    assertNotNull(riderModule)
+    riderModule!!
+    assertTrue(ideCore.pluginId == riderModule.pluginId)
+  }
+
+  @Test
+  fun `create IDE manager with missing version suffix`() {
+    val ideManager = ProductInfoBasedIdeManager()
+    val ideRoot = MockIdeBuilder(temporaryFolder, "-missing-version-suffix").buildIdeaDirectory {
+      omitVersionSuffix()
+    }
+    val ide = ideManager.createIde(ideRoot)
+    assertIdeAndPluginsIsCreated(ide)
+  }
+
+  private fun assertIdeAndPluginsIsCreated(ide: Ide) {
     assertEquals(5, ide.bundledPlugins.size)
     val uiPlugin = ide.getPluginById("intellij.notebooks.ui")
     assertNotNull(uiPlugin)
@@ -67,27 +99,7 @@ class ProductInfoBasedIdeManagerTest {
     with(codeWithMe!!) {
       assertNotNull(productDescriptor)
       val productDescriptor = productDescriptor!!
-      assertEquals(LocalDate.of(4000, 1, 1), productDescriptor.releaseDate)
+      assertEquals(java.time.LocalDate.of(4000, 1, 1), productDescriptor.releaseDate)
     }
-  }
-
-  @Test
-  fun `create nonIDEA IDE manager from mock IDE`() {
-    val ideManager = ProductInfoBasedIdeManager()
-    val ideRoot = MockRiderBuilder(temporaryFolder).buildIdeaDirectory()
-    val ide = ideManager.createIde(ideRoot)
-
-    val ideCore = ide.getPluginById("com.intellij")
-    assertNotNull(ideCore)
-    with(ideCore!!) {
-      with(definedModules) {
-        assertEquals(1, size)
-        assertEquals("com.intellij.modules.rider", definedModules.first())
-      }
-    }
-    val riderModule = ide.getPluginByModule("com.intellij.modules.rider")
-    assertNotNull(riderModule)
-    riderModule!!
-    assertTrue(ideCore.pluginId == riderModule.pluginId)
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.nio.file.Path
+import java.time.LocalDate
 
 class ProductInfoBasedIdeManagerTest {
 
@@ -99,7 +100,7 @@ class ProductInfoBasedIdeManagerTest {
     with(codeWithMe!!) {
       assertNotNull(productDescriptor)
       val productDescriptor = productDescriptor!!
-      assertEquals(java.time.LocalDate.of(4000, 1, 1), productDescriptor.releaseDate)
+      assertEquals(LocalDate.of(4000, 1, 1), productDescriptor.releaseDate)
     }
   }
 }


### PR DESCRIPTION
- Make `versionSuffix` attribute is optional in `product-info.json`.
- Improve unit test infrastructure to support configurable mock Product Info variants.

See [MP-6774](https://youtrack.jetbrains.com/issue/MP-6774) Plugin Verifier: NPE on versionSuffix in Product Info JSON