### PR TITLE
Overriding internal API in the same JAR

### DIFF
--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/filter/SameModuleUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/filter/SameModuleUsageFilter.kt
@@ -8,6 +8,7 @@ import com.jetbrains.pluginverifier.verifiers.hasAnnotation
 import com.jetbrains.pluginverifier.verifiers.resolution.BinaryClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.hasSameOrigin
 import com.jetbrains.pluginverifier.verifiers.resolution.searchParentOverrides
 import org.objectweb.asm.tree.AbstractInsnNode
 
@@ -20,7 +21,7 @@ class SameModuleUsageFilter(private val annotation: BinaryClassName) : ApiUsageF
   ) =
     invokedMethod
       .findAnnotatedElement(annotation, context)
-      ?.let { isSameOrigin(it, callerMethod) } ?: false
+      ?.hasSameOrigin(callerMethod) == true
 
   private fun isSameOrigin(method: Method, anotherMethod: Method): Boolean =
     method.containingClassFile.classFileOrigin == anotherMethod.containingClassFile.classFileOrigin

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
@@ -51,10 +51,10 @@ private fun sameOrBroaderVisibility(method: Method, anotherMethod: Method): Bool
   return method.visibilityRating >= anotherMethod.visibilityRating
 }
 
-fun Method.sameOrigin(method: Method): Boolean =
+fun Method.hasSameOrigin(method: Method): Boolean =
   containingClassFile.classFileOrigin == method.containingClassFile.classFileOrigin
 
-fun Method.hasDifferentOrigin(method: Method): Boolean = !sameOrigin(method)
+fun Method.hasDifferentOrigin(method: Method): Boolean = !hasSameOrigin(method)
 
 private val Method.visibilityRating: Int
   get() = when {

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
@@ -51,6 +51,11 @@ private fun sameOrBroaderVisibility(method: Method, anotherMethod: Method): Bool
   return method.visibilityRating >= anotherMethod.visibilityRating
 }
 
+fun Method.sameOrigin(method: Method): Boolean =
+  containingClassFile.classFileOrigin == method.containingClassFile.classFileOrigin
+
+fun Method.hasDifferentOrigin(method: Method): Boolean = !sameOrigin(method)
+
 private val Method.visibilityRating: Int
   get() = when {
     isPublic -> 3

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
@@ -7,10 +7,12 @@ package com.jetbrains.pluginverifier.usages.internal
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.method.MethodOverridingProcessor
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.hasDifferentOrigin
 
 class InternalMethodOverridingProcessor(private val internalApiUsageRegistrar: InternalApiUsageRegistrar) : MethodOverridingProcessor {
   override fun processMethodOverriding(method: Method, overriddenMethod: Method, context: VerificationContext) {
-    if (overriddenMethod.isInternalApi(context.classResolver, method.location)) {
+    if (overriddenMethod.isInternalApi(context.classResolver, method.location)
+      && overriddenMethod.hasDifferentOrigin(method)) {
       internalApiUsageRegistrar.registerInternalApiUsage(
         InternalMethodOverridden(
           overriddenMethod.location,


### PR DESCRIPTION
Allow to override an _internal method_ of a class that belongs to the same plugin.

- [MP-7136 Plugin Verifier: Overriding a method with @Internal annotation within the same plugin](https://youtrack.jetbrains.com/issue/MP-7136)