### PR TITLE
Remove the spec-version property from TeamCity Actions

### DIFF
--- a/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionDescriptor.kt
+++ b/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionDescriptor.kt
@@ -14,7 +14,6 @@ import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionC
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirementType
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirementValue
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirements
-import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionSpecVersion
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepName
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepParams
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepScript
@@ -22,10 +21,7 @@ import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionS
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionSteps
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionVersion
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class TeamCityActionDescriptor(
-  @JsonProperty(ActionSpecVersion.NAME)
-  val specVersion: String? = null,
   @JsonProperty(ActionCompositeName.NAME)
   val name: String? = null,
   @JsonProperty(ActionVersion.NAME)

--- a/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionProblems.kt
+++ b/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionProblems.kt
@@ -10,6 +10,10 @@ object ParseYamlProblem : InvalidPropertyProblem() {
   override val message = "The action specification should follow valid YAML syntax."
 }
 
+data class UnknownPropertyProblem(val propertyName: String) : InvalidPropertyProblem() {
+  override val message = "Unknown property <$propertyName>."
+}
+
 class InvalidPropertyValueProblem(override val message: String) : InvalidPropertyProblem()
 
 class MissingValueProblem(propertyName: String, propertyDescription: String) : InvalidPropertyProblem() {

--- a/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionSpec.kt
+++ b/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionSpec.kt
@@ -1,11 +1,6 @@
 package com.jetbrains.plugin.structure.teamcity.action
 
 object TeamCityActionSpec {
-  object ActionSpecVersion {
-    const val NAME = "spec-version"
-    const val DESCRIPTION = "the version of action specification"
-  }
-
   object ActionCompositeName {
     const val NAME = "name"
     const val DESCRIPTION = "the composite action name in the 'namespace/name' format"

--- a/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionSpecVersionUtils.kt
+++ b/intellij-plugin-structure/structure-teamcity-actions/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/action/TeamCityActionSpecVersionUtils.kt
@@ -17,7 +17,7 @@ object TeamCityActionSpecVersionUtils {
     }
   }
 
-  fun getSemverFromString(specVersion: String): Semver {
-    return Semver(specVersion, Semver.SemverType.LOOSE)
+  fun getSemverFromString(version: String): Semver {
+    return Semver(version, Semver.SemverType.LOOSE)
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/ParseValidActionTests.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/ParseValidActionTests.kt
@@ -69,26 +69,6 @@ class ParseValidActionTests(
   }
 
   @Test
-  fun `parse action with loose semver spec version`() {
-    val validVersions = listOf(
-      "1", "1.2", "1.2.3", "1.2-test", "1.2.3-test+12333"
-    )
-    validVersions.forEach { specVersion ->
-      createPluginSuccessfully(prepareActionYaml(someAction.copy(specVersion = specVersion)))
-    }
-  }
-
-  @Test
-  fun `parse action with spec version limits`() {
-    val validVersions = listOf(
-      "9999", "0.9999", "0.0.9999", "9999.9999.9999"
-    )
-    validVersions.forEach { specVersion ->
-      createPluginSuccessfully(prepareActionYaml(someAction.copy(specVersion = specVersion)))
-    }
-  }
-
-  @Test
   fun `parse action when non-archived YAML file is provided`() {
     val yaml = temporaryFolder.newFile("action.yaml")
     val action = someAction.copy()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/ParseValidFullActionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/ParseValidFullActionTest.kt
@@ -18,7 +18,6 @@ class ParseValidFullActionTest(
   private val actionYaml =
     """
     ---
-    spec-version: 1.0.0
     name: namespace/simple-action
     version: 1.2.3
     description: this is a simple action

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/TestData.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/action/TestData.kt
@@ -13,7 +13,6 @@ import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionC
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirementType
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirementValue
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionRequirements
-import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionSpecVersion
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepName
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepParams
 import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionStepScript
@@ -23,7 +22,6 @@ import com.jetbrains.plugin.structure.teamcity.action.TeamCityActionSpec.ActionV
 
 object Actions {
   val someAction = TeamCityActionBuilder(
-    specVersion = "1.0.0",
     name = "action_namespace/action_name",
     version = "1.2.3",
     description = "some description",
@@ -70,8 +68,6 @@ object Steps {
 }
 
 data class TeamCityActionBuilder(
-  @JsonProperty(ActionSpecVersion.NAME)
-  var specVersion: String? = null,
   @JsonProperty(ActionCompositeName.NAME)
   var name: String? = null,
   @JsonProperty(ActionVersion.NAME)


### PR DESCRIPTION
The specification version will no longer be stated explicitly in the action's YAML, but will be calculated explicitly at the moment of the upload. Currently, all uploaded actions will have the specification version 1.0.0. After we add new capabilities to actions, we will calculate the specification version based on the YAML content. I have discussed this with @kesarevs.

Unknown properties in the action's YAML will now fail the deserialization. This is used to protect us from incorrectly calculating the specification format version by not including unknown fields in the calculation.