### PR TITLE
Consolidate resolution logic for missing layout component files

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,15 @@ Here is the full syntax of the command:
     A file that contains patterns of problems that will be reflected in report. All other problems will be ignored. Applied to short problem description.
     The file must contain lines in form: `<plugin_xml_id_regexp_pattern>:<plugin_version_regexp_pattern>:<problem_description_regexp_pattern>`
 
+* `-missing-layout-classpath-file`
+
+    Sets the behavior when a product info layout declares a missing classpath. 
+    Available options: 
+     - `skip-warn`: skip the entire layout component and log a warning (the default),
+     - `skip-silently`: skip the entire layout component,
+     - `fail`: fail the verification with an error indicating an incorrect IDE,
+     - `ignore`: process the layout component as is
+
 ## Technical details
 
 Plugin Verifier uses the following paths for operational purposes:

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverConfiguration.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverConfiguration.kt
@@ -1,0 +1,7 @@
+package com.jetbrains.plugin.structure.ide.classes
+
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+
+data class IdeResolverConfiguration(val readMode: Resolver.ReadMode, val missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN)
+

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/IdeRelativePath.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/IdeRelativePath.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide.layout
+
+import com.jetbrains.plugin.structure.base.utils.exists
+import java.nio.file.Path
+
+data class IdeRelativePath(val idePath: Path, val relativePath: Path) {
+  val resolvedPath: Path? = idePath.resolve(relativePath)
+
+  val exists: Boolean
+    get() = resolvedPath?.exists() == true
+
+  fun toList(): List<Path> = if (resolvedPath != null) listOf(resolvedPath) else emptyList()
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/InvalidIdeLayoutException.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/InvalidIdeLayoutException.kt
@@ -1,0 +1,17 @@
+package com.jetbrains.plugin.structure.ide.layout
+
+import java.nio.file.Path
+
+open class InvalidIdeLayoutException(message: String) : RuntimeException(message)
+
+class MissingClasspathFileInLayoutComponentException private constructor(message: String) :
+  InvalidIdeLayoutException(message) {
+  companion object {
+    fun of(idePath: Path, failedComponents: List<ResolvedLayoutComponent>): InvalidIdeLayoutException {
+      val failedNames = failedComponents.joinToString { it.name }
+      return MissingClasspathFileInLayoutComponentException("Invalid IDE layout in [$idePath]. " +
+        "The following components have missing files in 'classpath': [$failedNames]")
+    }
+  }
+}
+

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/LayoutComponents.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/LayoutComponents.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide.layout
+
+import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
+import java.nio.file.Path
+
+class LayoutComponents(val layoutComponents: List<ResolvedLayoutComponent>) :
+    Iterable<ResolvedLayoutComponent> {
+    companion object {
+      fun of(idePath: Path, productInfo: ProductInfo): LayoutComponents {
+        val resolvedLayoutComponents = productInfo.layout
+          .map { ResolvedLayoutComponent(idePath, it) }
+        return LayoutComponents(resolvedLayoutComponents)
+      }
+    }
+
+    override fun iterator() = layoutComponents.iterator()
+  }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide.layout
+
+enum class MissingLayoutFileMode {
+  IGNORE,
+  SKIP_SILENTLY,
+  SKIP_AND_WARN,
+  FAIL
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ResolvedLayoutComponent.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ResolvedLayoutComponent.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide.layout
+
+import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
+import java.nio.file.Path
+
+data class ResolvedLayoutComponent(val idePath: Path, val layoutComponent: LayoutComponent) {
+    val name: String
+      get() = layoutComponent.name
+
+    fun getClasspaths(): List<Path> {
+      return if (layoutComponent is LayoutComponent.Classpathable) {
+        layoutComponent.getClasspath()
+      } else {
+        emptyList()
+      }
+    }
+
+    fun resolveClasspaths(): List<IdeRelativePath> {
+      return if (layoutComponent is LayoutComponent.Classpathable) {
+        layoutComponent.getClasspath().map { IdeRelativePath(idePath, it) }
+      } else {
+        emptyList()
+      }
+    }
+
+    fun allClasspathsExist(): Boolean {
+      return resolveClasspaths().all { it.exists }
+    }
+
+    val isClasspathable: Boolean
+      get() = layoutComponent is LayoutComponent.Classpathable
+  }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide.resolver
+
+import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
+import com.jetbrains.plugin.structure.ide.layout.MissingClasspathFileInLayoutComponentException
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.*
+import com.jetbrains.plugin.structure.ide.layout.ResolvedLayoutComponent
+import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(LayoutComponentsProvider::class.java)
+
+class LayoutComponentsProvider(private val missingLayoutFileMode: MissingLayoutFileMode) {
+  @Throws(MissingClasspathFileInLayoutComponentException::class)
+  fun resolveLayoutComponents(productInfo: ProductInfo, idePath: Path): LayoutComponents {
+    val layoutComponents = LayoutComponents.of(idePath, productInfo)
+    return if (missingLayoutFileMode == IGNORE) {
+      layoutComponents
+    } else {
+      val (okComponents, failedComponents) = layoutComponents.partition { it.allClasspathsExist() }
+      if (missingLayoutFileMode == FAIL) {
+        throw MissingClasspathFileInLayoutComponentException.of(idePath, failedComponents)
+      }
+      logUnavailableClasspath(failedComponents)
+      LayoutComponents(okComponents)
+    }
+  }
+
+  private fun logUnavailableClasspath(failedComponents: List<ResolvedLayoutComponent>) {
+    if (missingLayoutFileMode == SKIP_SILENTLY || !LOG.isWarnEnabled) return
+    val logMsg = failedComponents.joinToString("\n") {
+      val cp = it.getClasspaths().joinToString(", ")
+      "Layout component '${it.name}' has some nonexistent 'classPath' elements: '$cp'"
+    }
+    LOG.warn(logMsg)
+  }
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
@@ -1,7 +1,9 @@
 package com.jetbrains.plugin.structure.ide.resolver
 
-import com.jetbrains.plugin.structure.base.utils.exists
-import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
+import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.FAIL
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.SKIP_AND_WARN
+import com.jetbrains.plugin.structure.ide.layout.ResolvedLayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import com.jetbrains.plugin.structure.intellij.plugin.JarFilesResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolver
@@ -16,10 +18,14 @@ private val LOG: Logger = LoggerFactory.getLogger(ProductInfoResourceResolver::c
 class ProductInfoResourceResolver(
   productInfo: ProductInfo,
   idePath: Path,
-  private val excludeMissingProductInfoLayoutComponents: Boolean = true
+  excludeMissingProductInfoLayoutComponents: Boolean = true
 ) : ResourceResolver {
 
-  private val delegateResolver = getPlatformResourceResolver(resolveLayoutComponents(productInfo, idePath))
+  private val missingLayoutFileMode = if (excludeMissingProductInfoLayoutComponents) SKIP_AND_WARN else FAIL
+
+  private val layoutComponentsProvider = LayoutComponentsProvider(missingLayoutFileMode)
+
+  private val delegateResolver = getPlatformResourceResolver(layoutComponentsProvider.resolveLayoutComponents(productInfo, idePath))
 
   private fun getPlatformResourceResolver(layoutComponents: LayoutComponents): CompositeResourceResolver {
     val resourceResolvers = layoutComponents.mapNotNull {
@@ -31,16 +37,6 @@ class ProductInfoResourceResolver(
       }
     }
     return CompositeResourceResolver(resourceResolvers)
-  }
-  private fun resolveLayoutComponents(productInfo: ProductInfo, idePath: Path): LayoutComponents {
-    val layoutComponents = LayoutComponents.of(idePath, productInfo)
-    return if (excludeMissingProductInfoLayoutComponents) {
-      val (okComponents, failedComponents) = layoutComponents.partition { it.allClasspathsExist() }
-      logUnavailableClasspath(failedComponents)
-      LayoutComponents(okComponents)
-    } else {
-      layoutComponents
-    }
   }
 
   private fun getResourceResolver(layoutComponent: ResolvedLayoutComponent): NamedResourceResolver? {
@@ -58,61 +54,5 @@ class ProductInfoResourceResolver(
   override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result =
     delegateResolver.resolveResource(relativePath, basePath)
 
-  private fun logUnavailableClasspath(failedComponents: List<ResolvedLayoutComponent>) {
-    val logMsg = failedComponents.joinToString("\n") {
-      val cp = it.getClasspaths().joinToString(", ")
-      "Layout component '${it.name}' has some nonexistent 'classPath' elements: '$cp'"
-    }
-    LOG.atWarn().log(logMsg)
-  }
 
-  private data class IdeRelativePath(val idePath: Path, val relativePath: Path) {
-    val resolvedPath: Path? = idePath.resolve(relativePath)
-
-    val exists: Boolean
-      get() = resolvedPath?.exists() ?: false
-
-    fun toList(): List<Path> = if (resolvedPath != null) listOf(resolvedPath) else emptyList()
-  }
-
-  private data class ResolvedLayoutComponent(val idePath: Path, val layoutComponent: LayoutComponent) {
-    val name: String
-      get() = layoutComponent.name
-
-    fun getClasspaths(): List<Path> {
-      return if (layoutComponent is LayoutComponent.Classpathable) {
-        layoutComponent.getClasspath()
-      } else {
-        emptyList()
-      }
-    }
-
-    fun resolveClasspaths(): List<IdeRelativePath> {
-      return if (layoutComponent is LayoutComponent.Classpathable) {
-        layoutComponent.getClasspath().map { IdeRelativePath(idePath, it) }
-      } else {
-        emptyList()
-      }
-    }
-
-    fun allClasspathsExist(): Boolean {
-      return resolveClasspaths().all { it.exists }
-    }
-
-    val isClasspathable: Boolean
-      get() = layoutComponent is LayoutComponent.Classpathable
-  }
-
-  private class LayoutComponents(val layoutComponents: List<ResolvedLayoutComponent>) :
-    Iterable<ResolvedLayoutComponent> {
-    companion object {
-      fun of(idePath: Path, productInfo: ProductInfo): LayoutComponents {
-        val resolvedLayoutComponents = productInfo.layout
-          .map { ResolvedLayoutComponent(idePath, it) }
-        return LayoutComponents(resolvedLayoutComponents)
-      }
-    }
-
-    override fun iterator() = layoutComponents.iterator()
-  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
@@ -1,0 +1,95 @@
+package com.jetbrains.plugin.structure.ide.classes
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.IdeManager
+import com.jetbrains.plugin.structure.ide.InvalidIdeException
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+class IdeResolverCreatorTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `layout component with missing file in the filesystem is skipped`() {
+    val ideResolver = IdeResolverCreator.createIdeResolver(createIdeWithNonExistentFileOfLayoutComponent())
+    assertEquals("IDE Resolver class count", 0, ideResolver.allClasses.size)
+    assertEquals("IDE Resolver package count", 0, ideResolver.allPackages.size)
+  }
+
+  @Test
+  fun `layout component with missing file in the filesystem fails the whole IDE`() {
+    val resolverConfiguration = IdeResolverConfiguration(ReadMode.FULL, MissingLayoutFileMode.FAIL)
+    assertThrows("IDE has invalid layout", InvalidIdeException::class.java) {
+      IdeResolverCreator.createIdeResolver(createIdeWithNonExistentFileOfLayoutComponent(), resolverConfiguration)
+    }
+  }
+
+  private fun createIdeWithNonExistentFileOfLayoutComponent(): Ide {
+    val ideVersion = "IU-251.7539"
+    val ideRoot: Path = temporaryFolder.newFolder("idea").toPath()
+
+    buildDirectory(ideRoot) {
+      file("build.txt", ideVersion)
+      file("product-info.json", productInfoJson)
+      dir("lib") {
+        zip("product.jar") {
+          dir("META-INF") {
+            file("plugin.xml", ideaCorePluginXml)
+          }
+        }
+      }
+      dir("modules") {
+        zip("module-descriptors.jar") { /* intentionally left blank */ }
+      }
+    }
+
+    return IdeManager.createManager().createIde(ideRoot)
+  }
+
+  @Language("JSON")
+  private val productInfoJson = """
+    {
+      "name": "IntelliJ IDEA",
+      "version": "2025.1",
+      "versionSuffix": "EAP",
+      "buildNumber": "251.7539",
+      "productCode": "IU",
+      "envVarBaseName": "IDEA",
+      "dataDirectoryName": "IntelliJIdea2025.1",
+      "svgIconPath": "bin/idea.svg",
+      "productVendor": "JetBrains",
+      "launch": [],
+      "bundledPlugins": [],
+      "modules": [],
+      "fileExtensions": [],
+      "layout": [
+        {
+          "name": "intellij.qodana.sarif",
+          "kind": "moduleV2",
+          "classPath": [
+            "plugins/qodana/lib/modules/intellij.qodana.sarif.jar"
+          ]
+        }
+      ]
+    }        
+      """.trimIndent()
+
+  private val ideaCorePluginXml: String
+    @Language("JSON")
+    get() = """
+    <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+      <id>com.intellij</id>
+      <name>IDEA CORE</name>
+    </idea-plugin>        
+    """.trimIndent()
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
@@ -85,9 +85,9 @@ class IdeResolverCreatorTest {
       """.trimIndent()
 
   private val ideaCorePluginXml: String
-    @Language("JSON")
+    @Language("XML")
     get() = """
-    <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <idea-plugin>
       <id>com.intellij</id>
       <name>IDEA CORE</name>
     </idea-plugin>        

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolverTest.kt
@@ -2,6 +2,9 @@ package com.jetbrains.plugin.structure.ide.classes.resolver
 
 import com.jetbrains.plugin.structure.base.utils.createParentDirs
 import com.jetbrains.plugin.structure.classes.resolvers.ResolutionResult
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode
+import com.jetbrains.plugin.structure.ide.classes.IdeResolverConfiguration
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import com.jetbrains.plugin.structure.intellij.platform.Launch
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent.Plugin
@@ -62,6 +65,8 @@ class PluginDependencyFilteredResolverTest {
     }
     return this
   }
+
+  private val resolverConfiguration = IdeResolverConfiguration(ReadMode.FULL, MissingLayoutFileMode.SKIP_AND_WARN)
 
   @Before
   fun setUp() {
@@ -142,7 +147,7 @@ class PluginDependencyFilteredResolverTest {
 
     val ide = MockIde(ideVersion, ideRoot, bundledPlugins = listOf(ideaCorePlugin, jsonPlugin))
 
-    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide)
+    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide, resolverConfiguration)
     val pluginDependencyFilteredResolver = PluginDependencyFilteredResolver(plugin, productInfoClassResolver)
 
     with(pluginDependencyFilteredResolver.filteredResolvers) {
@@ -201,7 +206,7 @@ class PluginDependencyFilteredResolverTest {
     val bundledPlugins = listOf(ideaCorePlugin, jsonPlugin)
     val ide = MockIde(ideVersion, ideRoot, bundledPlugins)
 
-    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide)
+    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide, resolverConfiguration)
     val pluginDependencyFilteredResolver = PluginDependencyFilteredResolver(plugin, productInfoClassResolver)
 
     val editorCaretClassName = "com/intellij/openapi/editor/Caret"
@@ -257,7 +262,7 @@ class PluginDependencyFilteredResolverTest {
     val bundledPlugins = listOf(ideaCorePlugin, jsonPlugin, javaPlugin)
     val ide = MockIde(ideVersion, ideRoot, bundledPlugins)
 
-    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide)
+    val productInfoClassResolver = ProductInfoClassResolver(productInfo, ide, resolverConfiguration)
     val pluginDependencyFilteredResolver = PluginDependencyFilteredResolver(plugin, productInfoClassResolver)
 
     val editorCaretClassName = "com/intellij/openapi/editor/Caret"

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -633,7 +633,7 @@ class DependenciesTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents = false)
+    val ide = ProductInfoBasedIdeManager()
       .createIde(ideRoot)
     with(ide.bundledPlugins) {
       assertEquals(170, size)
@@ -646,7 +646,7 @@ class DependenciesTest {
     val dependencyTree = DependencyTree(ide)
     with(dependencyTree.getTransitiveDependencies(git4Idea)) {
       assertEquals(22, size)
-      val expectedDependencies = listOf(
+      listOf(
         "com.jetbrains.performancePlugin",
         "com.intellij.modules.lang",
         "org.jetbrains.plugins.terminal",

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -87,5 +87,15 @@ open class CmdOpts(
     description = "The problems that will be ignored. Comma-separated list of plugin problem identifiers.\n" +
       "\tExample: -mute ForbiddenPluginIdPrefix,TemplateWordInPluginId"
   )
-  var mutedPluginProblems: Array<String> = emptyArray()
+  var mutedPluginProblems: Array<String> = emptyArray(),
+
+  @set:Argument(
+    "missing-layout-classpath-file",
+    description = "Sets the behavior when a product info layout declares a missing classpath. " +
+      "Available options: skip-warn (skip the entire layout component and log a warning, the default); " +
+      "skip-silently (skip the entire layout component);  " +
+      "fail (fails the verification with an error indicating an incorrect IDE); " +
+      "ignore (process the layout component as is)"
+    )
+  var missingLayoutClasspathFile: String? = "skip-warn"
 )

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/cli/OptionsParserTest.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.pluginverifier.tests.cli
 
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
 import com.jetbrains.pluginverifier.output.OutputFormat
@@ -91,6 +92,32 @@ class OptionsParserTest {
     with(options) {
       assertEquals(2, outputFormats.size)
       assertEquals(listOf(OutputFormat.PLAIN, OutputFormat.HTML), outputFormats)
+    }
+  }
+
+  @Test
+  fun `missing layout classpath file parameter is handled by skipping silently`() {
+    val args = arrayOf("-missing-layout-classpath-file", "skip-silently")
+
+    val opts = CmdOpts()
+    Args.parse(opts, args, false)
+
+    val options = OptionsParser.createMissingLayoutClasspathFile(opts)
+    with(options) {
+      assertEquals(MissingLayoutFileMode.SKIP_SILENTLY, this)
+    }
+  }
+
+  @Test
+  fun `missing layout classpath file parameter is handled by skipping skipping with a warning`() {
+    val args = arrayOf("")
+
+    val opts = CmdOpts()
+    Args.parse(opts, args, false)
+
+    val options = OptionsParser.createMissingLayoutClasspathFile(opts)
+    with(options) {
+      assertEquals(MissingLayoutFileMode.SKIP_AND_WARN, this)
     }
   }
 


### PR DESCRIPTION
In nightly versions of the Platform, the `product-info.json` contains layout components with `classpath` entries that do not exist in the filesystem. 

For example:
```
"layout": [
  {
    "name": "intellij.qodana.sarif",
    "kind": "moduleV2",
    "classPath": [
      "plugins/qodana/lib/modules/intellij.qodana.sarif.jar"
    ]
  }
]
```

- Consolidate logic resolution for both `ResourceResolver` and `Resolver` in the Structure library.
- By default, when a such missing classpath entries occur, skip the whole layout component. Then, log accordingly at _warn_ level.
- Add a CLI parameter switch `-missing-layout-classpath-file` to configure behavior from the command line.