### PR TITLE
Support `product-info.json` in MacOS distributions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ jetbrains-annotations = "24.0.1"
 jsoup = "1.16.1"
 junit = "4.13.2"
 kotson = "2.5.0"
+logback-core = "1.4.7"
 logback-classic = "1.4.7"
 nexus-publish = "1.3.0"
 okhttp = "4.11.0"
@@ -34,6 +35,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotson = { group = "com.github.salomonbrys.kotson", name = "kotson", version.ref = "kotson" }
+logback-core = { group = "ch.qos.logback", name = "logback-core", version.ref = "logback-core" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback-classic" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-loggingInterceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-loggingInterceptor" }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/LayoutComponents.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/LayoutComponents.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.ide.layout
 
+import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import java.nio.file.Path
 
@@ -18,4 +19,7 @@ class LayoutComponents(val layoutComponents: List<ResolvedLayoutComponent>) :
     }
 
     override fun iterator() = layoutComponents.iterator()
+
+  val content: List<LayoutComponent>
+    get() = layoutComponents.map { it.layoutComponent }
   }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.ide.layout
 
 enum class MissingLayoutFileMode {
   IGNORE,
+  SKIP_CLASSPATH,
   SKIP_SILENTLY,
   SKIP_AND_WARN,
   FAIL

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
@@ -29,7 +29,7 @@ class LayoutComponentsProvider(private val missingLayoutFileMode: MissingLayoutF
       if (failedComponents.isNotEmpty()) {
         if (missingLayoutFileMode == FAIL) throw MissingClasspathFileInLayoutComponentException.of(idePath, failedComponents)
         if (missingLayoutFileMode == SKIP_CLASSPATH) {
-          acceptedComponents += skipClasspath(failedComponents)
+          acceptedComponents += failedComponents.map { it.skipMissingClasspathElements() }
         }
         logUnavailableClasspath(failedComponents)
       }
@@ -37,13 +37,7 @@ class LayoutComponentsProvider(private val missingLayoutFileMode: MissingLayoutF
     }
   }
 
-  private fun skipClasspath(failedComponents: List<ResolvedLayoutComponent>): List<ResolvedLayoutComponent> {
-    return failedComponents.map {
-      it.skipClassPath()
-    }
-  }
-
-  private fun ResolvedLayoutComponent.skipClassPath() = with(layoutComponent) {
+  private fun ResolvedLayoutComponent.skipMissingClasspathElements() = with(layoutComponent) {
     when (this) {
       is LayoutComponent.ModuleV2 -> copy(classPaths = existingClasspaths)
       is LayoutComponent.Plugin -> copy(classPaths = existingClasspaths)

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProvider.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.ide.layout.MissingClasspathFileInLayoutCom
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.*
 import com.jetbrains.plugin.structure.ide.layout.ResolvedLayoutComponent
+import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -24,13 +25,39 @@ class LayoutComponentsProvider(private val missingLayoutFileMode: MissingLayoutF
       layoutComponents
     } else {
       val (okComponents, failedComponents) = layoutComponents.partition { it.allClasspathsExist() }
+      val acceptedComponents = mutableListOf<ResolvedLayoutComponent>()
       if (failedComponents.isNotEmpty()) {
         if (missingLayoutFileMode == FAIL) throw MissingClasspathFileInLayoutComponentException.of(idePath, failedComponents)
+        if (missingLayoutFileMode == SKIP_CLASSPATH) {
+          acceptedComponents += skipClasspath(failedComponents)
+        }
         logUnavailableClasspath(failedComponents)
       }
-      LayoutComponents(okComponents)
+      LayoutComponents(okComponents + acceptedComponents)
     }
   }
+
+  private fun skipClasspath(failedComponents: List<ResolvedLayoutComponent>): List<ResolvedLayoutComponent> {
+    return failedComponents.map {
+      it.skipClassPath()
+    }
+  }
+
+  private fun ResolvedLayoutComponent.skipClassPath() = with(layoutComponent) {
+    when (this) {
+      is LayoutComponent.ModuleV2 -> copy(classPaths = existingClasspaths)
+      is LayoutComponent.Plugin -> copy(classPaths = existingClasspaths)
+      is LayoutComponent.ProductModuleV2 -> copy(classPaths = existingClasspaths)
+      is LayoutComponent.PluginAlias -> this
+    }
+  }.let {
+    ResolvedLayoutComponent(idePath, it)
+  }
+
+  private val ResolvedLayoutComponent.existingClasspaths
+    get() = resolveClasspaths()
+      .filter { it.exists }
+      .map { it.relativePath.toString() }
 
   private fun logUnavailableClasspath(failedComponents: List<ResolvedLayoutComponent>) {
     if (missingLayoutFileMode == SKIP_SILENTLY || !LOG.isWarnEnabled) return

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ProductInfoResourceResolver.kt
@@ -1,8 +1,6 @@
 package com.jetbrains.plugin.structure.ide.resolver
 
 import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
-import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.FAIL
-import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.SKIP_AND_WARN
 import com.jetbrains.plugin.structure.ide.layout.ResolvedLayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import com.jetbrains.plugin.structure.intellij.plugin.JarFilesResourceResolver
@@ -18,12 +16,8 @@ private val LOG: Logger = LoggerFactory.getLogger(ProductInfoResourceResolver::c
 class ProductInfoResourceResolver(
   productInfo: ProductInfo,
   idePath: Path,
-  excludeMissingProductInfoLayoutComponents: Boolean = true
+  layoutComponentsProvider: LayoutComponentsProvider
 ) : ResourceResolver {
-
-  private val missingLayoutFileMode = if (excludeMissingProductInfoLayoutComponents) SKIP_AND_WARN else FAIL
-
-  private val layoutComponentsProvider = LayoutComponentsProvider(missingLayoutFileMode)
 
   private val delegateResolver = getPlatformResourceResolver(layoutComponentsProvider.resolveLayoutComponents(productInfo, idePath))
 

--- a/intellij-plugin-structure/tests/build.gradle.kts
+++ b/intellij-plugin-structure/tests/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
   testImplementation(libs.jimfs)
   testImplementation(libs.jackson.yaml)
   testImplementation(libs.semver4j)
-  testRuntimeOnly(sharedLibs.logback.classic)
+  testImplementation(sharedLibs.logback.core)
+  testImplementation(sharedLibs.logback.classic)
 
   testImplementation(sharedLibs.byteBuddy)
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -153,11 +153,16 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
     }
   }
 
-  internal fun buildCoreIdeDirectoryForMacOs(productInfo: ProductInfo.() -> Unit = {}) =
+  internal fun buildCoreIdeDirectoryForMacOs(productInfoJson: String = ""): Path
+    = buildCoreIdeDirectoryForMacOs({ productInfoJson })
+
+  internal fun buildCoreIdeDirectoryForMacOs(productInfoJson: () -> String = { "" }) =
     buildDirectory(directory = ideRoot) {
       dir("Resources") {
-        file("build.txt", "IU-192.1")
-        file("product-info.json", productInfoJson(productInfo))
+        file("build.txt", "242.10180.25")
+        with(productInfoJson()) {
+          if (isNotEmpty()) file("product-info.json", this)
+        }
       }
       dir("lib") {
         zip("idea.jar") {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -153,6 +153,34 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
     }
   }
 
+  internal fun buildCoreIdeDirectoryForMacOs(productInfo: ProductInfo.() -> Unit = {}) =
+    buildDirectory(directory = ideRoot) {
+      dir("Resources") {
+        file("build.txt", "IU-192.1")
+        file("product-info.json", productInfoJson(productInfo))
+      }
+      dir("lib") {
+        zip("idea.jar") {
+          dir("META-INF") {
+            file("plugin.xml") {
+              """
+                <idea-plugin>
+                  <id>com.intellij</id>
+                  <name>IDEA CORE</name>
+                  <version>1.0</version>
+                  <module value="com.intellij.modules.platform"/>                
+                </idea-plugin>
+                """.trimIndent()
+            }
+          }
+        }
+      }
+      dir("modules") {
+        zip("module-descriptors.jar") { /* intentionally blank */ }
+      }
+    }
+
+
   private fun productInfoJson(init: ProductInfo.() -> Unit = {}) = with(ProductInfo()) {
     init()
     """

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -30,6 +30,16 @@ class ProductInfoBasedIdeManagerTest {
   }
 
   @Test
+  fun `create IDE manager from mock IDE on macOS`() {
+    val ideManager = ProductInfoBasedIdeManager()
+    val ideRoot = MockIdeBuilder(temporaryFolder, folderSuffix = "-mac").buildCoreIdeDirectoryForMacOs()
+    val ide = ideManager.createIde(ideRoot)
+    assertEquals(1, ide.bundledPlugins.size)
+    val corePlugin = ide.findPluginById("com.intellij")
+    assertNotNull(corePlugin)
+  }
+
+  @Test
   fun `create nonIDEA IDE manager from mock IDE`() {
     val ideManager = ProductInfoBasedIdeManager()
     val ideRoot = MockRiderBuilder(temporaryFolder).buildIdeaDirectory()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -633,7 +633,7 @@ class DependenciesTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager()
+    val ide = ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents = false)
       .createIde(ideRoot)
     with(ide.bundledPlugins) {
       assertEquals(170, size)


### PR DESCRIPTION
Support `product-info.json` in MacOS distributions, where the corresponding files are in the `Resources` subfolder.