### PR TITLE
IDE Diff Builder: Migrate API usages in the structure library

### DIFF
--- a/ide-diff-builder/src/main/java/org/jetbrains/ide/diff/builder/cli/ApiQualityCheckCommand.kt
+++ b/ide-diff-builder/src/main/java/org/jetbrains/ide/diff/builder/cli/ApiQualityCheckCommand.kt
@@ -24,7 +24,7 @@ import com.jetbrains.pluginverifier.output.teamcity.TeamCityTest
 import com.jetbrains.pluginverifier.results.presentation.JvmDescriptorsPresentation
 import com.jetbrains.pluginverifier.results.presentation.toSimpleJavaClassName
 import com.jetbrains.pluginverifier.usages.deprecated.deprecationInfo
-import com.jetbrains.pluginverifier.usages.experimental.findEffectiveExperimentalAnnotation
+import com.jetbrains.pluginverifier.usages.experimental.resolveExperimentalApiAnnotation
 import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
@@ -418,7 +418,7 @@ class ApiQualityCheckCommand : Command {
     val signature = classFileMember.toSignature()
     val apiEvents = apiMetadata[signature]
 
-    val experimentalMemberAnnotation = classFileMember.findEffectiveExperimentalAnnotation(ideResolver)
+    val experimentalMemberAnnotation = classFileMember.resolveExperimentalApiAnnotation(ideResolver)
     if (experimentalMemberAnnotation != null) {
       if (experimentalMemberAnnotation !is MemberAnnotation.AnnotatedViaContainingClass) {
         val since = apiEvents.filterIsInstance<MarkedExperimentalIn>().map { it.ideVersion }.minOrNull()

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -124,7 +124,7 @@ class AnnotationResolver(val annotation: FullyQualifiedClassName) {
 }
 
 fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver): Boolean =
-  isMemberEffectivelyAnnotatedWith(annotationResolver, classResolver, location = null)
+  isMemberEffectivelyAnnotatedWith(annotationResolver, classResolver, usageLocation = null)
 
-fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver, location: Location?): Boolean =
-  annotationResolver.resolve(this, classResolver, location) != null
+fun ClassFileMember.isMemberEffectivelyAnnotatedWith(annotationResolver: AnnotationResolver, classResolver: Resolver, usageLocation: Location?): Boolean =
+  annotationResolver.resolve(this, classResolver, usageLocation) != null

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
@@ -23,4 +23,8 @@ fun ClassFileMember.isExperimentalApi(classResolver: Resolver, usageLocation: Lo
 fun ClassFileMember.isExperimentalApi(classResolver: Resolver): Boolean =
   isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver, usageLocation = null)
 
+@Suppress("unused")
+fun ClassFileMember.resolveExperimentalApiAnnotation(classResolver: Resolver) =
+  experimentalApiStatusResolver.resolve(this, classResolver, usageLocation = null)
+
 private val experimentalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Experimental")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsage.kt
@@ -19,4 +19,8 @@ abstract class ExperimentalApiUsage : ApiUsage()
 fun ClassFileMember.isExperimentalApi(classResolver: Resolver, usageLocation: Location): Boolean =
   isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver, usageLocation)
 
+@Suppress("unused")
+fun ClassFileMember.isExperimentalApi(classResolver: Resolver): Boolean =
+  isMemberEffectivelyAnnotatedWith(experimentalApiStatusResolver, classResolver, usageLocation = null)
+
 private val experimentalApiStatusResolver = AnnotationResolver("org/jetbrains/annotations/ApiStatus\$Experimental")


### PR DESCRIPTION
In `ide-diff-builder` migrate API usages in the `structure` library to the recent API.