### PR TITLE
Discover plugin classes in `lib/modules` directory

### DIFF
--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
@@ -1,9 +1,7 @@
 package com.jetbrains.plugin.structure.intellij.classes.locator
 
 import com.jetbrains.plugin.structure.base.utils.isDirectory
-import com.jetbrains.plugin.structure.base.utils.isJar
-import com.jetbrains.plugin.structure.base.utils.isZip
-import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.classes.resolvers.buildJarOrZipFileResolvers
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
@@ -23,7 +21,7 @@ class LibModulesDirectoryLocator(
     }
 
     val origin = fileOriginProvider.getFileOrigin(idePlugin, pluginFile)
-    val jarsOrZips = modulesDir.listFiles().filter { file -> file.isJar() || file.isZip() }
+    val jarsOrZips = modulesDir.listJars()
 
     return buildJarOrZipFileResolvers(jarsOrZips, readMode, origin)
   }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
@@ -7,6 +7,11 @@ import com.jetbrains.plugin.structure.classes.resolvers.buildJarOrZipFileResolve
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import java.nio.file.Path
 
+/**
+ * Locates classes from `lib/modules` directory.
+ *
+ * Such classes correspond to V2 plugin modules with module-level libraries packaged into separate JARs.
+ */
 class LibModulesDirectoryLocator(
   private val readMode: Resolver.ReadMode,
   private val fileOriginProvider: FileOriginProvider = LibModulesDirectoryOriginProvider

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/IdePluginClassesFinder.kt
@@ -17,6 +17,7 @@ import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.ClassesDirectoryKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.JarPluginKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.LibDirectoryKey
+import com.jetbrains.plugin.structure.intellij.classes.locator.LibModulesDirectoryKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.LocationKey
 import com.jetbrains.plugin.structure.intellij.extractor.ExtractorResult
 import com.jetbrains.plugin.structure.intellij.extractor.PluginExtractor
@@ -91,7 +92,7 @@ class IdePluginClassesFinder private constructor(
 
   companion object {
 
-    val MAIN_CLASSES_KEYS = listOf(JarPluginKey, ClassesDirectoryKey, LibDirectoryKey)
+    val MAIN_CLASSES_KEYS = listOf(JarPluginKey, ClassesDirectoryKey, LibDirectoryKey, LibModulesDirectoryKey)
 
     fun findPluginClasses(
       idePlugin: IdePlugin,

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -1,0 +1,95 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.intellij.classes.locator.LibModulesDirectoryLocator
+import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.pluginverifier.createPluginResolver
+import com.jetbrains.pluginverifier.tests.mocks.classBytes
+import com.jetbrains.pluginverifier.tests.mocks.descriptor
+import com.jetbrains.pluginverifier.tests.mocks.ideaPlugin
+import net.bytebuddy.ByteBuddy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PluginClasspathTest : BasePluginTest() {
+  private val byteBuddy = ByteBuddy()
+
+  private fun buildPluginInZip(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.zip").toPath(), pluginContentBuilder)
+    val ideManager = IdePluginManager.createManager()
+    return ideManager.createPlugin(pluginFile, validateDescriptor = true)
+  }
+
+  private fun buildPluginInDirectory(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
+    val pluginFile = buildDirectory(temporaryFolder.newFolder("plugin").toPath(), pluginContentBuilder)
+    val ideManager = IdePluginManager.createManager()
+    return ideManager.createPlugin(pluginFile, validateDescriptor = true)
+  }
+
+  @Test
+  fun `classes in plugin JAR and in plugin lib-modules are discovered`() {
+    val pluginId = "pluginverifier"
+    val descriptor = ideaPlugin(pluginId, "Mock Classpath")
+    val result = buildPluginInZip {
+      dir(pluginId) {
+        dir("lib") {
+          zip("plugin.jar") {
+            descriptor(descriptor)
+            classBytes("SomeClass", byteBuddy)
+          }
+          dir("modules") {
+            zip("plugin-module.jar") {
+              classBytes("Module", byteBuddy)
+            }
+          }
+        }
+      }
+    }
+    assertTrue(result is PluginCreationSuccess)
+    val pluginCreated = result as PluginCreationSuccess
+
+    IdePluginClassesFinder.findPluginClasses(pluginCreated.plugin).use { classLocations ->
+      classLocations.createPluginResolver().use {
+        val pluginClasses = it.allClasses
+        assertEquals(2, pluginClasses.size)
+        assertTrue(pluginClasses.containsAll(setOf("SomeClass", "Module")))
+      }
+    }
+  }
+
+  @Test
+  fun `lib-modules directory locator discovers classes`() {
+    val pluginId = "pluginverifier"
+    val descriptor = ideaPlugin(pluginId, "Mock Classpath")
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        zip("plugin.jar") {
+          descriptor(descriptor)
+        }
+        dir("modules") {
+          zip("plugin-module.jar") {
+            classBytes("Module", byteBuddy)
+          }
+        }
+      }
+    }
+
+    assertTrue(result is PluginCreationSuccess)
+    val pluginCreated = result as PluginCreationSuccess
+    val plugin = pluginCreated.plugin
+
+    val locator = LibModulesDirectoryLocator(Resolver.ReadMode.FULL)
+    val classes = locator.findClasses(plugin, plugin.originalFile!!)
+      .flatMap { it.allClasses }
+    assertEquals(1, classes.size)
+    assertEquals("Module", classes.first())
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
@@ -1,0 +1,42 @@
+package com.jetbrains.pluginverifier.tests.mocks
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
+import net.bytebuddy.ByteBuddy
+
+internal fun ideaPlugin(pluginId: String = "someid",
+                       pluginName: String = "someName",
+                       vendor: String = "vendor",
+                       sinceBuild: String = "131.1",
+                       untilBuild: String = "231.1",
+                       description: String = "this description is looooooooooong enough") = """
+    <id>$pluginId</id>
+    <name>$pluginName</name>
+    <version>someVersion</version>
+    ""<vendor email="vendor.com" url="url">$vendor</vendor>""
+    <description>$description</description>
+    <change-notes>these change-notes are looooooooooong enough</change-notes>
+    <idea-version since-build="$sinceBuild" until-build="$untilBuild"/>
+    <depends>com.intellij.modules.platform</depends>
+  """
+
+internal fun ContentBuilder.descriptor(header: String) {
+  dir("META-INF") {
+    file("plugin.xml") {
+      """
+          <idea-plugin>
+            $header
+          </idea-plugin>
+        """
+    }
+  }
+}
+
+internal fun ContentBuilder.classBytes(className: FullyQualifiedClassName, byteBuddy: ByteBuddy) {
+  val dynamicType = byteBuddy
+    .subclass(Object::class.java)
+    .name(className)
+    .make()
+  val simpleName = dynamicType.typeDescription.simpleName
+  file("$simpleName.class", dynamicType.bytes)
+}


### PR DESCRIPTION
When resolving plugin classes in a ZIP or in a directory, discover classes in `lib/modules` JAR as well.

* Add a new `LibModulesDirectoryLocator` that searches for classes in the `lib/modules`
* Plug this locator into `IdeClassesFinder` default list of locators

See [MP-6799](https://youtrack.jetbrains.com/issue/MP-6799).

See also [IntelliJ Platform Gradle Plugin](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/10aa1af4016f710d5a2e2bf8cb4f877a0add3ba0/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt#L89-L96) and its JAR handling in `lib/modules`.