### PR TITLE
Disable Kotlin `internal` modifier usage check

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/PluginVerificationContext.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/verifiers/PluginVerificationContext.kt
@@ -24,7 +24,6 @@ import com.jetbrains.pluginverifier.usages.experimental.ExperimentalApiUsageProc
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsageRegistrar
-import com.jetbrains.pluginverifier.usages.internal.kotlin.KtInternalModifierUsageProcessor
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginApiCompatibilityIssueAnalyzer
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.javaPlugin.JavaPluginApiUsageRegistrar
@@ -67,7 +66,6 @@ data class PluginVerificationContext(
       ExperimentalApiUsageProcessor(this),
       DiscouragingClassUsageProcessor(this),
       InternalApiUsageProcessor(this),
-      KtInternalModifierUsageProcessor(this),
       OverrideOnlyMethodUsageProcessor(this),
       JavaPluginApiUsageProcessor(this),
       PropertyUsageProcessor()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
@@ -127,10 +127,9 @@ class KotlinInternalModifierUsageTest {
     val plugin = prepareUsage(pluginSpec) { usageClassUdt }
 
     verify(ide, plugin).run {
-      assertEquals(1, size)
+      assertEquals(0, size)
       with(filterIsInstance<KtInternalClassUsage>()) {
-        assertEquals(1, size)
-        assertEquals(getInternalClassUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
+        assertEquals(0, size)
       }
     }
   }
@@ -173,15 +172,13 @@ class KotlinInternalModifierUsageTest {
     val plugin = prepareUsage(pluginSpec) { usageClassUdt }
 
     verify(ide, plugin).run {
-      assertEquals(2, size)
+      assertEquals(0, size)
       with(filterIsInstance<KtInternalClassUsage>()) {
-        assertEquals(1, size)
-        assertEquals(getInternalClassUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
+        assertEquals(0, size)
       }
 
       with(filterIsInstance<KtInternalMethodUsage>()) {
-        assertEquals(1, size)
-        assertEquals(getInternalMethodUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
+        assertEquals(0, size)
       }
     }
   }
@@ -223,8 +220,7 @@ class KotlinInternalModifierUsageTest {
     }
     verify(ide, idePlugin).run {
       with(filterIsInstance<KtInternalFieldUsage>()) {
-        assertEquals(1, size)
-        assertEquals(getInternalFieldUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
+        assertEquals(0, size)
       }
     }
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
@@ -44,6 +44,7 @@ import net.bytebuddy.jar.asm.MethodVisitor
 import net.bytebuddy.matcher.ElementMatchers.named
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -90,6 +91,7 @@ class KotlinInternalModifierUsageTest {
   private val pluginSpec = IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o.")
 
   @Test
+  @Ignore
   fun `JetBrains plugin class calls a public method in an internal class `() {
 
     val internalApiServiceClassName = generateInternalApiServiceClassName()
@@ -127,14 +129,16 @@ class KotlinInternalModifierUsageTest {
     val plugin = prepareUsage(pluginSpec) { usageClassUdt }
 
     verify(ide, plugin).run {
-      assertEquals(0, size)
+      assertEquals(1, size)
       with(filterIsInstance<KtInternalClassUsage>()) {
-        assertEquals(0, size)
+        assertEquals(1, size)
+        assertEquals(getInternalClassUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
       }
     }
   }
 
   @Test
+  @Ignore
   fun `JetBrains plugin class uses an internal class and an internal method name`() {
     val internalApiServiceClassName = generateInternalApiServiceClassName()
 
@@ -172,18 +176,21 @@ class KotlinInternalModifierUsageTest {
     val plugin = prepareUsage(pluginSpec) { usageClassUdt }
 
     verify(ide, plugin).run {
-      assertEquals(0, size)
+      assertEquals(2, size)
       with(filterIsInstance<KtInternalClassUsage>()) {
-        assertEquals(0, size)
+        assertEquals(1, size)
+        assertEquals(getInternalClassUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
       }
 
       with(filterIsInstance<KtInternalMethodUsage>()) {
-        assertEquals(0, size)
+        assertEquals(1, size)
+        assertEquals(getInternalMethodUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
       }
     }
   }
 
   @Test
+  @Ignore
   fun `internal field access is reported as an internal Kotlin API usage`() {
     val internalFieldName = "internalField"
     val internalFieldValue = 17
@@ -220,7 +227,8 @@ class KotlinInternalModifierUsageTest {
     }
     verify(ide, idePlugin).run {
       with(filterIsInstance<KtInternalFieldUsage>()) {
-        assertEquals(0, size)
+        assertEquals(1, size)
+        assertEquals(getInternalFieldUsageMsg(usageClassName, internalApiServiceClassName), this[0].fullDescription)
       }
     }
   }


### PR DESCRIPTION
Disable API usage checks of Kotlin `internal` modifier.

Rationale: The current implementation triggers many false positives, such as [MP-6784](https://youtrack.jetbrains.com/issue/MP-6784). Additional effort is required, with a scope extending beyond the 2024.2 release.