### PR TITLE
Increase plugin artifact size limit to 1.5GB

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/Settings.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/Settings.kt
@@ -4,13 +4,14 @@
 
 package com.jetbrains.plugin.structure.base.plugin
 
+import com.jetbrains.plugin.structure.base.utils.ONE_POINT_FIVE_GB
 import org.apache.commons.io.FileUtils
 import java.nio.file.Path
 import java.nio.file.Paths
 
 enum class Settings(private val key: String, private val defaultValue: () -> String) {
   EXTRACT_DIRECTORY("intellij.structure.temp.dir", { Paths.get(FileUtils.getTempDirectory().absolutePath).resolve("extracted-plugins").toString() }),
-  INTELLIJ_PLUGIN_SIZE_LIMIT("intellij.structure.intellij.plugin.size.limit", { FileUtils.ONE_GB.toString() }),
+  INTELLIJ_PLUGIN_SIZE_LIMIT("intellij.structure.intellij.plugin.size.limit", { ONE_POINT_FIVE_GB.toString() }),
   FLEET_PLUGIN_SIZE_LIMIT("intellij.structure.fleet.plugin.size.limit", { FileUtils.ONE_GB.toString() }),
   TOOLBOX_PLUGIN_SIZE_LIMIT("intellij.structure.toolbox.plugin.size.limit", { FileUtils.ONE_GB.toString() }),
   TEAM_CITY_PLUGIN_SIZE_LIMIT("intellij.structure.team.city.plugin.size.limit", { FileUtils.ONE_GB.toString() }),

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -5,18 +5,31 @@
 package com.jetbrains.plugin.structure.base.utils
 
 import com.jetbrains.plugin.structure.base.telemetry.UNKNOWN_SIZE
+import org.apache.commons.io.FileUtils.ONE_GB
 import org.slf4j.LoggerFactory
-import java.io.*
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.math.BigDecimal
 import java.nio.charset.Charset
-import java.nio.file.*
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitOption
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.*
 import java.util.stream.Collectors
 import kotlin.streams.toList
 
 private val LOG = LoggerFactory.getLogger("structure.FileUtil")
 
 typealias Bytes = Long
+
+internal val ONE_GB_BD = BigDecimal(ONE_GB)
+internal val ONE_POINT_FIVE_GB = BigDecimal("1.5").multiply(ONE_GB_BD).toLong()
 
 fun Path.isZip(): Boolean = this.hasExtension("zip")
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/plugin/SettingsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/plugin/SettingsTest.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.plugin.structure.base.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SettingsTest {
+  @Test
+  fun `1_5GB is the IntelliJ plugin size limit`() {
+    assertEquals(1_610_612_736L,Settings.INTELLIJ_PLUGIN_SIZE_LIMIT.getAsLong())
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimplePluginCreatorResultResolver.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimplePluginCreatorResultResolver.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level
+import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+
+class SimplePluginCreatorResultResolver : PluginCreationResultResolver {
+  private val _problems = mutableListOf<PluginProblem>()
+
+  val problems: List<PluginProblem> = _problems
+
+  override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationSuccess<IdePlugin> =
+    PluginCreationSuccess<IdePlugin>(plugin, problems.remapToWarnings())
+
+  override fun classify(plugin: IdePlugin, problems: List<PluginProblem>): List<ReclassifiedPluginProblem> =
+    problems.remapToWarnings()
+
+  private fun List<PluginProblem>.remapToWarnings() = map { problem ->
+    ReclassifiedPluginProblem(Level.WARNING, problem)
+  }
+
+  fun reset() = _problems.clear()
+}


### PR DESCRIPTION
Increase plugin artifact size limit to 1.5GB.

See [MP-7177](https://youtrack.jetbrains.com/issue/MP-7177/Increase-plugin-artifact-size-limit-to-1.5GB)