### PR TITLE
Do not resolve Product Info layout components without actual files in the distribution

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -191,7 +191,7 @@ class ProductInfoBasedIdeManager : IdeManager() {
       val cp = it.getClasspaths().joinToString(", ")
       "Layout component '${it.name}' has some nonexistent 'classPath' elements: '$cp'"
     }
-    LOG.atDebug().log(logMsg)
+    LOG.atWarn().log(logMsg)
   }
 
   private fun Path.containsProductInfoJson(): Boolean = resolve(PRODUCT_INFO_JSON).exists()

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
@@ -24,18 +24,24 @@ internal sealed class PluginWithArtifactPathResult(open val pluginArtifactPath: 
         log.atWarn().log("Following ${failures.size} plugins could not be created: $failedPluginPaths")
         if (log.isDebugEnabled) {
           buildString {
+            append("The following problems were encountered:\n")
             failures
               .filterIsInstance<Failure>()
               .forEach { (pluginArtifactPath, problems, pluginName) ->
                 append("Unable to load")
                 val pluginArtifactRelativePath = idePath.relativize(pluginArtifactPath)
                 if (pluginName != null) {
-                  append(" '$pluginName' from '$pluginArtifactRelativePath")
+                  append(" '$pluginName' from '$pluginArtifactRelativePath'")
                 } else {
-                  append("'$pluginArtifactRelativePath'")
-                }.append(": ")
-                append(problems.joinToString("\n* ", "\n* "))
+                  append(" '$pluginArtifactRelativePath'")
+                }
+                if (problems.isNotEmpty()) {
+                  append(": ")
+                  append(problems.joinToString("\n* ", "\n* "))
+                }
+                append("\n")
               }
+
           }.let { log.debug(it) }
         }
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
@@ -49,7 +49,9 @@ sealed class LayoutComponent(val kind: String) {
 
   data class PluginAlias(
     @JsonProperty("name") override val name: String,
-  ) : LayoutComponent("pluginAlias")
+  ) : LayoutComponent("pluginAlias") {
+    override fun toString(): String = "Plugin alias '$name'"
+  }
 
   data class ModuleV2(
     override val name: String,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -107,6 +107,23 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
               }
             }
           }
+          zip("java-impl.jar") {
+            dir("META-INF") {
+              file("plugin.xml") {
+                """
+                <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+                  <id>com.intellij.java</id>
+                  <version>242.20224.38</version>
+                  <idea-version since-build="242.20224.38" until-build="242.20224.38" />
+                  <name>Java</name>
+                  <xi:include href="intellij.java.duplicates.analysis.xml">
+                    <xi:fallback />
+                  </xi:include>
+                </idea-plugin>                                    
+                """.trimIndent()
+              }
+            }
+          }
         }
       }
       dir("cwm-plugin") {
@@ -180,7 +197,7 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
             "classPath": [
               "plugins/cwm-plugin/lib/cwm-plugin.jar"
             ]
-          }              
+          }      
           $layoutJson                  
         ]
       } 


### PR DESCRIPTION
Some distributions contain `product-info.json` with layout components that do not exist in the filesystem. 

For example, this is the layout entry:

```
    {
      "name": "org.jetbrains.plugins.emojipicker",
      "kind": "plugin",
      "classPath": [
        "plugins/emojipicker/lib/emojipicker.jar"
      ]
    }
```

However,  no `plugins/emojipicker/lib/emojipicker.jar` is available in the Windows distribution, as this plugin is Linux-only.

## Issues

- Platform-wide `ResourceResolver` is pointing to invalid files which will break resource resolution. Especially, when a plugin is XIncluding another descriptor that should be present in such resolver, resolution in a nonexistent JAR file will throw an exception.
- Parsing of such layout elements might lead to nonexistent classpath.

## Solution

- In platform-wide `ResourceResolver`, do not include JAR files that do not exist in the Platform distribution in the filesystem.
- When parsing a layout element, omit it when any of the declared classpaths (`classPath` elements) is not resolved in the Platform distribution in the filesystem.

## See also

See also [MP-6708](https://youtrack.jetbrains.com/issue/MP-6708)
