### PR TITLE
Verify that `com.intellij.languageBundle` EP is internal and must be used by JetBrains only

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -30,6 +30,7 @@ import com.jetbrains.plugin.structure.intellij.beans.ProductDescriptorBean
 import com.jetbrains.plugin.structure.intellij.extractor.PluginBeanExtractor
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.verifiers.LanguageBundleExtensionPointVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginUntilBuildVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
@@ -682,6 +683,7 @@ internal class PluginCreator private constructor(
 
     ServiceExtensionPointPreloadVerifier().verify(plugin, ::registerProblem)
     StatusBarWidgetFactoryExtensionPointVerifier().verify(plugin, ::registerProblem)
+    LanguageBundleExtensionPointVerifier().verify(plugin, ::registerProblem)
   }
 
   private fun resolveDocumentAndValidateBean(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
@@ -63,7 +63,7 @@ class LanguageBundleExtensionPointIsInternal : PluginProblem() {
     get() = Level.UNACCEPTABLE_WARNING
 
   override val message
-    get() = "The extension point in the <${extensionPointName}> element is internal " +
+    get() = "The extension point in the <${extensionPointName}> element is marked with @ApiStatus.Internal " +
       "and must be used by JetBrains only."
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.plugin.structure.intellij.problems
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 
@@ -55,6 +55,18 @@ class StatusBarWidgetFactoryExtensionPointIdMissing(private val implementationCl
     get() = "The extension point in the <${extensionPointName}> element must have 'id' attribute set with the same " +
             "value returned from the getId() method of the $implementationClassFqn implementation."
 }
+
+class LanguageBundleExtensionPointIsInternal : PluginProblem() {
+  private val extensionPointName = "com.intellij.languageBundle"
+
+  override val level
+    get() = Level.UNACCEPTABLE_WARNING
+
+  override val message
+    get() = "The extension point in the <${extensionPointName}> element is internal " +
+      "and must be used by JetBrains only."
+}
+
 
 class NoDependencies(descriptorPath: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ExtensionPointVerifiers.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ExtensionPointVerifiers.kt
@@ -3,6 +3,8 @@ package com.jetbrains.plugin.structure.intellij.verifiers
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor.ServiceDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.PluginVendors.isDevelopedByJetBrains
+import com.jetbrains.plugin.structure.intellij.problems.LanguageBundleExtensionPointIsInternal
 import com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported
 import com.jetbrains.plugin.structure.intellij.problems.StatusBarWidgetFactoryExtensionPointIdMissing
 
@@ -43,6 +45,22 @@ class StatusBarWidgetFactoryExtensionPointVerifier {
       val extensionId = it.getAttribute("id")
       if (extensionId == null) {
         problemRegistrar.registerProblem(StatusBarWidgetFactoryExtensionPointIdMissing(implementation))
+      }
+    }
+  }
+}
+
+/**
+ * Rule: EP `com.intellij.languageBundle` is internal and must be used by JetBrains only.
+ */
+class LanguageBundleExtensionPointVerifier {
+  private val extensionPointName = "com.intellij.languageBundle"
+
+  fun verify(plugin: IdePlugin, problemRegistrar: ProblemRegistrar) {
+    if (!isDevelopedByJetBrains(plugin)) {
+      val languageBundles = plugin.extensions[extensionPointName] ?: emptyList()
+      if (languageBundles.isNotEmpty()) {
+        problemRegistrar.registerProblem(LanguageBundleExtensionPointIsInternal())
       }
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/BaseExtensionPointTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/BaseExtensionPointTest.kt
@@ -1,0 +1,22 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.mocks.SimpleProblemRegistrar
+import org.junit.Before
+
+internal const val PLUGIN_ID = "com.example.thirdparty"
+internal const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
+internal const val JETBRAINS_PLUGIN_VENDOR = "JetBrains"
+
+abstract class BaseExtensionPointTest<V : Any>(val verifier: V) {
+
+  protected val problemRegistrar = SimpleProblemRegistrar()
+
+  protected val problems: List<PluginProblem>
+    get() = problemRegistrar.problems
+
+  @Before
+  fun setUp() {
+    problemRegistrar.reset()
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
@@ -1,32 +1,13 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.mocks.MockExtension
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 
-private const val PLUGIN_ID = "com.example.thirdparty"
-private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
-private const val JETBRAINS_PLUGIN_VENDOR = "JetBrains"
 private const val MESSAGE_TEMPLATE = "The extension point in the <com.intellij.languageBundle> element is internal and must be used by JetBrains only."
 
-
-class LanguageBundleEpVerifierTest {
-  private lateinit var verifier: LanguageBundleExtensionPointVerifier
-
-  private lateinit var problems: MutableList<PluginProblem>
-
-  private val problemRegistrar = ProblemRegistrar {
-    problems += it
-  }
-
-  @Before
-  fun setUp() {
-    verifier = LanguageBundleExtensionPointVerifier()
-    problems = mutableListOf()
-  }
+class LanguageBundleEpVerifierTest : BaseExtensionPointTest<LanguageBundleExtensionPointVerifier>(LanguageBundleExtensionPointVerifier()) {
 
   @Test
   fun `plugin is not allowed to use languageBundle EP`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
@@ -1,0 +1,58 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.mocks.MockExtension
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+private const val PLUGIN_ID = "com.example.thirdparty"
+private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
+private const val JETBRAINS_PLUGIN_VENDOR = "JetBrains"
+private const val MESSAGE_TEMPLATE = "The extension point in the <com.intellij.languageBundle> element is internal and must be used by JetBrains only."
+
+
+class LanguageBundleEpVerifierTest {
+  private lateinit var verifier: LanguageBundleExtensionPointVerifier
+
+  private lateinit var problems: MutableList<PluginProblem>
+
+  private val problemRegistrar = ProblemRegistrar {
+    problems += it
+  }
+
+  @Before
+  fun setUp() {
+    verifier = LanguageBundleExtensionPointVerifier()
+    problems = mutableListOf()
+  }
+
+  @Test
+  fun `plugin is not allowed to use languageBundle EP`() {
+    val extension = MockExtension.from("languageBundle", "locale" to "en-US")
+
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = PLUGIN_VENDOR
+      extension.apply(this)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    assertEquals(1, problems.size)
+    val problem = problems[0]
+    assertEquals(MESSAGE_TEMPLATE, problem.message)
+  }
+
+  @Test
+  fun `JetBrains plugin is allowed to use languageBundle EP`() {
+    val extension = MockExtension.from("languageBundle", "locale" to "en-US")
+
+    val idePlugin = IdePluginImpl().apply {
+      pluginId = PLUGIN_ID
+      vendor = JETBRAINS_PLUGIN_VENDOR
+      extension.apply(this)
+    }
+    verifier.verify(idePlugin, problemRegistrar)
+    assertEquals(0, problems.size)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
@@ -5,7 +5,7 @@ import com.jetbrains.plugin.structure.mocks.MockExtension
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-private const val MESSAGE_TEMPLATE = "The extension point in the <com.intellij.languageBundle> element is internal and must be used by JetBrains only."
+private const val MESSAGE_TEMPLATE = "The extension point in the <com.intellij.languageBundle> element is marked with @ApiStatus.Internal and must be used by JetBrains only."
 
 class LanguageBundleEpVerifierTest : BaseExtensionPointTest<LanguageBundleExtensionPointVerifier>(LanguageBundleExtensionPointVerifier()) {
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LanguageBundleEpVerifierTest.kt
@@ -11,7 +11,7 @@ class LanguageBundleEpVerifierTest : BaseExtensionPointTest<LanguageBundleExtens
 
   @Test
   fun `plugin is not allowed to use languageBundle EP`() {
-    val extension = MockExtension.from("languageBundle", "locale" to "en-US")
+    val extension = MockExtension.from("com.intellij.languageBundle", "locale" to "en-US")
 
     val idePlugin = IdePluginImpl().apply {
       pluginId = PLUGIN_ID
@@ -26,7 +26,7 @@ class LanguageBundleEpVerifierTest : BaseExtensionPointTest<LanguageBundleExtens
 
   @Test
   fun `JetBrains plugin is allowed to use languageBundle EP`() {
-    val extension = MockExtension.from("languageBundle", "locale" to "en-US")
+    val extension = MockExtension.from("com.intellij.languageBundle", "locale" to "en-US")
 
     val idePlugin = IdePluginImpl().apply {
       pluginId = PLUGIN_ID

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/ServiceExtensionPointPreloadVerifierTest.kt
@@ -1,34 +1,17 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor.*
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import org.junit.Assert
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 
 
-private const val PLUGIN_ID = "com.example.thirdparty"
-private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
 private const val MESSAGE_TEMPLATE = "Service preloading is deprecated in the <%s> element. Remove the 'preload' " +
   "attribute and migrate to listeners, see https://plugins.jetbrains.com/docs/intellij/plugin-listeners.html."
 
-class ServiceExtensionPointPreloadVerifierTest {
-  private lateinit var verifier: ServiceExtensionPointPreloadVerifier
-
-  private lateinit var problems: MutableList<PluginProblem>
-
-  private val problemRegistrar = ProblemRegistrar {
-    problems += it
-  }
-
-  @Before
-  fun setUp() {
-    verifier = ServiceExtensionPointPreloadVerifier()
-    problems = mutableListOf()
-  }
-
+class ServiceExtensionPointPreloadVerifierTest :
+  BaseExtensionPointTest<ServiceExtensionPointPreloadVerifier>(ServiceExtensionPointPreloadVerifier()) {
 
   @Test
   fun `has a single project service that is preloaded`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/StatusBarWidgetFactoryExtensionPointVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/StatusBarWidgetFactoryExtensionPointVerifierTest.kt
@@ -1,35 +1,18 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import org.jdom2.Element
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
-private const val PLUGIN_ID = "com.example.thirdparty"
-private const val PLUGIN_VENDOR = "PluginIndustries s.r.o."
 private const val EP_IMPLEMENTATION = "com.example.MyStatusBarWidgetFactory"
 
 private const val MESSAGE_TEMPLATE = "The extension point in the <com.intellij.statusBarWidgetFactory> element must have " +
   "'id' attribute set with the same value returned from the getId() method of the $EP_IMPLEMENTATION implementation."
 
 
-class StatusBarWidgetFactoryExtensionPointVerifierTest {
-  private lateinit var verifier: StatusBarWidgetFactoryExtensionPointVerifier
-
-  private lateinit var problems: MutableList<PluginProblem>
-
-  private val problemRegistrar = ProblemRegistrar {
-    problems += it
-  }
-
-  @Before
-  fun setUp() {
-    verifier = StatusBarWidgetFactoryExtensionPointVerifier()
-    problems = mutableListOf()
-  }
-
+class StatusBarWidgetFactoryExtensionPointVerifierTest :
+  BaseExtensionPointTest<StatusBarWidgetFactoryExtensionPointVerifier>(StatusBarWidgetFactoryExtensionPointVerifier()) {
 
   @Test
   fun `status bar widget factory extension does not declare ID`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/Extensions.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/Extensions.kt
@@ -1,0 +1,22 @@
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import org.jdom2.Element
+
+class MockExtension(private val fullyQualifiedName: String, private val elements: List<Element>) {
+  fun apply(plugin: IdePluginImpl) {
+    plugin.extensions[fullyQualifiedName] = elements.toMutableList()
+  }
+
+  companion object {
+    fun from(extensionLocalName: String, vararg attributes: Pair<String, String>): MockExtension {
+      val extensionFqn = "com.intellij.$extensionLocalName"
+      val element = Element(extensionFqn).apply {
+        for ((attrName, attrValue) in attributes) {
+          setAttribute(attrName, attrValue)
+        }
+      }
+      return MockExtension(extensionFqn, listOf(element))
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/Extensions.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/Extensions.kt
@@ -9,14 +9,13 @@ class MockExtension(private val fullyQualifiedName: String, private val elements
   }
 
   companion object {
-    fun from(extensionLocalName: String, vararg attributes: Pair<String, String>): MockExtension {
-      val extensionFqn = "com.intellij.$extensionLocalName"
-      val element = Element(extensionFqn).apply {
+    fun from(fullyQualifiedName: String, vararg attributes: Pair<String, String>): MockExtension {
+      val element = Element(fullyQualifiedName).apply {
         for ((attrName, attrValue) in attributes) {
           setAttribute(attrName, attrValue)
         }
       }
-      return MockExtension(extensionFqn, listOf(element))
+      return MockExtension(fullyQualifiedName, listOf(element))
     }
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimpleProblemRegistrar.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimpleProblemRegistrar.kt
@@ -1,0 +1,19 @@
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.verifiers.ProblemRegistrar
+
+class SimpleProblemRegistrar : ProblemRegistrar {
+  private val _problems = mutableListOf<PluginProblem>()
+
+  val problems: List<PluginProblem>
+    get() = _problems
+
+  override fun registerProblem(problem: PluginProblem) {
+    _problems += problem
+  }
+
+  fun reset() {
+    _problems.clear()
+  }
+}


### PR DESCRIPTION
As per docs, 

> com.intellij.languageBundle EP is internal and must be used by JetBrains only.

- Add a verifier for this verification rule.
- Add a new problem with _unacceptable warning_ severity.
- Consolidate common behaviours in the unit tests into a parent class.

See [MP-6788](https://youtrack.jetbrains.com/issue/MP-6788) 