### PR TITLE
Reuse filesystem accessed by different uri to the same file

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.jar
 
+import com.jetbrains.plugin.structure.base.utils.exists
 import java.net.URI
 import java.nio.file.Path
 
@@ -15,7 +16,11 @@ const val JAR_SCHEME = "jar"
 fun Path.toJarFileUri(): URI {
   return if (toUri().scheme == FILE_SCHEMA) {
     val absoluteJarPath = if (isAbsolute) this else toAbsolutePath()
-    URI("$JAR_FILE_SCHEMA:${absoluteJarPath.toUri()}")
+    if(absoluteJarPath.exists()) {
+      URI("$JAR_FILE_SCHEMA:${absoluteJarPath.toRealPath().toUri()}")
+    } else {
+      URI("$JAR_FILE_SCHEMA:${absoluteJarPath.normalize().toUri()}")
+    }
   } else {
     toUri()
   }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/traversal/PlatformSearcher.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/traversal/PlatformSearcher.kt
@@ -41,7 +41,7 @@ class PlatformSearcher(private val zipEntryFilter: (ZipEntry) -> Boolean = { tru
 
   @Throws(IOException::class)
   private fun ZipFilePath.getUri(zipEntry: ZipEntry): URI {
-    return FileSystems.newFileSystem(/* path = */ this, /* loader = */ null).use { fs ->
+    return FileSystems.newFileSystem(/* path = */ this, /* loader = */ null as ClassLoader).use { fs ->
       fs.getPath(zipEntry.name).toUri()
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
@@ -1,0 +1,43 @@
+package com.jetbrains.plugin.structure.jar
+
+import com.jetbrains.plugin.structure.base.utils.writeText
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.net.URI
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+class SingletonCachingJarFileSystemProviderTest {
+
+  @Rule
+  @JvmField
+  val tempFolder = TemporaryFolder()
+
+  @Test
+  fun `Jar Uris are normalized`() {
+    val jarPath = tempFolder.root.toPath().resolve("test.jar")
+    FileSystems.newFileSystem(URI.create("jar:${jarPath.toUri()}"), mapOf<String, Any>("create" to true)).use {
+      it.getPath("hello.txt").writeText("Hello World")
+    }
+
+    //Getting two filesystems with different path that point to the same file.
+    val fs1 = SingletonCachingJarFileSystemProvider.getFileSystem(jarPath)
+    val fs2 = SingletonCachingJarFileSystemProvider.getFileSystem(
+      Path.of("${tempFolder.root.absolutePath}/../${tempFolder.root.name}/test.jar")
+    )
+
+    Assert.assertSame(fs1, fs2)
+
+    //After jar is closed for the first time, filesystem remains open
+    SingletonCachingJarFileSystemProvider.close(jarPath)
+    Assert.assertTrue(fs1.isOpen)
+    Assert.assertTrue(fs2.isOpen)
+
+    //After closed for second time, the filesystem has no users and is closed
+    SingletonCachingJarFileSystemProvider.close(jarPath)
+    Assert.assertFalse(fs1.isOpen)
+    Assert.assertFalse(fs2.isOpen)
+  }
+}


### PR DESCRIPTION
When a jar file was opened with different uris pointing to the same file they would return the same file system because the jdk normalizes the uri, eg jar:file:/tmp/../tmp/file.jar becomes jar:file:/tmp/file.jar.

Therefore the number of users of one filesystem was incorrect and it might have been closed while still in use.

This occured eg. in mono repos with multiple intellij plugins and parallel builds.