### PR TITLE
Missing declaration of compatibility with K2 mode for Kotlin-dependent plugins is a warning

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -130,6 +130,7 @@ class PluginVerifier(
       groupMissingClassesToMissingPackages(context.compatibilityProblems, context.classResolver)
 
       val compatibilityProblems = context.compatibilityProblems + structureProblemsResolver.resolveCompatibilityProblems(context)
+      val compatibilityWarnings = context.compatibilityWarnings + structureProblemsResolver.resolveCompatibilityWarnings(context)
       val (reportProblems, ignoredProblems) = partitionReportAndIgnoredProblems(compatibilityProblems, context)
 
       val (reportedInternalApiUsages, ignoredInternalApiUsages) = partitionReportAndIgnoredInternalApiUsages(context.internalApiUsages, context)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/CompatibilityProblemResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/CompatibilityProblemResolver.kt
@@ -1,7 +1,10 @@
 package com.jetbrains.pluginverifier.results.problems
 
 import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 
 interface CompatibilityProblemResolver {
   fun resolveCompatibilityProblems(context: PluginVerificationContext): List<CompatibilityProblem>
+
+  fun resolveCompatibilityWarnings(context: PluginVerificationContext): List<CompatibilityWarning>
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/KotlinCompatibilityModeProblemResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/KotlinCompatibilityModeProblemResolver.kt
@@ -4,6 +4,7 @@ import com.jetbrains.plugin.structure.intellij.problems.UndeclaredKotlinK2Compat
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationDescriptor.IDE
 import com.jetbrains.pluginverifier.verifiers.PluginVerificationContext
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 
 /**
  Remaps [UndeclaredKotlinK2CompatibilityMode] structure [com.jetbrains.plugin.structure.base.problems.PluginProblem]
@@ -20,22 +21,24 @@ class KotlinCompatibilityModeProblemResolver : CompatibilityProblemResolver {
   private val sinceIdeVersion = IdeVersion.createIdeVersion("242.21829.142")
 
   /**
-   * Remaps any [UndeclaredKotlinK2CompatibilityMode] structure warning to an [UndeclaredKotlinK2CompatibilityModeProblem]
+   * Remaps any [UndeclaredKotlinK2CompatibilityMode] structure warning to an [UndeclaredKotlinK2CompatibilityModeWarning]
    * and removes it from the [plugin verification context][PluginVerificationContext].
    */
-  override fun resolveCompatibilityProblems(context: PluginVerificationContext): List<CompatibilityProblem> {
+  override fun resolveCompatibilityWarnings(context: PluginVerificationContext): List<CompatibilityWarning> {
     if (!context.isSinceSupportedIdeVersion()) return emptyList()
 
     return context.pluginStructureWarnings
       .map { it.problem }
       .filterIsInstance<UndeclaredKotlinK2CompatibilityMode>()
-      .map { UndeclaredKotlinK2CompatibilityModeProblem(it) }
+      .map { UndeclaredKotlinK2CompatibilityModeWarning(it) }
       .apply {
         if (isNotEmpty()) {
           context.pluginStructureWarnings.removeIf { it.problem is UndeclaredKotlinK2CompatibilityMode }
         }
       }
   }
+
+  override fun resolveCompatibilityProblems(context: PluginVerificationContext) = emptyList<CompatibilityProblem>()
 
   private fun PluginVerificationContext.isSinceSupportedIdeVersion(): Boolean {
     if (verificationDescriptor !is IDE) return false

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/KotlinCompatibilityModeProblemResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/KotlinCompatibilityModeProblemResolver.kt
@@ -25,7 +25,10 @@ class KotlinCompatibilityModeProblemResolver : CompatibilityProblemResolver {
    * and removes it from the [plugin verification context][PluginVerificationContext].
    */
   override fun resolveCompatibilityWarnings(context: PluginVerificationContext): List<CompatibilityWarning> {
-    if (!context.isSinceSupportedIdeVersion()) return emptyList()
+    if (!context.isSinceSupportedIdeVersion()) {
+      context.removeUndeclaredKotlinK2CompatibilityModeProblems()
+      return emptyList()
+    }
 
     return context.pluginStructureWarnings
       .map { it.problem }
@@ -33,9 +36,13 @@ class KotlinCompatibilityModeProblemResolver : CompatibilityProblemResolver {
       .map { UndeclaredKotlinK2CompatibilityModeWarning(it) }
       .apply {
         if (isNotEmpty()) {
-          context.pluginStructureWarnings.removeIf { it.problem is UndeclaredKotlinK2CompatibilityMode }
+          context.removeUndeclaredKotlinK2CompatibilityModeProblems()
         }
       }
+  }
+
+  private fun PluginVerificationContext.removeUndeclaredKotlinK2CompatibilityModeProblems() {
+    pluginStructureWarnings.removeIf { it.problem is UndeclaredKotlinK2CompatibilityMode }
   }
 
   override fun resolveCompatibilityProblems(context: PluginVerificationContext) = emptyList<CompatibilityProblem>()

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/UndeclaredKotlinK2CompatibilityModeWarning.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/results/problems/UndeclaredKotlinK2CompatibilityModeWarning.kt
@@ -1,8 +1,9 @@
 package com.jetbrains.pluginverifier.results.problems
 
 import com.jetbrains.plugin.structure.intellij.problems.UndeclaredKotlinK2CompatibilityMode
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 
-data class UndeclaredKotlinK2CompatibilityModeProblem(private val problem: UndeclaredKotlinK2CompatibilityMode) : CompatibilityProblem() {
+data class UndeclaredKotlinK2CompatibilityModeWarning(private val problem: UndeclaredKotlinK2CompatibilityMode) : CompatibilityWarning() {
   override val problemType = "Plugin descriptor problem"
   override val shortDescription = "Plugin does not declare Kotlin plugin mode in the <org.jetbrains.kotlin.supportsKotlinPluginMode> extension. "
   override val fullDescription = "Plugin depends on the Kotlin plugin (org.jetbrains.kotlin) but does not declare " +

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/K2ModeCompatibilityTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/K2ModeCompatibilityTest.kt
@@ -45,8 +45,8 @@ class K2ModeCompatibilityTest : BasePluginTest() {
         assertTrue(first() is UndeclaredKotlinK2CompatibilityModeWarning)
       }
 
-      val structureProblems = verifiedResult.pluginStructureWarnings.map { it.problem }
-      assertNoProblems(structureProblems)
+      val structureWarnings = verifiedResult.pluginStructureWarnings.map { it.problem }
+      assertNoProblems(structureWarnings)
     }
   }
 
@@ -75,8 +75,8 @@ class K2ModeCompatibilityTest : BasePluginTest() {
       val verifiedResult = verificationResult as PluginVerificationResult.Verified
       assertEmpty("Compatibility Problems", verifiedResult.compatibilityProblems)
       assertEmpty("Compatibility Warnings", verifiedResult.compatibilityWarnings)
-      val structureProblems = verifiedResult.pluginStructureWarnings.map { it.problem }
-      with(structureProblems.filterIsInstance<UndeclaredKotlinK2CompatibilityMode>()) {
+      val structureWarnings = verifiedResult.pluginStructureWarnings.map { it.problem }
+      with(structureWarnings.filterIsInstance<UndeclaredKotlinK2CompatibilityMode>()) {
         assertEquals(1, size)
       }
     }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/K2ModeCompatibilityTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/K2ModeCompatibilityTest.kt
@@ -5,7 +5,7 @@ import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.intellij.problems.UndeclaredKotlinK2CompatibilityMode
 import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.results.problems.UndeclaredKotlinK2CompatibilityModeProblem
+import com.jetbrains.pluginverifier.results.problems.UndeclaredKotlinK2CompatibilityModeWarning
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -39,9 +39,10 @@ class K2ModeCompatibilityTest : BasePluginTest() {
       val verificationResult = VerificationRunner().runPluginVerification(ide, plugin)
       assertTrue(verificationResult is PluginVerificationResult.Verified)
       val verifiedResult = verificationResult as PluginVerificationResult.Verified
-      with(verifiedResult.compatibilityProblems) {
+      assertEmpty("Compatibility Problems", verifiedResult.compatibilityProblems)
+      with(verifiedResult.compatibilityWarnings) {
         assertEquals(1, size)
-        assertTrue(first() is UndeclaredKotlinK2CompatibilityModeProblem)
+        assertTrue(first() is UndeclaredKotlinK2CompatibilityModeWarning)
       }
 
       val structureProblems = verifiedResult.pluginStructureWarnings.map { it.problem }
@@ -72,7 +73,8 @@ class K2ModeCompatibilityTest : BasePluginTest() {
       val verificationResult = VerificationRunner().runPluginVerification(ide, plugin)
       assertTrue(verificationResult is PluginVerificationResult.Verified)
       val verifiedResult = verificationResult as PluginVerificationResult.Verified
-      assertEquals(0, verifiedResult.compatibilityProblems.size)
+      assertEmpty("Compatibility Problems", verifiedResult.compatibilityProblems)
+      assertEmpty("Compatibility Warnings", verifiedResult.compatibilityWarnings)
       val structureProblems = verifiedResult.pluginStructureWarnings.map { it.problem }
       with(structureProblems.filterIsInstance<UndeclaredKotlinK2CompatibilityMode>()) {
         assertEquals(1, size)


### PR DESCRIPTION
Treat missing declaration of compatibility with K2 mode for Kotlin-dependent plugins is a warning.

Acording to clarification, the `org.jetbrains.kotlin.supportsKotlinPluginMode` is required to mark a plugin that has been already migrated to the K2 Kotlin Analysis API.

- Rename `UndeclaredKotlinK2CompatibilityModeProblem` to `UndeclaredKotlinK2CompatibilityModeWarning`. Make it inherit from `CompatibilityWarning` instead.
- Support resolution of `CompatibilityWarning`s from `PluginVerificationContext`.
- Migrate implementation from _problems_ to _warnings_ in the `CompatibilityProblemResolver`.

See also a base PR #1150.