### PR TITLE
Detect extracted JSON plugin for Platform 2024.3+

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilder.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilder.kt
@@ -4,8 +4,12 @@
 
 package com.jetbrains.plugin.structure.base.utils.contentBuilder
 
-import com.jetbrains.plugin.structure.base.utils.*
-import java.io.File
+import com.jetbrains.plugin.structure.base.utils.createDir
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isFile
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.readBytes
+import com.jetbrains.plugin.structure.base.utils.simpleName
 import java.nio.file.Path
 
 interface ContentBuilder {
@@ -16,6 +20,7 @@ interface ContentBuilder {
   fun file(name: String, localFile: Path)
   fun dir(name: String, localDirectory: Path)
   fun dir(name: String, content: ContentBuilder.() -> Unit)
+  fun dirs(name: String, content: ContentBuilder.() -> Unit)
   fun zip(name: String, content: ContentBuilder.() -> Unit)
 }
 
@@ -43,7 +48,7 @@ fun buildZipFileContent(content: ContentBuilder.() -> Unit): ContentSpec {
   return result
 }
 
-private class ContentBuilderImpl(private val result: ChildrenOwnerSpec) : ContentBuilder {
+class ContentBuilderImpl(private val result: ChildrenOwnerSpec) : ContentBuilder {
   override fun file(name: String) {
     file(name, "")
   }
@@ -67,6 +72,95 @@ private class ContentBuilderImpl(private val result: ChildrenOwnerSpec) : Conten
   override fun dir(name: String, content: ContentBuilder.() -> Unit) {
     val directorySpec = buildDirectoryContent(content)
     addChild(name, directorySpec)
+  }
+
+  override fun dirs(name: String, content: ContentBuilder.() -> Unit) {
+    val pathElements = name.split("/")
+    when (pathElements.size) {
+      0 -> throw IllegalArgumentException("Cannot have empty name")
+      1 -> dir(pathElements.first(), content)
+      else -> {
+        val firstElement = pathElements.first()
+        // /home/jetbrains/data/
+        // first ->home
+        val w = pathElements.drop(1).windowed(2).reversed()
+        val tree = w.mapIndexed { i, (parent, child) ->
+          val childSpec = if (i == 0) {
+            SingleChildSpec(child, buildDirectoryContent(content))
+          } else {
+            SingleChildSpec(child)
+          }
+          val parentSpec = SingleChildSpec(parent, childSpec)
+          parentSpec
+        }
+
+        val tree2 = ArrayList(tree).apply { add(null) }
+        for (index in 0 until tree2.size - 1) {
+          val current = tree2[index] ?: continue
+          val next = tree2[index + 1]
+          if (next != null) {
+            val n = next.copy(child = current)
+            tree2[index + 1] = n
+          } else {
+            if (index + 1 == tree2.size - 1) {
+              /*
+              current.replaceChild(content)?.let {
+                tree2[index] = it
+              }
+
+               */
+            }
+          }
+        }
+        println(tree2)
+        addChild(firstElement, tree2.dropLast(1).last())
+      }
+    }
+  }
+
+  private fun SingleChildSpec.deepestChild(): SingleChildSpec? {
+    var c = this.child
+    var result: SingleChildSpec? = null
+    while (true) {
+      if (c is SingleChildSpec) {
+        result = c
+        c = c.child
+      } else {
+        break
+      }
+    }
+    return result
+  }
+
+  private fun SingleChildSpec.replaceChild(content: ContentBuilder.() -> Unit): SingleChildSpec? {
+    return when (child) {
+      is SingleChildSpec -> {
+        val newChild = child.copy(child = buildDirectoryContent(content))
+        copy(child = newChild)
+      }
+
+      is DirectorySpec -> {
+        copy(child = buildDirectoryContent(content))
+      }
+
+      else -> {
+        null
+      }
+    }
+  }
+
+  private data class SingleChildSpec(val name: String, val child: ContentSpec) : ContentSpec {
+    constructor(name: String) : this(name, DirectorySpec())
+
+    override fun generate(target: Path) {
+      target.createDir()
+      val childFile = target.resolve(name)
+      child.generate(childFile)
+    }
+
+    override fun toString(): String {
+      return "$name/$child"
+    }
   }
 
   override fun dir(name: String, localDirectory: Path) {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/DirectorySpec.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/DirectorySpec.kt
@@ -25,4 +25,14 @@ class DirectorySpec : ChildrenOwnerSpec {
       spec.generate(childFile)
     }
   }
+
+  override fun toString(): String {
+    return children.map { (name, content) ->
+      if (content is DirectorySpec) {
+        "$name: $content"
+      } else {
+        name
+      }
+    }.joinToString(prefix = "[", postfix = "]")
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
@@ -1,0 +1,111 @@
+package com.jetbrains.plugin.structure.base.utils.contentBuilder
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import com.jetbrains.plugin.structure.base.utils.exists
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.streams.toList
+
+class ContentBuilderTest {
+  @Test
+  fun `single directory is properly constructed`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      val resultPath = buildDirectory(rootDir) {
+        dirs("jetbrains") {
+          file("build.txt", "IU-243.12818.78")
+        }
+      }
+      Files.walk(resultPath).use { it.toList() }.run { println(this) }
+      val expectedPath = jimFs.getPath("/jetbrains/build.txt")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directories are properly constructed`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      val resultPath = buildDirectory(rootDir) {
+        dirs("jetbrains/ide/idea") {
+          file("build.txt", "IU-243.12818.78")
+        }
+      }
+      Files.walk(resultPath).use { it.toList() }.run { println(this) }
+      val expectedPath = jimFs.getPath("/jetbrains/ide/idea/build.txt")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directories are properly constructed with deeply nested directories`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      val resultPath = buildDirectory(rootDir) {
+        dirs("jetbrains/products/ide/idea") {
+          file("build.txt", "IU-243.12818.78")
+        }
+      }
+      Files.walk(resultPath).use { it.toList() }.run { println(this) }
+      val expectedPath = jimFs.getPath("/jetbrains/products/ide/idea/build.txt")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directories are properly constructed with 5 layers of nested directories`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      val resultPath = buildDirectory(rootDir) {
+        dirs("dev/jetbrains/products/ide/idea") {
+          file("build.txt", "IU-243.12818.78")
+        }
+      }
+      Files.walk(resultPath).use { it.toList() }.run { println(this) }
+      val expectedPath = jimFs.getPath("/dev/jetbrains/products/ide/idea/build.txt")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directories are properly constructed with single dir`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      buildDirectory(rootDir) {
+        dirs("idea") {
+          dir("lib") {
+            file("idea_rt.jar")
+          }
+        }
+      }
+      val expectedPath = jimFs.getPath("/idea/lib/idea_rt.jar")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directories are properly constructed with deeply nested directories and explicitly nested directory`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      val resultPath = buildDirectory(rootDir) {
+        dirs("idea/lib") {
+          dir("rt") {
+            file("servlet.jar")
+          }
+        }
+      }
+      Files.walk(resultPath).use { it.toList() }.run { println(this) }
+      val expectedPath = jimFs.getPath("/idea/lib/rt/servlet.jar")
+      assertTrue(expectedPath.exists())
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
@@ -27,6 +27,32 @@ class ContentBuilderTest {
   }
 
   @Test
+  fun `single directory with empty content is properly constructed`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      buildDirectory(rootDir) {
+        dirs("jetbrains") { /* empty directory */ }
+      }
+      val expectedPath = jimFs.getPath("/jetbrains")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
+  fun `directory with a subdirectory that contains an empty content is properly constructed`() {
+    Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
+      val rootDir: Path = jimFs.rootDirectories.first()
+
+      buildDirectory(rootDir) {
+        dirs("jetbrains/ide") { /* empty directory */ }
+      }
+      val expectedPath = jimFs.getPath("/jetbrains/ide")
+      assertTrue(expectedPath.exists())
+    }
+  }
+
+  @Test
   fun `directories are properly constructed`() {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/contentBuilder/ContentBuilderTest.kt
@@ -5,9 +5,7 @@ import com.google.common.jimfs.Jimfs
 import com.jetbrains.plugin.structure.base.utils.exists
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.streams.toList
 
 class ContentBuilderTest {
   @Test
@@ -15,12 +13,11 @@ class ContentBuilderTest {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()
 
-      val resultPath = buildDirectory(rootDir) {
+      buildDirectory(rootDir) {
         dirs("jetbrains") {
           file("build.txt", "IU-243.12818.78")
         }
       }
-      Files.walk(resultPath).use { it.toList() }.run { println(this) }
       val expectedPath = jimFs.getPath("/jetbrains/build.txt")
       assertTrue(expectedPath.exists())
     }
@@ -57,12 +54,11 @@ class ContentBuilderTest {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()
 
-      val resultPath = buildDirectory(rootDir) {
+      buildDirectory(rootDir) {
         dirs("jetbrains/ide/idea") {
           file("build.txt", "IU-243.12818.78")
         }
       }
-      Files.walk(resultPath).use { it.toList() }.run { println(this) }
       val expectedPath = jimFs.getPath("/jetbrains/ide/idea/build.txt")
       assertTrue(expectedPath.exists())
     }
@@ -73,12 +69,11 @@ class ContentBuilderTest {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()
 
-      val resultPath = buildDirectory(rootDir) {
+      buildDirectory(rootDir) {
         dirs("jetbrains/products/ide/idea") {
           file("build.txt", "IU-243.12818.78")
         }
       }
-      Files.walk(resultPath).use { it.toList() }.run { println(this) }
       val expectedPath = jimFs.getPath("/jetbrains/products/ide/idea/build.txt")
       assertTrue(expectedPath.exists())
     }
@@ -89,12 +84,11 @@ class ContentBuilderTest {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()
 
-      val resultPath = buildDirectory(rootDir) {
+      buildDirectory(rootDir) {
         dirs("dev/jetbrains/products/ide/idea") {
           file("build.txt", "IU-243.12818.78")
         }
       }
-      Files.walk(resultPath).use { it.toList() }.run { println(this) }
       val expectedPath = jimFs.getPath("/dev/jetbrains/products/ide/idea/build.txt")
       assertTrue(expectedPath.exists())
     }
@@ -122,14 +116,13 @@ class ContentBuilderTest {
     Jimfs.newFileSystem(Configuration.unix()).use { jimFs ->
       val rootDir: Path = jimFs.rootDirectories.first()
 
-      val resultPath = buildDirectory(rootDir) {
+      buildDirectory(rootDir) {
         dirs("idea/lib") {
           dir("rt") {
             file("servlet.jar")
           }
         }
       }
-      Files.walk(resultPath).use { it.toList() }.run { println(this) }
       val expectedPath = jimFs.getPath("/idea/lib/rt/servlet.jar")
       assertTrue(expectedPath.exists())
     }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/results/problems/UndeclaredPluginDependencyProblem.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/results/problems/UndeclaredPluginDependencyProblem.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.results.problems
+
+data class UndeclaredPluginDependencyProblem(
+  val undeclaredPluginId: String,
+  val classOrPackage: ApiElement,
+  val reason: String?
+) : CompatibilityProblem() {
+  override val problemType: String = "Undeclared plugin dependency"
+  override val shortDescription: String =
+    "Plugin '$undeclaredPluginId' not declared as a plugin dependency for $classOrPackage" + reason?.let { ". $it" }
+      .orEmpty()
+  override val fullDescription: String =
+    "Plugin '$undeclaredPluginId' is not declared in the plugin descriptor as a dependency for $classOrPackage" + reason?.let { ". $it" }
+      .orEmpty()
+
+  sealed class ApiElement {
+    data class Class(val className: String) : ApiElement() {
+      override fun toString(): String = "class [$className]"
+    }
+
+    data class Package(val packageName: String) : ApiElement() {
+      override fun toString(): String = "package [$packageName]"
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/CompatibilityProblemChangeList.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/CompatibilityProblemChangeList.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.analysis
+
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+
+class CompatibilityProblemChangeList {
+
+  private val _addedProblems = hashSetOf<CompatibilityProblem>()
+
+  val addedProblems: Set<CompatibilityProblem>
+    get() = _addedProblems
+
+  private val _removedProblems = hashSetOf<CompatibilityProblem>()
+
+  val removedProblems: Set<CompatibilityProblem>
+    get() = _removedProblems
+
+  operator fun plusAssign(problem: CompatibilityProblem) {
+    _addedProblems += problem
+  }
+
+  operator fun minusAssign(problem: CompatibilityProblem) {
+    _removedProblems += problem
+  }
+
+  fun first(): CompatibilityProblem = problems.first()
+
+  val problems: Set<CompatibilityProblem>
+    get() = addedProblems - removedProblems
+
+  val size: Int
+    get() = problems.size
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/ExtractedJsonPluginAnalyzer.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/ExtractedJsonPluginAnalyzer.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.analysis
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.results.problems.ClassNotFoundProblem
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.results.problems.UndeclaredPluginDependencyProblem
+import com.jetbrains.pluginverifier.results.problems.UndeclaredPluginDependencyProblem.ApiElement.Class
+import com.jetbrains.pluginverifier.verifiers.resolution.BinaryClassName
+import com.jetbrains.pluginverifier.verifiers.resolution.toFullyQualifiedClassName
+
+private const val JSON_PLUGIN_ID = "com.intellij.modules.json"
+
+private const val JSON_PLUGIN_EXTRACTED_REASON = "JSON support has been extracted to a separate plugin."
+
+class ExtractedJsonPluginAnalyzer {
+  private val removedPackages = listOf(
+    "com.intellij.json",
+    "com.intellij.json.codeinsight",
+    "com.intellij.json.highlighting",
+    "com.intellij.json.psi",
+    "com.jetbrains.jsonSchema"
+  )
+
+  private val removedClasses = listOf(
+    "com.intellij.json.JsonElementTypes",
+    "com.intellij.json.JsonFileType",
+    "com.intellij.json.JsonLanguage",
+    "com.intellij.json.JsonParserDefinition",
+    "com.intellij.json.JsonTokenType"
+  )
+
+  fun analyze(
+    ide: Ide,
+    plugin: IdePlugin,
+    compatibilityProblems: Collection<CompatibilityProblem>
+  ): CompatibilityProblemChangeList {
+    return if (!supports(ide)) {
+      CompatibilityProblemChangeList()
+    } else {
+      CompatibilityProblemChangeList().also { problems ->
+        compatibilityProblems.filterIsInstance<ClassNotFoundProblem>()
+          .forEach { problem ->
+            val className: BinaryClassName = problem.unresolved.className
+            if (isRemovedClass(className) || isRemovedPackage(className)) {
+              problems += undeclaredPluginDependency(className)
+              problems -= problem
+            }
+          }
+      }
+    }
+  }
+
+  private fun supports(ide: Ide): Boolean =
+    isAtLeastVersion(ide, "243")
+
+  private fun isRemovedClass(className: BinaryClassName): Boolean =
+    removedClasses.contains(className.toFullyQualifiedClassName())
+
+  private fun isRemovedPackage(className: BinaryClassName): Boolean {
+    val pkg = Package.of(className)
+    val removedPkg = getRemovedPackage(pkg)
+    return removedPkg != null
+  }
+
+  private fun getRemovedPackage(pkg: Package): Package? {
+    val removedPackage = removedPackages.firstOrNull { it == pkg.name }
+    return if (removedPackage != null) {
+      Package(removedPackage)
+    } else {
+      pkg.parent.let {
+        if (it == Package.ROOT) {
+          null
+        } else {
+          getRemovedPackage(it)
+        }
+      }
+    }
+  }
+
+  private fun undeclaredPluginDependency(className: BinaryClassName): UndeclaredPluginDependencyProblem {
+    return UndeclaredPluginDependencyProblem(
+      JSON_PLUGIN_ID,
+      Class(className.toFullyQualifiedClassName()),
+      JSON_PLUGIN_EXTRACTED_REASON
+    )
+  }
+
+  private fun isAtLeastVersion(ide: Ide, expectedVersion: String): Boolean {
+    return ide.version > IdeVersion.createIdeVersion(expectedVersion)
+  }
+
+  internal class Package(val name: String) {
+    companion object {
+      val ROOT = Package("")
+
+      fun of(className: BinaryClassName): Package {
+        return Package(className.packageName.toFullyQualifiedClassName())
+      }
+    }
+
+    private val elements: List<String> = name.split(".")
+
+    val parent: Package
+      get() {
+        val parentElements = elements.dropLast(1)
+        return if (parentElements.isEmpty()) {
+          ROOT
+        } else {
+          Package(parentElements.joinToString("."))
+        }
+      }
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (javaClass != other?.javaClass) return false
+
+      other as Package
+
+      return name == other.name
+    }
+
+    override fun hashCode(): Int = name.hashCode()
+  }
+}
+
+private val BinaryClassName.packageName get() = substringBeforeLast('/', "")
+

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/json/JsonParserDefinition.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/com/intellij/json/JsonParserDefinition.java
@@ -1,0 +1,4 @@
+package com.intellij.json;
+
+public class JsonParserDefinition {
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
@@ -12,6 +12,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.tests.bytecode.Dumps.ComIntellijTasks_TaskRepositorySubtype
 import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
 import com.jetbrains.pluginverifier.tests.mocks.PluginSpec
 import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
@@ -242,6 +243,18 @@ abstract class BaseBytecodeTest {
         if (includeKotlinStdLib) {
           findKotlinStdLib().apply {
             file(simpleName, this)
+          }
+        }
+        /* A JAR with at least one file in the `com.intellij` package.
+          This mimics a regular IDE in order to align with unit tests.
+        */
+        zip("app.jar") {
+          dir("com") {
+            dir("intellij") {
+              dir("tasks") {
+                file("Task.class", ComIntellijTasks_TaskRepositorySubtype())
+              }
+            }
           }
         }
       }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
@@ -197,8 +197,17 @@ abstract class BaseBytecodeTest {
     return ide
   }
 
+  /**
+   * Builds an instance of the IDE with specified bundled plugins and.
+   *
+   * @param bundledPlugins List of plugins to include in the `plugins` directory.
+   * @param bundledCorePlugins List of plugins to include in the `lib` directory of the IDE.
+   * @param includeKotlinStdLib whether to include the Kotlin standard library.
+   * @return The created instance of the IDE.
+   */
   internal fun buildIdeWithBundledPlugins(
     bundledPlugins: List<PluginSpec> = emptyList(),
+    bundledCorePlugins: List<PluginSpec> = emptyList(),
     includeKotlinStdLib: Boolean = false,
   ): Ide {
     val ideaDirectory = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
@@ -217,6 +226,9 @@ abstract class BaseBytecodeTest {
                 """.trimIndent()
             }
           }
+        }
+        bundledCorePlugins.forEach { plugin ->
+          plugin.buildJar(this)
         }
         if (includeKotlinStdLib) {
           findKotlinStdLib().apply {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
@@ -1,0 +1,288 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.IdeManager
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
+import com.jetbrains.pluginverifier.verifiers.resolution.BinaryClassName
+import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.jvm.JvmMetadataVersion
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.method.MethodDescription
+import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.Implementation
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size
+import net.bytebuddy.jar.asm.Label
+import net.bytebuddy.jar.asm.MethodVisitor
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.Opcodes.*
+import java.lang.reflect.Modifier
+import java.lang.reflect.Type
+import java.util.*
+
+abstract class BaseBytecodeTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var byteBuddy: ByteBuddy
+
+  @Before
+  fun setUp() {
+    byteBuddy = ByteBuddy()
+  }
+
+  protected fun verify(ide: Ide, idePlugin: IdePlugin): Set<InternalApiUsage> {
+    val apiUsageFilter = InternalApiUsageFilter()
+
+    // Run verification
+    val verificationResult = VerificationRunner().runPluginVerification(
+      ide, idePlugin,
+      apiUsageFilters = listOf(apiUsageFilter)
+    ) as PluginVerificationResult.Verified
+
+    // No warnings should be produced
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(emptySet<CompatibilityWarning>(), verificationResult.compatibilityWarnings)
+    // JetBrains Plugin should not report internal usages. These are in the ignored usages
+    assertEquals(0, verificationResult.internalApiUsages.size)
+    return verificationResult.ignoredInternalApiUsages.keys
+  }
+
+  protected fun assertVerified(spec: VerificationSpec.() -> Unit) =
+    runPluginVerification(spec) as PluginVerificationResult.Verified
+
+  internal fun prepareUsage(
+    pluginSpec: IdeaPluginSpec,
+    dynamicTypeBuilder: () -> DynamicType.Unloaded<*>
+  ): IdePlugin {
+    return buildIdePlugin(pluginSpec) {
+      usageClass(dynamicTypeBuilder())
+    }
+  }
+
+  internal fun prepareUsage(
+    pluginSpec: IdeaPluginSpec,
+    classFileName: String,
+    classFileBinaryContent: ByteArray
+  ): IdePlugin {
+    return buildIdePlugin(pluginSpec) {
+      dir("plugin") {
+        file("$classFileName.class", classFileBinaryContent)
+      }
+    }
+  }
+
+  protected fun prepareIdeWithApi(platformApiClassTypeBuilder: () -> DynamicType.Unloaded<*>): Ide {
+    return buildIdeWithBundledPlugins {
+      dir("com") {
+        dir("intellij") {
+          dir("openapi") {
+            apiClass(platformApiClassTypeBuilder())
+          }
+        }
+      }
+    }
+  }
+
+  private fun ContentBuilder.usageClass(dynamicType: DynamicType.Unloaded<*>) {
+    val className = dynamicType.typeDescription.simpleName
+    dir("usage") {
+      file("$className.class", dynamicType.bytes)
+    }
+  }
+
+  private fun ContentBuilder.apiClass(dynamicType: DynamicType.Unloaded<*>) {
+    val className = dynamicType.typeDescription.simpleName
+    file("$className.class", dynamicType.bytes)
+  }
+
+  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+  private fun load(classDynamicType: DynamicType.Unloaded<Object>, classLoader: ClassLoader): Class<out Any> {
+    return classDynamicType.load(classLoader, ClassLoadingStrategy.Default.WRAPPER).loaded
+  }
+
+  protected fun String.construct() = byteBuddy
+    .subclass(Object::class.java)
+    .name(this)
+
+  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+  protected fun String.constructWithMethod(
+    method: String,
+    returnType: Type,
+    modifier: Int = Modifier.PUBLIC
+  ): DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<Object> {
+    return construct()
+      .defineMethod(method, returnType, modifier)
+  }
+
+  protected fun buildIdeWithBundledPlugins(
+    includeKotlinStdLib: Boolean = false,
+    javaPluginClassesBuilder: (ContentBuilder).() -> Unit
+  ): Ide {
+    val ideaDirectory = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
+      file("build.txt", "IU-192.1")
+      dir("lib") {
+        zip("idea.jar") {
+          dir("META-INF") {
+            file("plugin.xml") {
+              """
+                <idea-plugin>
+                  <id>com.intellij</id>
+                  <name>IDEA CORE</name>
+                  <version>1.0</version>
+                  <module value="com.intellij.modules.all"/>                
+                </idea-plugin>
+                """.trimIndent()
+            }
+          }
+        }
+        if (includeKotlinStdLib) {
+          findKotlinStdLib().apply {
+            file(simpleName, this)
+          }
+        }
+      }
+      dir("plugins") {
+        dir("java") {
+          dir("lib") {
+            zip("java.jar") {
+              dir("META-INF") {
+                file("plugin.xml") {
+                  """
+                    <idea-plugin>
+                      <id>com.intellij.java</id>
+                      <module value="com.intellij.modules.java"/>
+                    </idea-plugin>
+                    """.trimIndent()
+                }
+              }
+
+              //Generate content of Java plugin.
+              javaPluginClassesBuilder()
+            }
+          }
+        }
+      }
+    }
+
+    // Fast assert IDE is fine
+    val ide = IdeManager.createManager().createIde(ideaDirectory)
+    assertEquals("IU-192.1", ide.version.asString())
+
+    val javaPlugin = ide.bundledPlugins.find { it.pluginId == "com.intellij.java" }!!
+    assertEquals("com.intellij.java", javaPlugin.pluginId)
+    assertEquals(setOf("com.intellij.modules.java"), javaPlugin.definedModules)
+
+    return ide
+  }
+
+  private fun buildIdePlugin(
+    ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij", "JetBrains s.r.o."),
+    pluginClassesContentBuilder: (ContentBuilder).() -> Unit
+  ): IdePlugin {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
+      pluginClassesContentBuilder()
+
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              <id>${ideaPluginSpec.id}</id>
+              <name>someName</name>
+              <version>someVersion</version>
+              ""<vendor email="vendor.com" url="url">${ideaPluginSpec.vendor}</vendor>""
+              <description>this description is looooooooooong enough</description>
+              <change-notes>these change-notes are looooooooooong enough</change-notes>
+              <idea-version since-build="131.1"/>
+              <depends>com.intellij.modules.java</depends>
+            </idea-plugin>
+            """.trimIndent()
+        }
+      }
+    }
+
+    return (IdePluginManager.createManager().createPlugin(pluginFile) as PluginCreationSuccess).plugin
+  }
+
+  protected fun kotlinMetadata(configure: KmClass.() -> Unit) = KmClass().apply {
+    configure()
+  }.let {
+    KotlinClassMetadata
+      .Class(it, JvmMetadataVersion.LATEST_STABLE_SUPPORTED, 0)
+      .write()
+  }
+
+  protected fun String.randomize(): String {
+    return buildString {
+      append(this@randomize)
+      append("_")
+      append(UUID.randomUUID().toString().replace("-", ""))
+    }
+  }
+
+  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+  protected fun DynamicType.Unloaded<Object>.newInstance(classLoader: ClassLoader = this::class.java.classLoader) =
+    load(this, classLoader)
+      .getDeclaredConstructor().newInstance()
+
+  /**
+   * Creates a new instance of `callee` and invokes a `fieldName` while assigning a fixed value on this instance.
+   * This occurs within a method of the `caller`.
+   * The field value is hardwired to an integer
+   */
+  protected class DirectFieldAccess(
+    private val caller: BinaryClassName,
+    private val callee: BinaryClassName,
+    private val fieldName: String,
+    private val fieldValue: Int
+  ) : ByteCodeAppender {
+
+    override fun apply(
+      methodVisitor: MethodVisitor,
+      implementationContext: Implementation.Context,
+      instrumentedMethod: MethodDescription
+    ): Size {
+      with(methodVisitor) {
+        val methodBeginning = Label()
+        visitLabel(methodBeginning)
+        visitTypeInsn(NEW, callee)
+        visitInsn(DUP)
+        visitMethodInsn(INVOKESPECIAL, callee, "<init>", "()V", false)
+        visitVarInsn(ASTORE, 1)
+        val instanceScopeBeginning = Label()
+        visitLabel(instanceScopeBeginning)
+        visitVarInsn(ALOAD, 1)
+        visitIntInsn(BIPUSH, fieldValue)
+        visitFieldInsn(PUTFIELD, callee, fieldName, "I")
+        visitIntInsn(BIPUSH, fieldValue)
+        visitInsn(IRETURN)
+        val methodEnd = Label()
+        visitLabel(methodEnd)
+        visitLocalVariable("this", "L$caller;", null, methodBeginning, methodEnd, 0)
+        visitLocalVariable("instance", "L$callee;", null, instanceScopeBeginning, methodEnd, 1)
+      }
+      return Size(2, 2)
+    }
+
+    val implementation: Implementation
+      get() = Implementation.Simple(this)
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
@@ -29,6 +29,7 @@ import net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size
 import net.bytebuddy.jar.asm.Label
 import net.bytebuddy.jar.asm.MethodVisitor
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -36,6 +37,7 @@ import org.objectweb.asm.Opcodes.*
 import java.lang.reflect.Modifier
 import java.lang.reflect.Type
 import java.util.*
+import kotlin.reflect.KClass
 
 abstract class BaseBytecodeTest {
   @Rule
@@ -284,5 +286,28 @@ abstract class BaseBytecodeTest {
 
     val implementation: Implementation
       get() = Implementation.Simple(this)
+  }
+
+  protected fun assertContains(
+    compatibilityProblems: Collection<CompatibilityProblem>,
+    compatibilityProblemClass: KClass<out CompatibilityProblem>,
+    fullDescription: String? = null
+  ) {
+    val problems = compatibilityProblems.filterIsInstance(compatibilityProblemClass.java)
+    if (problems.isEmpty()) {
+      fail("There are no compatibility problems of class [${compatibilityProblemClass.qualifiedName}]")
+      return
+    }
+    if (fullDescription == null) {
+      return
+    }
+    val problemsWithMessage = problems.filter { it.fullDescription == fullDescription }
+    if (problemsWithMessage.isEmpty()) {
+      fail("Compatibility problems has ${problems.size} problem(s) of class [${compatibilityProblemClass.qualifiedName}], " +
+        "but none has a full description '$fullDescription'. " +
+        "Found [" + problems.joinToString { it.fullDescription } + "]"
+      )
+      return
+    }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/CompatibilityProblemChangeListTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/CompatibilityProblemChangeListTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.pluginverifier.analysis.CompatibilityProblemChangeList
+import com.jetbrains.pluginverifier.results.problems.PackageNotFoundProblem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompatibilityProblemChangeListTest {
+  @Test
+  fun `problems are added and removed`() {
+    val pluginPackageNotFoundProblem = PackageNotFoundProblem("com.intellij.json", emptySet())
+    val otherPackageNotFoundProblem = PackageNotFoundProblem("com.intellij.ide", emptySet())
+    val changeList = CompatibilityProblemChangeList()
+    changeList += otherPackageNotFoundProblem
+    changeList -= pluginPackageNotFoundProblem
+
+    assertEquals(1, changeList.problems.size)
+    assertEquals(1, changeList.addedProblems.size)
+    assertEquals(1, changeList.removedProblems.size)
+  }
+
+  @Test
+  fun `same problems are not duplicated`() {
+    val pluginPackageNotFoundProblem = PackageNotFoundProblem("com.intellij.json", emptySet())
+    val pluginPackageNotFoundProblemDuplicate = PackageNotFoundProblem("com.intellij.json", emptySet())
+
+    val changeList = CompatibilityProblemChangeList()
+    changeList += pluginPackageNotFoundProblem
+    changeList += pluginPackageNotFoundProblemDuplicate
+
+    assertEquals(1, changeList.problems.size)
+    assertEquals(1, changeList.addedProblems.size)
+    assertEquals(0, changeList.removedProblems.size)
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExtractedJsonPluginAnalyzerTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExtractedJsonPluginAnalyzerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.analysis.ExtractedJsonPluginAnalyzer
+import com.jetbrains.pluginverifier.results.location.ClassLocation
+import com.jetbrains.pluginverifier.results.modifiers.Modifiers
+import com.jetbrains.pluginverifier.results.modifiers.Modifiers.Modifier.PUBLIC
+import com.jetbrains.pluginverifier.results.problems.ClassNotFoundProblem
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.results.problems.UndeclaredPluginDependencyProblem
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.tests.mocks.MockIde
+import com.jetbrains.pluginverifier.tests.mocks.MockIdePlugin
+import com.jetbrains.pluginverifier.verifiers.resolution.toBinaryClassName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExtractedJsonPluginAnalyzerTest {
+  private val jsonPluginAnalyzer = ExtractedJsonPluginAnalyzer()
+  private val fileOrigin = object : FileOrigin {
+    override val parent: FileOrigin? = null
+  }
+
+  private val targetIde = MockIde(IdeVersion.createIdeVersion("IC-243.16128"))
+
+  private val plugin = MockIdePlugin()
+  private val usage = ClassLocation("plugin.Usage", signature = null, Modifiers.of(PUBLIC), fileOrigin)
+
+  @Test
+  fun `class references an undeclared JSON package`() {
+    val compatibilityProblems = mutableSetOf<CompatibilityProblem>(
+      ClassNotFoundProblem(ClassReference("com.intellij.json.JsonElementType".toBinaryClassName()), usage)
+    )
+    val problems = jsonPluginAnalyzer.analyze(targetIde, plugin, compatibilityProblems)
+    assertEquals(1, problems.size)
+    val problem = problems.first()
+    assertTrue(problem is UndeclaredPluginDependencyProblem)
+    problem as UndeclaredPluginDependencyProblem
+    assertEquals(
+      "Plugin 'com.intellij.modules.json' is not declared in the plugin descriptor as a dependency for " +
+        "class [com.intellij.json.JsonElementType]. " +
+        "JSON support has been extracted to a separate plugin.",
+      problem.fullDescription
+    )
+  }
+
+  @Test
+  fun `class package references an undeclared JSON package`() {
+    val compatibilityProblems = mutableSetOf<CompatibilityProblem>(
+      ClassNotFoundProblem(ClassReference("com.intellij.json.JsonElementTypes".toBinaryClassName()), usage)
+    )
+    val problems = jsonPluginAnalyzer.analyze(targetIde, plugin, compatibilityProblems)
+    assertEquals(1, problems.size)
+    val problem = problems.first()
+    assertTrue(problem is UndeclaredPluginDependencyProblem)
+    problem as UndeclaredPluginDependencyProblem
+    assertEquals(
+      "Plugin 'com.intellij.modules.json' is not declared in the plugin descriptor as a dependency for " +
+        "class [com.intellij.json.JsonElementTypes]. " +
+        "JSON support has been extracted to a separate plugin.",
+      problem.fullDescription
+    )
+  }
+
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
@@ -1,0 +1,26 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.pluginverifier.results.problems.PackageNotFoundProblem
+import com.jetbrains.pluginverifier.tests.bytecode.Dumps
+import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JsonPluginUsageTest : BaseBytecodeTest() {
+  private val pluginSpec = IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o.")
+
+  @Test
+  fun `plugin uses JSON classes but they are not available in the IDE`() {
+    assertVerified {
+      ide = buildIdeWithBundledPlugins {}
+      plugin = prepareUsage(pluginSpec, "JsonPluginUsage", Dumps.JsonPluginUsage())
+      kotlin = false
+    }.run {
+      with(compatibilityProblems) {
+        assertEquals(1, size)
+        assertContains(this, PackageNotFoundProblem::class)
+      }
+    }
+  }
+
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.pluginverifier.tests
 
+import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.pluginverifier.results.problems.PackageNotFoundProblem
 import com.jetbrains.pluginverifier.tests.bytecode.Dumps
 import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
@@ -8,6 +9,9 @@ import com.jetbrains.pluginverifier.tests.mocks.ideaPlugin
 import com.jetbrains.pluginverifier.tests.mocks.withRootElement
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class JsonPluginUsageTest : BaseBytecodeTest() {
   private val pluginSpec = IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o.")
@@ -51,4 +55,51 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
       }
     }
   }
+
+  @Test
+  fun `plugin uses JSON classes, JSON plugin is declared and includes classes`() {
+    val jsonPluginId = "com.intellij.modules.json"
+    val jsonPlugin = bundledPlugin {
+      id = jsonPluginId
+      descriptorContent = ideaPlugin(
+        pluginId = jsonPluginId,
+        pluginName = "JSON",
+        vendor = "JetBrains s.r.o."
+      ).withRootElement()
+      classContentBuilder = {
+        dirs("com/intellij/json") {
+          file("JsonParserDefinition.class", JsonParserDefinition())
+        }
+      }
+    }
+
+    val targetIde = buildIdeWithBundledPlugins(bundledCorePlugins = listOf(jsonPlugin))
+    assertEquals(2, targetIde.bundledPlugins.size)
+
+    assertVerified {
+      ide = targetIde
+      plugin = prepareUsage(pluginSpec, "JsonPluginUsage", Dumps.JsonPluginUsage())
+      kotlin = false
+    }.run {
+      with(compatibilityProblems) {
+        assertEquals(0, size)
+      }
+    }
+  }
+
+  fun findAfterIdeaBuildClassPath(): Path {
+    val directory = Paths.get("after-idea", "build", "classes", "java", "main")
+    return if (directory.exists()) {
+      directory
+    } else {
+      Paths.get("verifier-test").resolve(directory).also { check(it.exists()) }
+    }
+  }
+
+  private fun JsonParserDefinition(): ByteArray {
+    return findAfterIdeaBuildClassPath()
+      .resolve("com/intellij/json/JsonParserDefinition.class")
+      .let { Files.readAllBytes(it) }
+  }
+
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
@@ -13,8 +13,25 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
+private const val JSON_PLUGIN_ID = "com.intellij.modules.json"
+
 class JsonPluginUsageTest : BaseBytecodeTest() {
   private val pluginSpec = IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o.")
+
+  private val jsonPlugin
+    get() = bundledPlugin {
+      id = JSON_PLUGIN_ID
+      descriptorContent = ideaPlugin(
+        pluginId = JSON_PLUGIN_ID,
+        pluginName = "JSON",
+        vendor = "JetBrains s.r.o."
+      ).withRootElement()
+      classContentBuilder = {
+        dirs("com/intellij/json") {
+          file("JsonParserDefinition.class", JsonParserDefinition())
+        }
+      }
+    }
 
   @Test
   fun `plugin uses JSON classes but they are not available in the IDE`() {
@@ -32,16 +49,6 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
 
   @Test
   fun `plugin uses JSON classes, JSON plugin is declared, but without any classes`() {
-    val jsonPluginId = "com.intellij.modules.json"
-    val jsonPlugin = bundledPlugin {
-      id = jsonPluginId
-      descriptorContent = ideaPlugin(
-        pluginId = jsonPluginId,
-        pluginName = "JSON",
-        vendor = "JetBrains s.r.o."
-      ).withRootElement()
-    }
-
     val targetIde = buildIdeWithBundledPlugins(listOf(jsonPlugin))
     assertEquals(2, targetIde.bundledPlugins.size)
 
@@ -58,21 +65,6 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
 
   @Test
   fun `plugin uses JSON classes, JSON plugin is declared and includes classes`() {
-    val jsonPluginId = "com.intellij.modules.json"
-    val jsonPlugin = bundledPlugin {
-      id = jsonPluginId
-      descriptorContent = ideaPlugin(
-        pluginId = jsonPluginId,
-        pluginName = "JSON",
-        vendor = "JetBrains s.r.o."
-      ).withRootElement()
-      classContentBuilder = {
-        dirs("com/intellij/json") {
-          file("JsonParserDefinition.class", JsonParserDefinition())
-        }
-      }
-    }
-
     val targetIde = buildIdeWithBundledPlugins(bundledCorePlugins = listOf(jsonPlugin))
     assertEquals(2, targetIde.bundledPlugins.size)
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInternalModifierUsageTest.kt
@@ -1,77 +1,34 @@
 package com.jetbrains.pluginverifier.tests
 
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
-import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
-import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.base.utils.simpleName
-import com.jetbrains.plugin.structure.ide.Ide
-import com.jetbrains.plugin.structure.ide.IdeManager
-import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
-import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
-import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.tests.bytecode.Dumps
 import com.jetbrains.pluginverifier.tests.bytecode.JavaDumps
 import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
-import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.kotlin.KtInternalClassUsage
 import com.jetbrains.pluginverifier.usages.internal.kotlin.KtInternalFieldUsage
 import com.jetbrains.pluginverifier.usages.internal.kotlin.KtInternalMethodUsage
-import com.jetbrains.pluginverifier.verifiers.resolution.BinaryClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.toBinaryClassName
-import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmType
 import kotlinx.metadata.Visibility
-import kotlinx.metadata.jvm.JvmMetadataVersion
 import kotlinx.metadata.jvm.JvmMethodSignature
-import kotlinx.metadata.jvm.KotlinClassMetadata
 import kotlinx.metadata.jvm.signature
 import kotlinx.metadata.visibility
-import net.bytebuddy.ByteBuddy
-import net.bytebuddy.description.method.MethodDescription
-import net.bytebuddy.dynamic.DynamicType
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
 import net.bytebuddy.implementation.FixedValue
-import net.bytebuddy.implementation.Implementation
 import net.bytebuddy.implementation.MethodDelegation
-import net.bytebuddy.implementation.bytecode.ByteCodeAppender
-import net.bytebuddy.implementation.bytecode.ByteCodeAppender.Size
-import net.bytebuddy.jar.asm.Label
-import net.bytebuddy.jar.asm.MethodVisitor
 import net.bytebuddy.matcher.ElementMatchers.named
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Ignore
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import org.objectweb.asm.Opcodes.*
 import java.lang.reflect.Modifier
-import java.lang.reflect.Type
-import java.util.*
 
 private const val internalApiServiceClassName = "com.intellij.openapi.InternalApiService"
 
 private const val usageClassName = "usage.Usage"
 
 
-class KotlinInternalModifierUsageTest {
-  @Rule
-  @JvmField
-  val temporaryFolder = TemporaryFolder()
-
-  private lateinit var byteBuddy: ByteBuddy
-
-  @Before
-  fun setUp() {
-    byteBuddy = ByteBuddy()
-  }
+class KotlinInternalModifierUsageTest : BaseBytecodeTest() {
 
   private fun getInternalMethodUsageMsg(caller: String, callee: String) =
     "Internal method $callee.internalFortyTwo() : int " +
@@ -275,251 +232,14 @@ class KotlinInternalModifierUsageTest {
     }
   }
 
-  private fun verify(ide: Ide, idePlugin: IdePlugin): Set<InternalApiUsage> {
-    val apiUsageFilter = InternalApiUsageFilter()
-
-    // Run verification
-    val verificationResult = VerificationRunner().runPluginVerification(
-      ide, idePlugin,
-      apiUsageFilters = listOf(apiUsageFilter)
-    ) as PluginVerificationResult.Verified
-
-    // No warnings should be produced
-    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
-    assertEquals(emptySet<CompatibilityWarning>(), verificationResult.compatibilityWarnings)
-    // JetBrains Plugin should not report internal usages. These are in the ignored usages
-    assertEquals(0, verificationResult.internalApiUsages.size)
-    return verificationResult.ignoredInternalApiUsages.keys
-  }
-
-  private fun assertVerified(spec: VerificationSpec.() -> Unit) =
-    runPluginVerification(spec) as PluginVerificationResult.Verified
-
-  private fun prepareUsage(
-    pluginSpec: IdeaPluginSpec,
-    dynamicTypeBuilder: () -> DynamicType.Unloaded<*>
-  ): IdePlugin {
-    return buildIdePlugin(pluginSpec) {
-      usageClass(dynamicTypeBuilder())
-    }
-  }
-
-  private fun prepareUsage(
-    pluginSpec: IdeaPluginSpec,
-    classFileName: String,
-    classFileBinaryContent: ByteArray
-  ): IdePlugin {
-    return buildIdePlugin(pluginSpec) {
-      dir("plugin") {
-       file("$classFileName.class", classFileBinaryContent)
-      }
-    }
-  }
-
-  private fun prepareIdeWithApi(platformApiClassTypeBuilder: () -> DynamicType.Unloaded<*>): Ide {
-    return buildIdeWithBundledPlugins {
-      dir("com") {
-        dir("intellij") {
-          dir("openapi") {
-            apiClass(platformApiClassTypeBuilder())
-          }
-        }
-      }
-    }
-  }
-
-  private fun ContentBuilder.usageClass(dynamicType: DynamicType.Unloaded<*>) {
-    val className = dynamicType.typeDescription.simpleName
-    dir("usage") {
-      file("$className.class", dynamicType.bytes)
-    }
-  }
-
-  private fun ContentBuilder.apiClass(dynamicType: DynamicType.Unloaded<*>) {
-    val className = dynamicType.typeDescription.simpleName
-    file("$className.class", dynamicType.bytes)
-  }
-
-  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-  private fun load(classDynamicType: DynamicType.Unloaded<Object>, classLoader: ClassLoader): Class<out Any> {
-    return classDynamicType.load(classLoader, ClassLoadingStrategy.Default.WRAPPER).loaded
-  }
-
-  private fun String.construct() = byteBuddy
-    .subclass(Object::class.java)
-    .name(this)
-
-  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-  private fun String.constructWithMethod(
-    method: String,
-    returnType: Type,
-    modifier: Int = Modifier.PUBLIC
-  ): DynamicType.Builder.MethodDefinition.ParameterDefinition.Initial<Object> {
-    return construct()
-      .defineMethod(method, returnType, modifier)
-  }
-
-  private fun buildIdeWithBundledPlugins(
-    includeKotlinStdLib: Boolean = false,
-    javaPluginClassesBuilder: (ContentBuilder).() -> Unit
-  ): Ide {
-    val ideaDirectory = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
-      file("build.txt", "IU-192.1")
-      dir("lib") {
-        zip("idea.jar") {
-          dir("META-INF") {
-            file("plugin.xml") {
-              """
-                <idea-plugin>
-                  <id>com.intellij</id>
-                  <name>IDEA CORE</name>
-                  <version>1.0</version>
-                  <module value="com.intellij.modules.all"/>                
-                </idea-plugin>
-                """.trimIndent()
-            }
-          }
-        }
-        if (includeKotlinStdLib) {
-          findKotlinStdLib().apply {
-            file(simpleName, this)
-          }
-        }
-      }
-      dir("plugins") {
-        dir("java") {
-          dir("lib") {
-            zip("java.jar") {
-              dir("META-INF") {
-                file("plugin.xml") {
-                  """
-                    <idea-plugin>
-                      <id>com.intellij.java</id>
-                      <module value="com.intellij.modules.java"/>
-                    </idea-plugin>
-                    """.trimIndent()
-                }
-              }
-
-              //Generate content of Java plugin.
-              javaPluginClassesBuilder()
-            }
-          }
-        }
-      }
-    }
-
-    // Fast assert IDE is fine
-    val ide = IdeManager.createManager().createIde(ideaDirectory)
-    assertEquals("IU-192.1", ide.version.asString())
-
-    val javaPlugin = ide.bundledPlugins.find { it.pluginId == "com.intellij.java" }!!
-    assertEquals("com.intellij.java", javaPlugin.pluginId)
-    assertEquals(setOf("com.intellij.modules.java"), javaPlugin.definedModules)
-
-    return ide
-  }
-
-  private fun buildIdePlugin(
-    ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij", "JetBrains s.r.o."),
-    pluginClassesContentBuilder: (ContentBuilder).() -> Unit
-  ): IdePlugin {
-    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
-      pluginClassesContentBuilder()
-
-      dir("META-INF") {
-        file("plugin.xml") {
-          """
-            <idea-plugin>
-              <id>${ideaPluginSpec.id}</id>
-              <name>someName</name>
-              <version>someVersion</version>
-              ""<vendor email="vendor.com" url="url">${ideaPluginSpec.vendor}</vendor>""
-              <description>this description is looooooooooong enough</description>
-              <change-notes>these change-notes are looooooooooong enough</change-notes>
-              <idea-version since-build="131.1"/>
-              <depends>com.intellij.modules.java</depends>
-            </idea-plugin>
-            """.trimIndent()
-        }
-      }
-    }
-
-    return (IdePluginManager.createManager().createPlugin(pluginFile) as PluginCreationSuccess).plugin
-  }
-
   /**
    * Generate random API class name to prevent naming clashes in ByteBuddy.
    */
-  private fun generateInternalApiServiceClassName() = internalApiServiceClassName.randomize()
+  protected fun generateInternalApiServiceClassName() = internalApiServiceClassName.randomize()
   /**
    * Generate random API Usage class to prevent naming clashes in ByteBuddy.
    */
-  private fun generateUsageClassName() = usageClassName.randomize()
-
-  private fun kotlinMetadata(configure: KmClass.() -> Unit) = KmClass().apply {
-    configure()
-  }.let {
-    KotlinClassMetadata
-      .Class(it, JvmMetadataVersion.LATEST_STABLE_SUPPORTED, 0)
-      .write()
-  }
-
-  private fun String.randomize(): String {
-    return buildString {
-      append(this@randomize)
-      append("_")
-      append(UUID.randomUUID().toString().replace("-", ""))
-    }
-  }
-
-  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-  private fun DynamicType.Unloaded<Object>.newInstance(classLoader: ClassLoader = this::class.java.classLoader) =
-    load(this, classLoader)
-      .getDeclaredConstructor().newInstance()
-
-  /**
-   * Creates a new instance of `callee` and invokes a `fieldName` while assigning a fixed value on this instance.
-   * This occurs within a method of the `caller`.
-   * The field value is hardwired to an integer
-   */
-  private class DirectFieldAccess(
-    private val caller: BinaryClassName,
-    private val callee: BinaryClassName,
-    private val fieldName: String,
-    private val fieldValue: Int
-  ) : ByteCodeAppender {
-
-    override fun apply(
-      methodVisitor: MethodVisitor,
-      implementationContext: Implementation.Context,
-      instrumentedMethod: MethodDescription
-    ): Size {
-      with(methodVisitor) {
-        val methodBeginning = Label()
-        visitLabel(methodBeginning)
-        visitTypeInsn(NEW, callee)
-        visitInsn(DUP)
-        visitMethodInsn(INVOKESPECIAL, callee, "<init>", "()V", false)
-        visitVarInsn(ASTORE, 1)
-        val instanceScopeBeginning = Label()
-        visitLabel(instanceScopeBeginning)
-        visitVarInsn(ALOAD, 1)
-        visitIntInsn(BIPUSH, fieldValue)
-        visitFieldInsn(PUTFIELD, callee, fieldName, "I")
-        visitIntInsn(BIPUSH, fieldValue)
-        visitInsn(IRETURN)
-        val methodEnd = Label()
-        visitLabel(methodEnd)
-        visitLocalVariable("this", "L$caller;", null, methodBeginning, methodEnd, 0)
-        visitLocalVariable("instance", "L$callee;", null, instanceScopeBeginning, methodEnd, 1)
-      }
-      return Size(2, 2)
-    }
-
-    val implementation: Implementation
-      get() = Implementation.Simple(this)
-  }
+  protected fun generateUsageClassName() = usageClassName.randomize()
 
 }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/Dumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/Dumps.kt
@@ -338,5 +338,86 @@ object Dumps {
     return classWriter.toByteArray()
   }
 
+  @Suppress("TestFunctionName")
+  @Throws(Exception::class)
+  fun JsonPluginUsage(): ByteArray {
+    val classWriter = ClassWriter(0)
+    var methodVisitor: MethodVisitor
+    var annotationVisitor0: AnnotationVisitor
 
+    classWriter.visit(
+      V17,
+      ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+      "plugin/JsonPluginUsage",
+      null,
+      "java/lang/Object",
+      null
+    )
+
+    run {
+      annotationVisitor0 = classWriter.visitAnnotation("Lcom/intellij/openapi/components/Service;", true)
+      run {
+        val annotationVisitor1 = annotationVisitor0.visitArray("value")
+        annotationVisitor1.visitEnum(null, "Lcom/intellij/openapi/components/Service\$Level;", "PROJECT")
+        annotationVisitor1.visitEnd()
+      }
+      annotationVisitor0.visitEnd()
+    }
+    run {
+      annotationVisitor0 = classWriter.visitAnnotation("Lkotlin/Metadata;", true)
+      annotationVisitor0.visit("mv", intArrayOf(2, 0, 0))
+      annotationVisitor0.visit("k", 1)
+      annotationVisitor0.visit("xi", 48)
+      run {
+        val annotationVisitor1 = annotationVisitor0.visitArray("d1")
+        annotationVisitor1.visit(
+          null,
+          "\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\u0008\u0003\n\u0002\u0010\u0002\n\u0000\u0008\u0007\u0018\u00002\u00020\u0001B\u0007\u00a2\u0006\u0004\u0008\u0002\u0010\u0003J\u0006\u0010\u0004\u001a\u00020\u0005\u00a8\u0006\u0006"
+        )
+        annotationVisitor1.visitEnd()
+      }
+      run {
+        val annotationVisitor1 = annotationVisitor0.visitArray("d2")
+        annotationVisitor1.visit(null, "Lplugin/JsonPluginUsage;")
+        annotationVisitor1.visit(null, "")
+        annotationVisitor1.visit(null, "<init>")
+        annotationVisitor1.visit(null, "()V")
+        annotationVisitor1.visit(null, "serve")
+        annotationVisitor1.visit(null, "")
+        annotationVisitor1.visit(null, "kotlin-plugin-idea-plugin")
+        annotationVisitor1.visitEnd()
+      }
+      annotationVisitor0.visitEnd()
+    }
+    classWriter.visitInnerClass(
+      "com/intellij/openapi/components/Service\$Level",
+      "com/intellij/openapi/components/Service",
+      "Level",
+      ACC_PUBLIC or ACC_FINAL or ACC_STATIC or ACC_ENUM
+    )
+
+    run {
+      methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null)
+      methodVisitor.visitCode()
+      methodVisitor.visitVarInsn(ALOAD, 0)
+      methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      methodVisitor.visitInsn(RETURN)
+      methodVisitor.visitMaxs(1, 1)
+      methodVisitor.visitEnd()
+    }
+    run {
+      methodVisitor = classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "serve", "()V", null, null)
+      methodVisitor.visitCode()
+      methodVisitor.visitTypeInsn(NEW, "com/intellij/json/JsonParserDefinition")
+      methodVisitor.visitInsn(DUP)
+      methodVisitor.visitMethodInsn(INVOKESPECIAL, "com/intellij/json/JsonParserDefinition", "<init>", "()V", false)
+      methodVisitor.visitInsn(POP)
+      methodVisitor.visitInsn(RETURN)
+      methodVisitor.visitMaxs(2, 1)
+      methodVisitor.visitEnd()
+    }
+    classWriter.visitEnd()
+
+    return classWriter.toByteArray()
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/Dumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/Dumps.kt
@@ -420,4 +420,34 @@ object Dumps {
 
     return classWriter.toByteArray()
   }
+
+  /**
+   * A `com.intellij.tasks.TaskRepositorySubtype` dump as of IU-242.21713.
+   *
+   */
+  fun ComIntellijTasks_TaskRepositorySubtype(): ByteArray = ClassWriter(0).apply {
+    visit(
+      V17,
+      ACC_PUBLIC or ACC_ABSTRACT or ACC_INTERFACE,
+      "com/intellij/tasks/TaskRepositorySubtype",
+      null,
+      "java/lang/Object",
+      null
+    )
+
+    visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "getName", "()Ljava/lang/String;", null, null).apply {
+      visitEnd()
+    }
+    visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "getIcon", "()Ljavax/swing/Icon;", null, null).apply {
+      visitEnd()
+    }
+
+    visitMethod(
+      ACC_PUBLIC or ACC_ABSTRACT, "createRepository", "()Lcom/intellij/tasks/TaskRepository;", null, null
+    ).apply {
+      visitEnd()
+    }
+
+    visitEnd()
+  }.toByteArray()
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
@@ -65,6 +65,11 @@ internal fun bundledPlugin(s: PluginSpec.() -> Unit): PluginSpec {
 internal class PluginSpec {
   var id: String = "simple-plugin"
 
+  /**
+   * Plugin artifact name. Mapped to directory name or JAR name (without `.jar` suffix).
+   */
+  var artifactName: String? = null
+
   var descriptorContent: String = """
                     <idea-plugin>
                       <id>$id</id>
@@ -74,10 +79,16 @@ internal class PluginSpec {
 
   var classContentBuilder: (ContentBuilder.() -> Unit)? = null
 
+  private val dirName: String
+    get() = artifactName?.let { return it } ?: id
+
+  private val jarName: String
+    get() = "$dirName.jar"
+
   fun build(): ContentSpec = buildDirectoryContent {
-    dir(id) {
+    dir(dirName) {
       dir("lib") {
-        zip("$id.jar") {
+        zip("${artifactName}.jar") {
           dir("META-INF") {
             file("plugin.xml", descriptorContent)
           }
@@ -87,7 +98,7 @@ internal class PluginSpec {
   }
 
   fun build(contentBuilder: ContentBuilder) = with(contentBuilder) {
-    dir(id) {
+    dir(dirName) {
       dir("lib") {
         buildJar(this)
       }
@@ -95,7 +106,7 @@ internal class PluginSpec {
   }
 
   internal fun buildJar(contentBuilder: ContentBuilder) = with(contentBuilder) {
-    zip("$id.jar") {
+    zip(jarName) {
       dir("META-INF") {
         file("plugin.xml", descriptorContent)
       }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
@@ -2,7 +2,9 @@ package com.jetbrains.pluginverifier.tests.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentSpec
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectoryContent
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManager
@@ -52,4 +54,45 @@ internal fun Path.buildCoreIde(): Ide {
   val ide = IdeManager.createManager().createIde(ideaDirectory)
   assertEquals("IU-192.1", ide.version.asString())
   return ide
+}
+
+internal fun bundledPlugin(s: PluginSpec.() -> Unit): PluginSpec {
+  val builder = PluginSpec()
+  s(builder)
+  return builder
+}
+
+internal class PluginSpec {
+  var id: String = "simple-plugin"
+
+  var descriptorContent: String = """
+                    <idea-plugin>
+                      <id>$id</id>
+                      <module value="com.intellij.modules.all" />
+                    </idea-plugin>
+                    """.trimIndent()
+
+  fun build(): ContentSpec = buildDirectoryContent {
+    dir(id) {
+      dir("lib") {
+        zip("$id.jar") {
+          dir("META-INF") {
+            file("plugin.xml", descriptorContent)
+          }
+        }
+      }
+    }
+  }
+
+  fun build(contentBuilder: ContentBuilder) = with(contentBuilder) {
+    dir(id) {
+      dir("lib") {
+        zip("$id.jar") {
+          dir("META-INF") {
+            file("plugin.xml", descriptorContent)
+          }
+        }
+      }
+    }
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
@@ -72,6 +72,8 @@ internal class PluginSpec {
                     </idea-plugin>
                     """.trimIndent()
 
+  var classContentBuilder: (ContentBuilder.() -> Unit)? = null
+
   fun build(): ContentSpec = buildDirectoryContent {
     dir(id) {
       dir("lib") {
@@ -87,12 +89,17 @@ internal class PluginSpec {
   fun build(contentBuilder: ContentBuilder) = with(contentBuilder) {
     dir(id) {
       dir("lib") {
-        zip("$id.jar") {
-          dir("META-INF") {
-            file("plugin.xml", descriptorContent)
-          }
-        }
+        buildJar(this)
       }
+    }
+  }
+
+  internal fun buildJar(contentBuilder: ContentBuilder) = with(contentBuilder) {
+    zip("$id.jar") {
+      dir("META-INF") {
+        file("plugin.xml", descriptorContent)
+      }
+      classContentBuilder?.invoke(this)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
@@ -9,7 +9,8 @@ internal fun ideaPlugin(pluginId: String = "someid",
                        vendor: String = "vendor",
                        sinceBuild: String = "131.1",
                        untilBuild: String = "231.1",
-                       description: String = "this description is looooooooooong enough") = """
+                       description: String = "this description is looooooooooong enough",
+                       additionalDepends: String = "") = """
     <id>$pluginId</id>
     <name>$pluginName</name>
     <version>someVersion</version>
@@ -18,6 +19,7 @@ internal fun ideaPlugin(pluginId: String = "someid",
     <change-notes>these change-notes are looooooooooong enough</change-notes>
     <idea-version since-build="$sinceBuild" until-build="$untilBuild"/>
     <depends>com.intellij.modules.platform</depends>
+    $additionalDepends
   """
 
 internal fun ContentBuilder.descriptor(header: String) {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginDescriptors.kt
@@ -22,6 +22,8 @@ internal fun ideaPlugin(pluginId: String = "someid",
     $additionalDepends
   """
 
+internal fun String.withRootElement(): String = "<idea-plugin>$this</idea-plugin>"
+
 internal fun ContentBuilder.descriptor(header: String) {
   dir("META-INF") {
     file("plugin.xml") {


### PR DESCRIPTION
Detect usages of JSON plugin that has been extracted in the 2024.3 and newer.

- Introduce an `UndeclaredPluginDependencyProblem` Plugin Verifier pbolem that indicates a missing dependency on a plugin.
- Introduce `ExtractedJsonPluginAnalyzer` that detects missing classes in `ClassNotFoundProblem`s. It checks each class against a list of known classes and packages and possibly remaps such problem to an `UndeclaredPluginDependencyProblem`.
- Support loading of mock IDE classes in the testing infrastructure.

See [MP-6964](https://youtrack.jetbrains.com/issue/MP-6964) 