### PR TITLE
Validate values for `-suppress-internal-api-usages`

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -73,7 +73,7 @@ open class CmdOpts(
     "suppress-internal-api-usages",
     description = "Suppress internal API usage checks. Available options: no (default), jetbrains-plugins."
   )
-  var suppressInternalApiUsageWarnings: String? = "no",
+  var suppressInternalApiUsageWarnings: String = "no",
 
   @set:Argument(
   "submission-type",

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/OptionsParser.kt
@@ -37,6 +37,11 @@ import com.jetbrains.pluginverifier.output.teamcity.TeamCityHistory
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityLog
 import com.jetbrains.pluginverifier.output.teamcity.TeamCityResultPrinter
 import com.jetbrains.pluginverifier.repository.downloader.DownloadResult
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.FULL
+import com.jetbrains.pluginverifier.tasks.checkPlugin.InternalApiVerificationMode.IGNORE_IN_JETBRAINS_PLUGINS
+import com.jetbrains.pluginverifier.tasks.checkPlugin.JETBRAINS_PLUGINS_API_USAGE_MODE
+import com.jetbrains.pluginverifier.tasks.checkPlugin.STANDARD_API_USAGE_MODE
 import com.jetbrains.pluginverifier.verifiers.packages.DefaultPackageFilter
 import com.jetbrains.pluginverifier.verifiers.packages.PackageFilter
 import org.slf4j.LoggerFactory
@@ -304,6 +309,16 @@ object OptionsParser {
     }
 
     return KeepOnlyProblemsFilter(keepOnlyConditions)
+  }
+
+  @Throws(IllegalArgumentException::class)
+  fun parseInternalApiVerificationMode(opts: CmdOpts) : InternalApiVerificationMode {
+    val supportedValues = listOf(STANDARD_API_USAGE_MODE, JETBRAINS_PLUGINS_API_USAGE_MODE)
+    return when (opts.suppressInternalApiUsageWarnings) {
+      STANDARD_API_USAGE_MODE -> FULL
+      JETBRAINS_PLUGINS_API_USAGE_MODE -> IGNORE_IN_JETBRAINS_PLUGINS
+      else -> throw IllegalArgumentException("Unknown value of -suppress-internal-api-usage-warnings: ${opts.suppressInternalApiUsageWarnings}. Supported values: $supportedValues")
+    }
   }
 
   /**

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/CmdOptsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/CmdOptsTest.kt
@@ -1,0 +1,15 @@
+package com.jetbrains.pluginverifier.options
+
+import com.sampullara.cli.Args
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class CmdOptsTest {
+  @Test
+  fun `wrong value in suppress-internal-api-usages is handled`() {
+    val args = arrayOf("-suppress-internal-api-usages", "unsupported")
+    val opts = CmdOpts()
+    Args.parse(opts, args, false)
+    assertEquals("unsupported", opts.suppressInternalApiUsageWarnings)
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/OptionsParserTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/OptionsParserTest.kt
@@ -1,0 +1,16 @@
+package com.jetbrains.pluginverifier.options
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class OptionsParserTest {
+  @Test
+  fun `incorrect internal API verification mode is marked as an error`() {
+    val opts = CmdOpts().apply {
+      suppressInternalApiUsageWarnings = "invalid"
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      OptionsParser.parseInternalApiVerificationMode(opts)
+    }
+  }
+}


### PR DESCRIPTION
The `-suppress-internal-api-usages` parameter requires a value. Validate the values and emit exception when the validation fails.

This prevents a situation when a free arg might unexpectedly become a value of this switch.