### PR TITLE
Validate 'release-version' for paid plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ This option is used by JetBrains Marketplace by default.
 
     - `ForbiddenPluginIdPrefix`,
     - `TemplateWordInPluginId`,
-    - `TemplateWordInPluginName`
+    - `TemplateWordInPluginName`,
+    - `ReleaseVersionAndPluginVersionMismatch`,
 
     A comma-separated list of plugin problems is allowed, e.g.:
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ProductDescriptor.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ProductDescriptor.kt
@@ -30,6 +30,6 @@ data class ProductDescriptor(
     optional
   )
 
-  @Deprecated("Use version", replaceWith = ReplaceWith("version"))
+  @Deprecated("Use version.value field", replaceWith = ReplaceWith("version.value"))
   val releaseVersion: Int = version.value
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ProductDescriptor.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ProductDescriptor.kt
@@ -1,15 +1,35 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 import java.time.LocalDate
 
 data class ProductDescriptor(
   val code: String,
   val releaseDate: LocalDate,
-  val releaseVersion: Int,
+  val version: ProductReleaseVersion,
   val eap: Boolean,
   val optional: Boolean
-)
+) {
+
+  @Deprecated("Use version", replaceWith = ReplaceWith("ProductDescriptor(code, releaseDate, version, eap, optional)"))
+  constructor(
+    code: String,
+    releaseDate: LocalDate,
+    releaseVersion: Int,
+    eap: Boolean,
+    optional: Boolean
+  ) : this(
+    code,
+    releaseDate,
+    ProductReleaseVersion(releaseVersion),
+    eap,
+    optional
+  )
+
+  @Deprecated("Use version", replaceWith = ReplaceWith("version"))
+  val releaseVersion: Int = version.value
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -226,6 +226,12 @@ class ReleaseVersionAndPluginVersionMismatch(
 ) {
   override val level
     get() = Level.ERROR
+
+  override val hint: ProblemSolutionHint
+    get() = ProblemSolutionHint(
+      "release-version=\"20201\" and <version>2020.1</version>",
+      "https://plugins.jetbrains.com/docs/marketplace/add-required-parameters.html"
+    )
 }
 
 class UnableToFindTheme(descriptorPath: String, themePath: String) : InvalidDescriptorProblem(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.intellij.problems
@@ -7,6 +7,7 @@ package com.jetbrains.plugin.structure.intellij.problems
 import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 
 class PropertyWithDefaultValue(
   descriptorPath: String,
@@ -208,6 +209,20 @@ class ReleaseVersionWrongFormat(
   descriptorPath = descriptorPath,
   detailedMessage = "The <release-version> parameter ($releaseVersion) format is invalid. " +
     "Ensure it is an integer with at least two digits."
+) {
+  override val level
+    get() = Level.ERROR
+}
+
+class ReleaseVersionAndPluginVersionMismatch(
+  descriptorPath: String,
+  releaseVersion: ProductReleaseVersion,
+  pluginVersion: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The <release-version> parameter [$releaseVersion] and the plugin version [$pluginVersion] " +
+    "should have a matching beginning. " +
+    "For example, release version '20201' should match plugin version 2020.1.1"
 ) {
   override val level
     get() = Level.ERROR

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -201,6 +201,18 @@ class ReleaseDateInFuture(descriptorPath: String) : InvalidDescriptorProblem(
     get() = Level.ERROR
 }
 
+class ReleaseVersionWrongFormat(
+  descriptorPath: String,
+  releaseVersion: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The <release-version> parameter ($releaseVersion) format is invalid. " +
+    "Ensure it is an integer with at least two digits."
+) {
+  override val level
+    get() = Level.ERROR
+}
+
 class UnableToFindTheme(descriptorPath: String, themePath: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
   detailedMessage = "The theme description file cannot be found by the path '$themePath'. Ensure the theme description " +

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -9,7 +9,6 @@ import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionEr
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 
 class NoModuleDependencies(descriptorPath: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
@@ -179,20 +178,6 @@ open class NonexistentReleaseInUntilBuild(
   untilBuild: String,
   nonexistentRelease: String = ""
 ) : SuspiciousUntilBuild(untilBuild, "Version '$nonexistentRelease' does not exist")
-
-class SuspiciousReleaseVersion(
-  descriptorPath: String,
-  releaseVersion: ProductReleaseVersion,
-  pluginVersion: String
-) : InvalidDescriptorProblem(
-  descriptorPath = descriptorPath,
-  detailedMessage = "The <release-version> parameter [$releaseVersion] and the plugin version [$pluginVersion] " +
-    "should have a matching beginning. " +
-    "For example, release version '20201' should match plugin version 2020.1.1"
-) {
-  override val level
-    get() = Level.WARNING
-}
 
 class ForbiddenPluginIdPrefix(
   descriptorPath: String,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionEr
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 
 class NoModuleDependencies(descriptorPath: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
@@ -179,6 +180,19 @@ open class NonexistentReleaseInUntilBuild(
   nonexistentRelease: String = ""
 ) : SuspiciousUntilBuild(untilBuild, "Version '$nonexistentRelease' does not exist")
 
+class SuspiciousReleaseVersion(
+  descriptorPath: String,
+  releaseVersion: ProductReleaseVersion,
+  pluginVersion: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The <release-version> parameter [$releaseVersion] and the plugin version [$pluginVersion] " +
+    "should have similar integers at the beginning. " +
+    "For example, release version '20201' should match plugin version 2020.1.1"
+) {
+  override val level
+    get() = Level.WARNING
+}
 
 class ForbiddenPluginIdPrefix(
   descriptorPath: String,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -187,7 +187,7 @@ class SuspiciousReleaseVersion(
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
   detailedMessage = "The <release-version> parameter [$releaseVersion] and the plugin version [$pluginVersion] " +
-    "should have similar integers at the beginning. " +
+    "should have a matching beginning. " +
     "For example, release version '20201' should match plugin version 2020.1.1"
 ) {
   override val level

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -71,6 +71,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
     ReleaseDateWrongFormat::class,
     ReleaseDateInFuture::class,
     ReleaseVersionWrongFormat::class,
+    ReleaseVersionAndPluginVersionMismatch::class,
     UnableToFindTheme::class,
     UnableToReadTheme::class,
     OptionalDependencyDescriptorCycleProblem::class,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -70,6 +70,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
     TooLongPropertyValue::class,
     ReleaseDateWrongFormat::class,
     ReleaseDateInFuture::class,
+    ReleaseVersionWrongFormat::class,
     UnableToFindTheme::class,
     UnableToReadTheme::class,
     OptionalDependencyDescriptorCycleProblem::class,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
@@ -1,0 +1,45 @@
+package com.jetbrains.plugin.structure.intellij.verifiers
+
+import com.jetbrains.plugin.structure.base.problems.NotNumber
+import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat
+import com.jetbrains.plugin.structure.intellij.verifiers.ProductReleaseVersionVerifier.VerificationResult.Invalid
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
+
+class ProductReleaseVersionVerifier {
+  fun verify(plugin: PluginBean, descriptorPath: String, problemRegistrar: ProblemRegistrar): VerificationResult {
+    if (plugin.productDescriptor == null) return VerificationResult.NotApplicable
+
+    val releaseVersionValue = plugin.productDescriptor?.releaseVersion
+    if (releaseVersionValue.isNullOrEmpty()) {
+      return Invalid("Attribute '$RELEASE_VERSION_ATTRIBUTE_NAME' is missing").also {
+        problemRegistrar.registerProblem(PropertyNotSpecified(RELEASE_VERSION_ATTRIBUTE_NAME, descriptorPath))
+      }
+    }
+
+    return try {
+      ProductReleaseVersion.parse(releaseVersionValue).run {
+        if (isSingleDigit) {
+          Invalid("Attribute '$RELEASE_VERSION_ATTRIBUTE_NAME' is must have two or more digits: '$releaseVersionValue'").also {
+            problemRegistrar.registerProblem(ReleaseVersionWrongFormat(descriptorPath, releaseVersionValue))
+          }
+        } else {
+          VerificationResult.Valid(this)
+        }
+      }
+    } catch (e: NumberFormatException) {
+      Invalid("Attribute '$RELEASE_VERSION_ATTRIBUTE_NAME' is not an integer: '$releaseVersionValue'").also {
+        problemRegistrar.registerProblem(NotNumber(RELEASE_VERSION_ATTRIBUTE_NAME, descriptorPath))
+      }
+    }
+  }
+
+  sealed class VerificationResult {
+    data class Valid(val version: ProductReleaseVersion) : VerificationResult()
+    data class Invalid(val message: String) : VerificationResult()
+    object NotApplicable : VerificationResult()
+  }
+}
+
+private const val RELEASE_VERSION_ATTRIBUTE_NAME = "release-version"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
@@ -22,7 +22,7 @@ class ProductReleaseVersionVerifier {
     return try {
       ProductReleaseVersion.parse(releaseVersionValue).run {
         if (isSingleDigit) {
-          Invalid("Attribute '$RELEASE_VERSION_ATTRIBUTE_NAME' is must have two or more digits: '$releaseVersionValue'").also {
+          Invalid("Attribute '$RELEASE_VERSION_ATTRIBUTE_NAME' must have two or more digits: '$releaseVersionValue'").also {
             problemRegistrar.registerProblem(ReleaseVersionWrongFormat(descriptorPath, releaseVersionValue))
           }
         } else {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/ProductReleaseVersionVerifier.kt
@@ -3,8 +3,8 @@ package com.jetbrains.plugin.structure.intellij.verifiers
 import com.jetbrains.plugin.structure.base.problems.NotNumber
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch
 import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat
-import com.jetbrains.plugin.structure.intellij.problems.SuspiciousReleaseVersion
 import com.jetbrains.plugin.structure.intellij.verifiers.ProductReleaseVersionVerifier.VerificationResult.Invalid
 import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 
@@ -53,7 +53,7 @@ class ProductReleaseVersionVerifier {
     val pluginVersion = MajorMinorVersion.parse(plugin) ?: return
     if (!pluginVersion.matches(productReleaseVersion)) {
       problemRegistrar.registerProblem(
-        SuspiciousReleaseVersion(
+        ReleaseVersionAndPluginVersionMismatch(
           descriptorPath,
           productReleaseVersion,
           plugin.pluginVersion

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.plugin.structure.intellij.version
 
 
-private const val RELEASE_VERSION_TAG_NAME = "release-version"
 /**
  * Type-safe `release-version` of paid plugins.
  *

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
@@ -12,10 +12,10 @@ package com.jetbrains.plugin.structure.intellij.version
  */
 data class ProductReleaseVersion(val value: Int) {
   val major: Int
-    get() = if (isSingleDigit) value else value / 10
+    get() = if (isSingleDigit) 0 else value / 10
 
   val minor: Int
-    get() = if (isSingleDigit) 0 else value % 10
+    get() = if (isSingleDigit) value else value % 10
 
   val isSingleDigit: Boolean
     get() = value in 1..9

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersion.kt
@@ -1,0 +1,36 @@
+package com.jetbrains.plugin.structure.intellij.version
+
+
+private const val RELEASE_VERSION_TAG_NAME = "release-version"
+/**
+ * Type-safe `release-version` of paid plugins.
+ *
+ * Relevant docs:
+ * - See
+ * [Plugin Configuration file](https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__product-descriptor)
+ * at IntelliJ Platform Plugin SDK
+ * - [JetBrains Marketplace](https://plugins.jetbrains.com/docs/marketplace/add-required-parameters.html) guidelines
+ */
+data class ProductReleaseVersion(val value: Int) {
+  val major: Int
+    get() = if (isSingleDigit) value else value / 10
+
+  val minor: Int
+    get() = if (isSingleDigit) 0 else value % 10
+
+  val isSingleDigit: Boolean
+    get() = value in 1..9
+
+  override fun toString() = value.toString()
+
+  companion object {
+    fun parse(releaseVersionValue: String): ProductReleaseVersion {
+      return ProductReleaseVersion(releaseVersionValue.parseIntOrThrow())
+    }
+
+    @Throws(NumberFormatException::class)
+    private fun String.parseIntOrThrow() =
+      this.toIntOrNull()
+        ?: throw NumberFormatException("Release version [${this}] must be an integer")
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems-cli-muteable.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems-cli-muteable.json
@@ -13,5 +13,10 @@
     "id": "TemplateWordInPluginName",
     "class": "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName",
     "since": "2024-03-26"
+  },
+  {
+    "id": "ReleaseVersionAndPluginVersionMismatch",
+    "class": "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch",
+    "since": "2024-10-13"
   }
 ]

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -6,7 +6,7 @@
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
-    "com.jetbrains.plugin.structure.intellij.problems.SuspiciousReleaseVersion": "ignore"
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch": "warning"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",
@@ -20,6 +20,7 @@
     "com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported": "warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.ReleaseDateInFuture": "warning"
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseDateInFuture": "warning",
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch": "ignore"
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -5,8 +5,7 @@
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
-    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch": "warning"
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -5,7 +5,8 @@
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning"
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
+    "com.jetbrains.plugin.structure.intellij.problems.SuspiciousReleaseVersion": "ignore"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/plugin-problems.json
@@ -4,7 +4,8 @@
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning"
+    "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersionTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersionTest.kt
@@ -30,11 +30,11 @@ class ProductReleaseVersionTest {
   }
 
   @Test
-  fun `legacy release version`() {
+  fun `if release-version is a single digit, the major is 0 and the minor is value`() {
     with(parse("8")) {
       assertTrue(isSingleDigit)
-      assertEquals(8, major)
-      assertEquals(0, minor)
+      assertEquals(0, major)
+      assertEquals(8, minor)
       assertEquals(8, value)
     }
   }

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersionTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/version/ProductReleaseVersionTest.kt
@@ -1,0 +1,41 @@
+package com.jetbrains.plugin.structure.intellij.version
+
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion.Companion.parse
+import org.junit.Assert.*
+import org.junit.Test
+
+class ProductReleaseVersionTest {
+  @Test
+  fun `release version is handled`() {
+    with(parse("20201")) {
+      assertEquals(2020, major)
+      assertEquals(1, minor)
+      assertEquals(20201, value)
+    }
+
+    with(parse("400")) {
+      assertEquals(40, major)
+      assertEquals(0, minor)
+      assertEquals(400, value)
+    }
+  }
+
+  @Test
+  fun `illegal release version is handled`() {
+    assertThrows(NumberFormatException::class.java) {
+      parse("2020EAP")
+    }.run {
+      assertEquals("Release version [2020EAP] must be an integer", message)
+    }
+  }
+
+  @Test
+  fun `legacy release version`() {
+    with(parse("8")) {
+      assertTrue(isSingleDigit)
+      assertEquals(8, major)
+      assertEquals(0, minor)
+      assertEquals(8, value)
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -34,7 +34,7 @@ private const val HEADER = """
 private const val HEADER_WITHOUT_VERSION = """
       <id>someId</id>
       <name>someName</name>
-      ""<vendor email="vendor.com" url="url">vendor</vendor>""
+      <vendor email="vendor.com" url="url">vendor</vendor>
       <description>this description is looooooooooong enough</description>
       <change-notes>these change-notes are looooooooooong enough</change-notes>
       <idea-version since-build="131.1"/>
@@ -169,7 +169,7 @@ class PluginXmlValidationTest {
   }
 
   @Test
-  fun `paid plugin with a incorrect single-digit release version`() {
+  fun `paid plugin with an incorrect single-digit release version`() {
     val creationResult = buildMalformedPlugin {
       dir("META-INF") {
         file("plugin.xml") {
@@ -215,7 +215,7 @@ class PluginXmlValidationTest {
       val problem = filterIsInstance<SuspiciousReleaseVersion>().singleOrNull()
       assertNotNull(problem)
       problem!!
-      assertEquals("Invalid plugin descriptor 'plugin.xml'. The <release-version> parameter [10] and the plugin version [2.0] should have similar integers at the beginning. For example, release version '20201' should match plugin version 2020.1.1", problem.toString())
+      assertEquals("Invalid plugin descriptor 'plugin.xml'. The <release-version> parameter [10] and the plugin version [2.0] should have a matching beginning. For example, release version '20201' should match plugin version 2020.1.1", problem.toString())
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -11,16 +11,28 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.NoDependencies
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileIsEmpty
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileNotSpecified
+import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat
 import com.jetbrains.plugin.structure.intellij.problems.ServiceExtensionPointPreloadNotSupported
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.time.LocalDate
 
 private const val HEADER = """
       <id>someId</id>
       <name>someName</name>
       <version>someVersion</version>
+      ""<vendor email="vendor.com" url="url">vendor</vendor>""
+      <description>this description is looooooooooong enough</description>
+      <change-notes>these change-notes are looooooooooong enough</change-notes>
+      <idea-version since-build="131.1"/>
+    """
+
+private const val HEADER_WITHOUT_VERSION = """
+      <id>someId</id>
+      <name>someName</name>
       ""<vendor email="vendor.com" url="url">vendor</vendor>""
       <description>this description is looooooooooong enough</description>
       <change-notes>these change-notes are looooooooooong enough</change-notes>
@@ -129,6 +141,58 @@ class PluginXmlValidationTest {
       .singleOrNull()
     assertNotNull("Plugin descriptor plugin.xml does not include any module dependency tags. The plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html", unacceptableWarning)
   }
+
+  @Test
+  fun `paid plugin`() {
+    val pluginCreationSuccess = buildCorrectPlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $HEADER_WITHOUT_VERSION
+              <version>1.1</version>
+              <product-descriptor code="PCODE" release-date="20240813" release-version="10"/>
+              <depends>com.intellij.modules.lang</depends>              
+            </idea-plugin>
+          """
+        }
+      }
+    }
+    val plugin = pluginCreationSuccess.plugin
+    assertNotNull(plugin.productDescriptor)
+    with(plugin.productDescriptor!!) {
+      assertEquals("PCODE", code)
+      assertEquals(LocalDate.of(2024, 8, 13), releaseDate)
+      assertEquals(ProductReleaseVersion(10), version)
+    }
+  }
+
+  @Test
+  fun `paid plugin with a incorrect single-digit release version`() {
+    val creationResult = buildMalformedPlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $HEADER_WITHOUT_VERSION
+              <version>1.1</version>
+              <product-descriptor code="PCODE" release-date="20240813" release-version="1"/>
+              <depends>com.intellij.modules.lang</depends>              
+            </idea-plugin>
+          """
+        }
+      }
+    }
+    with(creationResult.errorsAndWarnings) {
+      assertEquals(1, size)
+      val problem = filterIsInstance<ReleaseVersionWrongFormat>()
+        .singleOrNull()
+      assertNotNull(problem)
+      problem!!
+      assertEquals("Invalid plugin descriptor 'plugin.xml'. The <release-version> parameter (1) format is invalid. Ensure it is an integer with at least two digits.", problem.toString())
+    }
+  }
+
 
   private fun buildMalformedPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationFail<IdePlugin> {
     val pluginCreationResult = buildIdePlugin(pluginContentBuilder)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
@@ -21,7 +21,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
     Assert.assertNotNull(existingPluginLevelRemapping)
     existingPluginLevelRemapping?.let {
       val ignoredProblems = it.findProblemsByLevel(IgnoredLevel)
-      assertThat(ignoredProblems.size, `is`(3))
+      assertThat(ignoredProblems.size, `is`(4))
     }
 
     val newPluginProblemSet = levelRemappings["new-plugin"]

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
@@ -21,7 +21,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
     Assert.assertNotNull(existingPluginLevelRemapping)
     existingPluginLevelRemapping?.let {
       val ignoredProblems = it.findProblemsByLevel(IgnoredLevel)
-      assertThat(ignoredProblems.size, `is`(4))
+      assertThat(ignoredProblems.size, `is`(3))
     }
 
     val newPluginProblemSet = levelRemappings["new-plugin"]

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -1,7 +1,18 @@
 package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.*
+import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
+import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
+import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
+import com.jetbrains.plugin.structure.base.problems.NotBoolean
+import com.jetbrains.plugin.structure.base.problems.NotNumber
+import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
+import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
+import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
+import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.simpleName
@@ -790,7 +801,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
 
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        productDescriptor = """<product-descriptor code="ABC" release-date="20180118" release-version="12" eap="aaaa"/>"""
+        productDescriptor = """<product-descriptor code="ABC" release-date="20180118" release-version="10" eap="aaaa"/>"""
       },
       listOf(
         NotBoolean("eap", "plugin.xml")
@@ -799,7 +810,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
 
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        productDescriptor = """<product-descriptor code="ABC" release-date="20180118" release-version="12" optional="not-bool"/>"""
+        productDescriptor = """<product-descriptor code="ABC" release-date="20180118" release-version="10" optional="not-bool"/>"""
       },
       listOf(
         NotBoolean("optional", "plugin.xml")
@@ -811,7 +822,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
     val releaseDateInFutureString = releaseDateInFuture.format(formatter)
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        productDescriptor = """<product-descriptor code="ABC" release-date="$releaseDateInFutureString" release-version="12"/>"""
+        productDescriptor = """<product-descriptor code="ABC" release-date="$releaseDateInFutureString" release-version="10"/>"""
       },
       listOf(
         ReleaseDateInFuture("plugin.xml")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginXml.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginXml.kt
@@ -37,7 +37,7 @@ val perfectXmlBuilder: PluginXmlBuilder
   get() = PluginXmlBuilder().apply {
     id = "<id>someId</id>"
     name = "<name>someName</name>"
-    version = "<version>someVersion</version>"
+    version = "<version>1</version>"
     vendor = """<vendor email="vendor.com" url="url">vendor</vendor>"""
     description = "<description>this description is looooooooooong enough</description>"
     changeNotes = "<change-notes>these change-notes are looooooooooong enough</change-notes>"

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -26,6 +26,7 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsMultipl
 import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsSingleJarInRoot
 import com.jetbrains.plugin.structure.intellij.problems.UnexpectedPluginZipStructure
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*
 import org.junit.Test
@@ -648,7 +649,7 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
     with(plugin.productDescriptor!!) {
       assertEquals("PABC", code)
       assertEquals(LocalDate.of(2018, 1, 18), releaseDate)
-      assertEquals(20181, version.value )
+      assertEquals(ProductReleaseVersion(10), version)
       assertEquals(true, eap)
       assertEquals(true, optional)
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -4,7 +4,13 @@ import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.classes.resolvers.*
+import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
+import com.jetbrains.plugin.structure.classes.resolvers.DirectoryFileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.JarFileResolver
+import com.jetbrains.plugin.structure.classes.resolvers.JarOrZipFileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.ResolutionResult
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExtensionKey
 import com.jetbrains.plugin.structure.intellij.classes.locator.PluginFileOrigin
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
@@ -14,7 +20,11 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.plugin.PluginXmlUtil.getAllClassesReferencedFromXml
-import com.jetbrains.plugin.structure.intellij.problems.*
+import com.jetbrains.plugin.structure.intellij.problems.DuplicatedDependencyWarning
+import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyDescriptorResolutionProblem
+import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsMultipleFiles
+import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsSingleJarInRoot
+import com.jetbrains.plugin.structure.intellij.problems.UnexpectedPluginZipStructure
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*
@@ -634,11 +644,14 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
     assertTrue(plugin.useIdeClassLoader)
     assertFalse(plugin.isImplementationDetail)
 
-    assertEquals("PABC", plugin.productDescriptor?.code)
-    assertEquals(LocalDate.of(2018, 1, 18), plugin.productDescriptor?.releaseDate)
-    assertEquals(20181, plugin.productDescriptor?.releaseVersion)
-    assertEquals(true, plugin.productDescriptor?.eap)
-    assertEquals(true, plugin.productDescriptor?.optional)
+    assertNotNull(plugin.productDescriptor)
+    with(plugin.productDescriptor!!) {
+      assertEquals("PABC", code)
+      assertEquals(LocalDate.of(2018, 1, 18), releaseDate)
+      assertEquals(20181, version.value )
+      assertEquals(true, eap)
+      assertEquals(true, optional)
+    }
   }
 
   private fun checkIdeCompatibility(plugin: IdePlugin) {

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
     <idea-version since-build="141.1009.5" until-build="141.9999999"/>
 
-    <product-descriptor code="PABC" release-date="20180118" release-version="20181" eap="true" optional="true"/>
+    <product-descriptor code="PABC" release-date="20180118" release-version="10" eap="true" optional="true"/>
 
     <module value="one_module"/>
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
@@ -44,7 +44,7 @@ class DependencyDiscoveryTest {
           append("""
             <product-descriptor 
               code="MOCKPLUGIN" 
-              release-version="10" 
+              release-version="20" 
               release-date="99991212" />
           """.trimIndent())
         }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/plugin/resolution/DependencyDiscoveryTest.kt
@@ -44,7 +44,7 @@ class DependencyDiscoveryTest {
           append("""
             <product-descriptor 
               code="MOCKPLUGIN" 
-              release-version="1" 
+              release-version="10" 
               release-date="99991212" />
           """.trimIndent())
         }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -528,7 +528,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
   @Test
   fun `existing paid plugin has release-version that does not match plugin version but this is filtered`() {
-    val paidIdeaPlugin = paidIdeaPlugin(releaseVersion = 20)
+    val paidIdeaPlugin = paidIdeaPlugin(pluginVersion = "2.1", releaseVersion = 20)
     val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = true)
     val result = buildPluginWithResult(problemResolver) {
       dir("META-INF") {
@@ -559,13 +559,14 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
   private fun ideaPlugin(pluginId: String = "someid",
                          pluginName: String = "someName",
+                         pluginVersion: String = "1",
                          vendor: String = "vendor",
                          sinceBuild: String = "131.1",
                          untilBuild: String = "231.1",
                          description: String = "this description is looooooooooong enough") = """
     <id>$pluginId</id>
     <name>$pluginName</name>
-    <version>1</version>
+    <version>$pluginVersion</version>
     ""<vendor email="vendor.com" url="url">$vendor</vendor>""
     <description>$description</description>
     <change-notes>these change-notes are looooooooooong enough</change-notes>
@@ -575,12 +576,13 @@ class ExistingPluginValidationTest : BasePluginTest() {
 
   private fun paidIdeaPlugin(pluginId: String = "someid",
                          pluginName: String = "someName",
+                         pluginVersion: String = "1",
                          vendor: String = "vendor",
                          sinceBuild: String = "131.1",
                          untilBuild: String = "231.1",
                          description: String = "this description is looooooooooong enough",
                          releaseVersion: Int = 20211) =
-    ideaPlugin(pluginId, pluginName, vendor, sinceBuild, untilBuild, description) +
+    ideaPlugin(pluginId, pluginName, pluginVersion, vendor, sinceBuild, untilBuild, description) +
       """
         <product-descriptor code="PTESTPLUGIN" release-date="20210818" release-version="$releaseVersion"/>
       """.trimIndent()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -489,7 +489,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
           """
           <idea-plugin>
             $header
-            <product-descriptor code="ABC" release-date="$releaseDateInFutureString" release-version="12"/>
+            <product-descriptor code="ABC" release-date="$releaseDateInFutureString" release-version="10"/>
           </idea-plugin>
         """
         }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -526,6 +526,25 @@ class ExistingPluginValidationTest : BasePluginTest() {
     assertMatchingPluginProblems(result as PluginCreationSuccess)
   }
 
+  @Test
+  fun `existing paid plugin has release-version that does not match plugin version but this is filtered`() {
+    val paidIdeaPlugin = paidIdeaPlugin(releaseVersion = 20)
+    val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = true)
+    val result = buildPluginWithResult(problemResolver) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $paidIdeaPlugin
+            </idea-plugin>
+          """
+        }
+      }
+    }
+    assertSuccess(result)
+    assertMatchingPluginProblems(result as PluginCreationSuccess)
+  }
+
   private fun pluginOf(header: String): ContentBuilder.() -> Unit = {
     dir("META-INF") {
       file("plugin.xml") {
@@ -546,7 +565,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
                          description: String = "this description is looooooooooong enough") = """
     <id>$pluginId</id>
     <name>$pluginName</name>
-    <version>someVersion</version>
+    <version>1</version>
     ""<vendor email="vendor.com" url="url">$vendor</vendor>""
     <description>$description</description>
     <change-notes>these change-notes are looooooooooong enough</change-notes>

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -529,7 +529,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
   }
 
   @Test
-  fun `existing paid plugin has release-version that does not match plugin version but this is filtered`() {
+  fun `existing paid plugin has release-version that does not match plugin version and this is an error`() {
     val paidIdeaPlugin = paidIdeaPlugin(pluginVersion = "2.1", releaseVersion = 20)
     val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = true)
     val result = buildPluginWithResult(problemResolver) {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/LevelRemappingTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/LevelRemappingTest.kt
@@ -1,0 +1,36 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.problems.LevelRemappingPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch
+import com.jetbrains.plugin.structure.intellij.problems.ignore
+import com.jetbrains.plugin.structure.intellij.problems.levelRemappingFromClassPathJson
+import com.jetbrains.plugin.structure.intellij.problems.newDefaultResolver
+import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import org.junit.Assert.fail
+import org.junit.Test
+
+class LevelRemappingTest {
+  @Test
+  fun `problem is remapped according to JSON rules and then explicitly ignored`() {
+    val problemLevelMappingManager = levelRemappingFromClassPathJson()
+    val levelRemappingDefinitionName = "existing-plugin"
+    val existingPluginResolver = problemLevelMappingManager.newDefaultResolver(levelRemappingDefinitionName)
+    val ignoringProblemResolver = LevelRemappingPluginCreationResultResolver(existingPluginResolver, ignore<ReleaseVersionAndPluginVersionMismatch>())
+
+    val problems = listOf(
+      ReleaseVersionAndPluginVersionMismatch(PLUGIN_XML, ProductReleaseVersion.parse("10"), "1.0")
+    )
+
+    val remappedProblems = ignoringProblemResolver.classify(IdePluginImpl(), problems)
+    assertEmpty(remappedProblems)
+  }
+
+  private fun assertEmpty(problems: List<PluginProblem>) {
+    if (problems.isNotEmpty()) {
+      fail("No problems were expected, but found ${problems.size}: " + problems.joinToString { it.message })
+    }
+  }
+}


### PR DESCRIPTION
[JetBrains Marketplace Guidelines](https://plugins.jetbrains.com/docs/marketplace/add-required-parameters.html) specify validation rules for `release-version` parameter that are applied on paid plugins.

New Plugin Problems
-------------------

1. `ReleaseVersionWrongFormat` when a `release-version` does not have two digits. This is an _error_ for new plugins and a _warning_ for existing plugins.
2. `ReleaseVersionAndPluginVersionMismatch` when a `release-version` does match the plugin version. This is an _error_ for both new plugins and existing plugins, and a _ignored_ problem for JetBrains plugins.


Technical improvements
----------------------

- Introduce `ProductReleaseVersionVerifier` as a separate class for `product-release` verification
- Introduce type-safe `ProductReleaseVersion` that holds major and minor components of product release number.
- Deprecate`releaseVersion` field in `ProductDescriptor` in favour of type-safe`version`.

Level remapping notes
----------------------
`ReleaseVersionAndPluginVersionMismatch` is at `ERROR` level for both existing and new plugins.
Some plugins were early adopters of the paid plugins feature, but their versions might not meet the current requirements.
Such plugins are explicitly handled on the JetBrains Marketplace side.

Such error can be muted via `-mute` CLI option.

See [MP-6824](https://youtrack.jetbrains.com/issue/MP-6824) Plugin Verifier: Improve validation of `release-version`