### PR TITLE
Allow to configure `IdeManager` when layout components are missing

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
@@ -3,10 +3,10 @@ package com.jetbrains.plugin.structure.ide
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import java.nio.file.Path
 
-class DispatchingIdeManager : IdeManager() {
+class DispatchingIdeManager(configuration: IdeManagerConfiguration = IdeManagerConfiguration()) : IdeManager() {
   private val standardIdeManager = IdeManagerImpl()
 
-  private val productInfoBasedIdeManager = ProductInfoBasedIdeManager()
+  private val productInfoBasedIdeManager = ProductInfoBasedIdeManager(configuration.missingLayoutFileMode)
 
   override fun createIde(idePath: Path): Ide = createIde(idePath, version = null)
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
@@ -1,0 +1,13 @@
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+
+fun createIdeManager(init: IdeManagerConfiguration.() -> Unit): IdeManager {
+  val spec = IdeManagerConfiguration()
+  spec.init()
+  return DispatchingIdeManager(spec)
+}
+
+class IdeManagerConfiguration {
+  var missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
@@ -1,6 +1,11 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide
 
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+import java.nio.file.Path
 
 fun createIdeManager(init: IdeManagerConfiguration.() -> Unit): IdeManager {
   val spec = IdeManagerConfiguration()
@@ -8,6 +13,17 @@ fun createIdeManager(init: IdeManagerConfiguration.() -> Unit): IdeManager {
   return DispatchingIdeManager(spec)
 }
 
-class IdeManagerConfiguration {
+fun createIde(init: IdeConfiguration.() -> Unit): Ide {
+  val spec = IdeConfiguration()
+  spec.init()
+  require(spec.path != null) { "IDE Path must be set" }
+  val ideManagerCfg = IdeManagerConfiguration(spec.missingLayoutFileMode)
+  return DispatchingIdeManager(ideManagerCfg).createIde(spec.path!!)
+}
+
+class IdeManagerConfiguration(var missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN)
+
+class IdeConfiguration {
   var missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN
+  var path: Path? = null
 }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -7,8 +7,8 @@ import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.ide.layout.CorePluginManager
 import com.jetbrains.plugin.structure.ide.layout.LoadingResults
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.SKIP_AND_WARN
-import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.SKIP_CLASSPATH
 import com.jetbrains.plugin.structure.ide.layout.ModuleFactory
 import com.jetbrains.plugin.structure.ide.layout.PluginFactory
 import com.jetbrains.plugin.structure.ide.layout.PluginWithArtifactPathResult
@@ -43,11 +43,11 @@ private val VERSION_FROM_PRODUCT_INFO: IdeVersion? = null
 
 private val LOG: Logger = LoggerFactory.getLogger(ProductInfoBasedIdeManager::class.java)
 
-class ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents: Boolean = true) : IdeManager() {
+class ProductInfoBasedIdeManager(missingLayoutFileMode: MissingLayoutFileMode = SKIP_AND_WARN) : IdeManager() {
   private val productInfoParser = ProductInfoParser()
 
   private val layoutComponentProvider =
-    LayoutComponentsProvider(missingLayoutFileMode = if (excludeMissingProductInfoLayoutComponents) SKIP_AND_WARN else SKIP_CLASSPATH)
+    LayoutComponentsProvider(missingLayoutFileMode = missingLayoutFileMode)
 
   /**
    * Problem level remapping used for bundled plugins.

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagersTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagersTest.kt
@@ -1,0 +1,15 @@
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.FAIL
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IdeManagersTest {
+  @Test
+  fun `IDE manager is created with DSL`() {
+    val ideManager = createIdeManager {
+      missingLayoutFileMode = FAIL
+    }
+    assertTrue(ideManager is DispatchingIdeManager)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -4,6 +4,7 @@ import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.ide.ProductInfoBasedIdeManager
+import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
@@ -633,7 +634,7 @@ class DependenciesTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents = false)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
       .createIde(ideRoot)
     with(ide.bundledPlugins) {
       assertEquals(280, size)
@@ -690,7 +691,7 @@ class DependenciesTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents = false)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
       .createIde(ideRoot)
     with(ide.bundledPlugins) {
       assertEquals(504, size)
@@ -814,7 +815,7 @@ class DependenciesTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(excludeMissingProductInfoLayoutComponents = false)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
       .createIde(ideRoot)
 
     val coveragePlugin = ide.findPluginById("Coverage")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/ide/IdeDescriptor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/ide/IdeDescriptor.kt
@@ -9,9 +9,9 @@ import com.jetbrains.plugin.structure.base.utils.closeOnException
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode
 import com.jetbrains.plugin.structure.ide.Ide
-import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.ide.classes.IdeResolverConfiguration
 import com.jetbrains.plugin.structure.ide.classes.IdeResolverCreator
+import com.jetbrains.plugin.structure.ide.createIde
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 import com.jetbrains.pluginverifier.jdk.DefaultJdkDescriptorProvider
 import com.jetbrains.pluginverifier.jdk.JdkDescriptor
@@ -76,7 +76,10 @@ data class IdeDescriptor(
       missingLayoutClasspathFileMode: MissingLayoutFileMode
     ): IdeDescriptor {
       val ideResolverConfiguration = IdeResolverConfiguration(ReadMode.FULL, missingLayoutClasspathFileMode)
-      val ide = IdeManager.createManager().createIde(idePath)
+      val ide = createIde {
+        path = idePath
+        missingLayoutFileMode = missingLayoutClasspathFileMode
+      }
       val ideResolver = IdeResolverCreator.createIdeResolver(ide, ideResolverConfiguration)
       ideResolver.closeOnException {
         when (val result = jdkDescriptorProvider.getJdkDescriptor(ide, defaultJdkPath)) {


### PR DESCRIPTION
When creating a generic IDE Manager, allow to provide a configuration.

A _missing layout file mode_ is currently enabled for configuration. This mode is propagated to the `DispatchingIdeManager` and the `ProductInfoBasedIdeManager` that supports this behaviour for Platform 2024.2 and newer.

This allows integration with [IntelliJ Platform Gradle Plugin](https://github.com/JetBrains/intellij-platform-gradle-plugin), when creating IDEs.