### PR TITLE
Handle plugins created from malformed paths in `product-info.json`

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
@@ -9,7 +9,9 @@ internal sealed class PluginWithArtifactPathResult(open val pluginArtifactPath: 
   data class Success(override val pluginArtifactPath: Path, val plugin: IdePlugin) :
     PluginWithArtifactPathResult(pluginArtifactPath)
 
-  data class Failure(override val pluginArtifactPath: Path, val pluginProblems: List<PluginProblem>) : PluginWithArtifactPathResult(pluginArtifactPath)
+  data class Failure(override val pluginArtifactPath: Path, val pluginProblems: List<PluginProblem>) : PluginWithArtifactPathResult(pluginArtifactPath) {
+    constructor(pluginArtifactPath: Path, vararg pluginProblems: PluginProblem) : this(pluginArtifactPath, pluginProblems.toList())
+  }
 
   companion object {
     internal fun logFailures(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -332,6 +332,7 @@ class IdePluginManager private constructor(
 
   override fun createPlugin(pluginFile: Path) = createPlugin(pluginFile, true)
 
+  @Throws(PluginFileNotFoundException::class)
   fun createPlugin(
     pluginFile: Path,
     validateDescriptor: Boolean,
@@ -342,6 +343,7 @@ class IdePluginManager private constructor(
     return pluginCreator.pluginCreationResult
   }
 
+  @Throws(PluginFileNotFoundException::class)
   fun createBundledPlugin(
     pluginFile: Path,
     ideVersion: IdeVersion,
@@ -365,13 +367,14 @@ class IdePluginManager private constructor(
     }.pluginCreationResult
   }
 
+  @Throws(PluginFileNotFoundException::class)
   private fun getPluginCreatorWithResult(
     pluginFile: Path,
     validateDescriptor: Boolean,
     descriptorPath: String,
     problemResolver: PluginCreationResultResolver
   ): PluginCreator {
-    require(pluginFile.exists()) { "Plugin file $pluginFile does not exist" }
+    if (!pluginFile.exists()) { throw PluginFileNotFoundException(pluginFile) }
     val pluginCreator: PluginCreator
     measureTimeMillis {
       if (pluginFile.isZip()) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginFileNotFoundException.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginFileNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import java.nio.file.Path
+
+class PluginFileNotFoundException(val file: Path) : IllegalArgumentException("Plugin file $file is not found or does not exist")

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginFileNotFoundException.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginFileNotFoundException.kt
@@ -2,4 +2,4 @@ package com.jetbrains.plugin.structure.intellij.plugin
 
 import java.nio.file.Path
 
-class PluginFileNotFoundException(val file: Path) : IllegalArgumentException("Plugin file $file is not found or does not exist")
+class PluginFileNotFoundException(val file: Path) : IllegalArgumentException("Plugin file $file not found or does not exist")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -180,7 +180,8 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
             "classPath": [
               "plugins/cwm-plugin/lib/cwm-plugin.jar"
             ]
-          }                      
+          }              
+          $layoutJson                  
         ]
       } 
     """.trimIndent()
@@ -192,6 +193,15 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
         "versionSuffix": "$it",
       """.trimIndent()
     } ?: ""
+
+  private val ProductInfo.layoutJson: String
+    get() {
+      return if (layout.isEmpty()) {
+        layout
+      } else {
+        ", $layout"
+      }
+    }
 
   private val platformLangPluginXml: String
     get() = """
@@ -208,6 +218,8 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
 
   class ProductInfo {
     var versionSuffix: String? = "EAP"
+
+    var layout: String = ""
 
     fun omitVersionSuffix() {
       versionSuffix = null

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -59,6 +59,25 @@ class ProductInfoBasedIdeManagerTest {
     assertIdeAndPluginsIsCreated(ide)
   }
 
+  @Test
+  fun `create IDE manager with nonexistent paths in layout component`() {
+    val ideManager = ProductInfoBasedIdeManager()
+    val ideRoot = MockIdeBuilder(temporaryFolder, "-missing-version-suffix").buildIdeaDirectory {
+      //language=JSON
+      layout = """
+        {
+          "name": "AngularJS",
+          "kind": "plugin",
+          "classPath": [
+            "../../../../../angular-pha3hahghohlu6A.jar"
+          ]
+        }
+      """.trimIndent()
+    }
+    val ide = ideManager.createIde(ideRoot)
+    assertIdeAndPluginsIsCreated(ide)
+  }
+
   private fun assertIdeAndPluginsIsCreated(ide: Ide) {
     assertEquals(5, ide.bundledPlugins.size)
     val uiPlugin = ide.getPluginById("intellij.notebooks.ui")


### PR DESCRIPTION
Handle plugins created from malformed paths in `product-info.json`.

- Create a custom `PluginFileNotFoundException` and throw it instead of generic `IllegalArgumentException` when plugin artifact is not found
- When creating plugins from `product-info.json`, catch `PluginFileNotFoundException` and rewrap to `Failure` in the `ProductInfoBasedIdeManager`
- Improve logging in the `ProductInfoBasedIdeManager` when bundled plugins in the IDE cannot be created

This is a workaround for certain broken IDE releases, which contain nonsensical paths in publicly available SNAPSHOT releases.

See [MP-6920](https://youtrack.jetbrains.com/issue/MP-6920)