### PR TITLE
Make dispatching IDE Manager configurable

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.ide
@@ -16,9 +16,10 @@ fun createIdeManager(init: IdeManagerConfiguration.() -> Unit): IdeManager {
 fun createIde(init: IdeConfiguration.() -> Unit): Ide {
   val spec = IdeConfiguration()
   spec.init()
-  require(spec.path != null) { "IDE Path must be set" }
-  val ideManagerCfg = IdeManagerConfiguration(spec.missingLayoutFileMode)
-  return DispatchingIdeManager(ideManagerCfg).createIde(spec.path!!)
+  val idePath = spec.path
+  require(idePath != null) { "IDE Path must be set" }
+  val ideManagerConfig = IdeManagerConfiguration(spec.missingLayoutFileMode)
+  return DispatchingIdeManager(ideManagerConfig).createIde(idePath)
 }
 
 class IdeManagerConfiguration(var missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN)

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagersTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagersTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide
 
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.FAIL


### PR DESCRIPTION
- Make `DispatchingIdeManager` configurable with ability to provide mode for missing layout entries
- Establish an alternative API to create IDEs with configuration
- When creating IDE Descriptor, honor the configuration for the resolver and for the IDE as well.