### PR TITLE
Remove JetBrains vendor check from `PluginIdVerifier`

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -8,8 +8,6 @@ import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
 
 val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example", "edu.example", "com.intellij", "org.jetbrains")
 
-val JETBRAINS_VENDORS = listOf("JetBrains", "JetBrains s.r.o.")
-
 val PRODUCT_ID_RESTRICTED_WORDS = listOf(
   "aqua", "clion",  "datagrip", "datalore",
   "dataspell", "dotcover", "dotmemory", "dotpeek", "dottrace", "fleet", "goland",
@@ -37,9 +35,6 @@ class PluginIdVerifier {
   }
 
   private fun verifyPrefix(plugin: PluginBean, descriptorPath: String, problemRegistrar: ProblemRegistrar) {
-    if (isDevelopedByJetBrains(plugin)) {
-      return
-    }
     val id = plugin.id
     DEFAULT_ILLEGAL_PREFIXES
       .filter(id::startsWith)
@@ -48,10 +43,6 @@ class PluginIdVerifier {
     id.split('.')
       .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.toLowerCase()) }
       .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, id, idComponent)) }
-  }
-
-  private fun isDevelopedByJetBrains(plugin: PluginBean): Boolean {
-    return JETBRAINS_VENDORS.contains(plugin.vendor?.name)
   }
 
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifierTest.kt
@@ -26,18 +26,6 @@ class PluginIdVerifierTest {
   }
 
   @Test
-  fun `plugin by JetBrains has no issues`() {
-    val comIntellijPlugin = plugin("com.intellij", "JetBrains")
-    val ideaCorePlugin = plugin("IDEA CORE", "JetBrains")
-
-    verifier.verify(comIntellijPlugin, DESCRIPTOR_PATH, problemRegistrar)
-    verifier.verify(ideaCorePlugin, DESCRIPTOR_PATH, problemRegistrar)
-
-    Assert.assertTrue(problems.isEmpty())
-  }
-
-
-  @Test
   fun `plugin by 3rd party is disallowed`() {
     val illegalId = "org.jetbrains"
     val illegalPlugin = plugin(illegalId, "Third Party Inc.")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
@@ -1,8 +1,11 @@
 package com.jetbrains.plugin.structure.mocks
 
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationResultResolver
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.assertEquals
 import java.nio.file.Path
@@ -11,6 +14,10 @@ abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePlugi
     override fun createManager(extractDirectory: Path): IdePluginManager =
         IdePluginManager.createManager(extractDirectory)
 
+    protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFileBuilder: () -> Path): IdePlugin {
+        return buildPluginSuccess(expectedWarnings, ::pluginFactory, pluginFileBuilder)
+    }
+
     protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
         val pluginFile = pluginFileBuilder()
         val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
@@ -18,5 +25,10 @@ abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePlugi
         assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
         assertEquals(pluginFile, plugin.originalFile)
         return plugin
+    }
+
+    protected fun pluginFactory(pluginManager: IdePluginManager, pluginArtifactPath: Path): PluginCreationResult<IdePlugin> {
+        val problemResolver = JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
+        return pluginManager.createPlugin(pluginArtifactPath, validateDescriptor = true, problemResolver = problemResolver)
     }
 }


### PR DESCRIPTION
Remove JetBrains vendor check from `PluginIdVerifier`.

This is a duplicate logic. Any `TemplateWordInPluginId` and `ForbiddenPluginIdPrefix` that are emitted from the `PluginIdVerifier` are already suppresed by the plugin problem remapping mechanism.

Any client library can customize this behaviour by using a proper `PluginCreationResultResolver`. For example, a `JetBrainsPluginCreationResultResolver` can wrap a `LevelRemappingPluginCreationResultResolver`. The latter can explicitly suppres both of these plugin problems.