### PR TITLE
Don't use log methods atXYZ() from SLF4J 2.x

### DIFF
--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -52,7 +52,7 @@ class ProductInfoClassResolver(
         if (layoutComponent is LayoutComponent.Classpathable) {
           getClasspathableResolver(layoutComponent)
         } else {
-          LOG.atDebug().log("No classpath declared for '{}'. Skipping", layoutComponent)
+          LOG.debug("No classpath declared for '{}'. Skipping", layoutComponent)
           null
         }
       }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/dependencies/PluginXmlDependencyFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/dependencies/PluginXmlDependencyFilter.kt
@@ -72,10 +72,10 @@ class PluginXmlDependencyFilter(private val ignoreComments: Boolean = true, priv
     return try {
       hasNext()
     } catch (e: XMLStreamException) {
-      LOG.atError().log("Cannot retrieve next event", e)
+      LOG.error("Cannot retrieve next event", e)
       false
     } catch (e: RuntimeException) {
-      LOG.atError().log("Cannot retrieve next event", e)
+      LOG.error("Cannot retrieve next event", e)
       false
     }
   }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
@@ -26,13 +26,12 @@ internal class ModuleFactory(private val moduleLoader: LayoutComponentLoader, pr
     val moduleName = layoutComponent.name
     val moduleDescriptor = moduleManager.findModuleByName(moduleName)
     if (moduleDescriptor == null) {
-      LOG.atDebug().log("No module descriptor found for $moduleName")
+      LOG.debug("No module descriptor found for {}", moduleName)
       return null
     }
     val loadingContext = getLoadingContext(moduleDescriptor, idePath)
     if (loadingContext == null) {
-      LOG.atDebug()
-        .log("No module plugin descriptor found for $moduleName in resource roots [{}]",
+      LOG.debug("No module plugin descriptor found for {} in resource roots [{}]", moduleName,
           moduleDescriptor.resources.joinToString { it.path.toString() })
       return null
     }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/PluginWithArtifactPathResult.kt
@@ -21,7 +21,7 @@ internal sealed class PluginWithArtifactPathResult(open val pluginArtifactPath: 
     ) {
       if (failures.isNotEmpty()) {
         val failedPluginPaths = getFailedPluginPaths(failures, idePath)
-        log.atWarn().log("Following ${failures.size} plugins could not be created: $failedPluginPaths")
+        log.warn("Following {} plugins could not be created: {}", failures.size, failedPluginPaths)
         if (log.isDebugEnabled) {
           buildString {
             append("The following problems were encountered:\n")

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
@@ -32,7 +32,7 @@ class ProductInfoResourceResolver(
       if (it.isClasspathable) {
         getResourceResolver(it)
       } else {
-        LOG.atDebug().log("No classpath declared for '{}'. Skipping", it.layoutComponent)
+        LOG.debug("No classpath declared for '{}'. Skipping", it.layoutComponent)
         null
       }
     }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/CountingXmlEventWriter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/CountingXmlEventWriter.kt
@@ -49,7 +49,7 @@ class CountingXmlEventWriter(private val delegate: XMLEventWriter) : XMLEventWri
       } catch (e: Exception) {
         when (e) {
           is RuntimeException, is XMLStreamException -> {
-            LOG.atError().log("Failed to close delegate XML event writer: {}", e.message)
+            LOG.error("Failed to close delegate XML event writer: {}", e.message)
             return
           }
         }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/traversal/TestIdeDumper.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/traversal/TestIdeDumper.kt
@@ -56,7 +56,7 @@ class TestIdeDumper {
         try {
           Files.copy(sourcePath, targetPath)
         } catch (e: IOException) {
-          LOG.atError().log("Cannot copy {} to {}", sourcePath, targetPath, e)
+          LOG.error("Cannot copy {} to {}", sourcePath, targetPath, e)
         }
     }
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/xinclude/XIncluder.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/xinclude/XIncluder.kt
@@ -10,7 +10,11 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
-import org.jdom2.*
+import org.jdom2.Comment
+import org.jdom2.Content
+import org.jdom2.Document
+import org.jdom2.Element
+import org.jdom2.Namespace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.lang.Boolean.parseBoolean
@@ -299,7 +303,7 @@ class XIncluder private constructor(private val resourceResolver: ResourceResolv
     } else {
       include
     }
-    LOG.atDebug().log("XIncluding '{}' from '{}'. Chain {}", include, resourceResult.description, chain)
+    LOG.debug("XIncluding '{}' from '{}'. Chain {}", include, resourceResult.description, chain)
   }
 
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
@@ -90,11 +90,10 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
        overriddenMethod.isMemberEffectivelyAnnotatedWith(overrideOnlyAnnotationResolver, verificationContext.classResolver)
     }
     return if (overriddenMethod == null) {
-      LOG.atTrace().log("No overridden method for $name is annotated by [$annotationFqn]")
+      LOG.trace("No overridden method for {} is annotated by [{}]", name, annotationFqn)
       false
     } else {
-      LOG.atDebug()
-        .log("Method '${overriddenMethod.method.name}' in [${overriddenMethod.klass.name}] is annotated by [$annotationFqn]")
+      LOG.debug("Method {} in [{}] is annotated by [{}]", overriddenMethod.method.name, overriddenMethod.klass.name, annotationFqn)
       true
     }
   }


### PR DESCRIPTION
Remove usages of `at___()` methods on SLF4J loggers.

- They are hard to integrate with IntelliJ Platform Gradle Plugin and specific logging implementations.
- They can be replaced by [hints in the SL4FJ](https://www.slf4j.org/faq.html#logging_performance) documentation.

In most cases, they use just simple template strings.