### PR TITLE
Upgrade Gradle Shadow plugin and change coordinates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ okhttp = "4.11.0"
 okhttp-loggingInterceptor = "4.11.0"
 retrofit = "2.9.0"
 retrofit-gson = "2.9.0"
-shadow = "8.1.1"
+shadow = "8.3.0"
 slf4j-api = "2.0.7"
 spullara-cliParser = "1.1.6"
 xz = "1.9"
@@ -43,6 +43,6 @@ xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog"}
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }


### PR DESCRIPTION
Gradle Shadow plugin has been migrated to new coordinates. Now it resides at [GradleUp](https://gradleup.com/shadow/) with `com.gradleup.shadow`.

See https://github.com/GradleUp/shadow/releases/tag/8.3.0