### PR TITLE
Support inline <module> declarations with CDATA in plugin descriptor

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginModuleBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginModuleBean.java
@@ -1,11 +1,13 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
 
 public class PluginModuleBean {
   @XmlAttribute(name = "name") public String moduleName;
+  @XmlValue public String value;
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -449,19 +449,6 @@ class IdePluginManager private constructor(
     }.pluginCreationResult
   }
 
-  fun createInlineModule(
-    descriptorResource: DescriptorResource,
-    pluginFile: Path,
-    ideVersion: IdeVersion,
-    problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver()
-  ): PluginCreationResult<IdePlugin> {
-    //FIXME parent plugin is null
-    return loadModuleFromDescriptorResource(descriptorResource, parentPlugin = null, myResourceResolver).apply {
-      setPluginVersion(ideVersion.asStringWithoutProductCode())
-      setOriginalFile(pluginFile)
-    }.pluginCreationResult
-  }
-
   @Throws(PluginFileNotFoundException::class)
   private fun getPluginCreatorWithResult(
     pluginFile: Path,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -504,12 +504,13 @@ class IdePluginManager private constructor(
 
   private fun getDescriptorResource(module: InlineModule, pluginFile: Path, descriptorPath: String): DescriptorResource {
     // FIXME descriptor path is not relative to the pluginFile JAR
-    val uri = if (pluginFile.isJar()) {
-      URI("jar:" + pluginFile.toUri().toString() + "!" + descriptorPath.toSystemIndependentName())
+    val parentUriStr = if (pluginFile.isJar()) {
+      "jar:" + pluginFile.toUri().toString() + "!" + descriptorPath.toSystemIndependentName()
     } else {
-      URI(pluginFile.toUri().toString() + "/" + descriptorPath.toSystemIndependentName())
+      pluginFile.toUri().toString() + "/" + descriptorPath.toSystemIndependentName()
     }
-    return DescriptorResource(module.textContent.byteInputStream(), uri)
+    val uriStr = parentUriStr + "#modules/" + module.name
+    return DescriptorResource(module.textContent.byteInputStream(), URI(uriStr), URI(parentUriStr))
   }
 
   private fun logPluginCreationWarnings(pluginId: String, pluginCreator: PluginCreator) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -1,6 +1,7 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
+
 package com.jetbrains.plugin.structure.intellij.plugin
 
 import com.jetbrains.plugin.structure.base.plugin.IconTheme
@@ -32,8 +33,12 @@ import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
 import com.jetbrains.plugin.structure.base.utils.withPathSeparatorOf
 import com.jetbrains.plugin.structure.intellij.extractor.ExtractorResult
 import com.jetbrains.plugin.structure.intellij.extractor.PluginExtractor.extractPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
+import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginLibDirectoryIsEmpty
@@ -52,6 +57,7 @@ import org.jdom2.input.JDOMParseException
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.IOException
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
@@ -146,6 +152,34 @@ class IdePluginManager private constructor(
     } catch (e: JarArchiveCannotBeOpenException) {
       LOG.warn("Unable to extract {} (searching for {}): {}", jarFile, descriptorPath, e.getShortExceptionMessage())
       createInvalidPlugin(jarFile, descriptorPath, UnableToExtractZip())
+    }
+  }
+
+  private fun loadModuleFromDescriptorResource(
+    descriptorResource: DescriptorResource,
+    parentPlugin: PluginCreator? = null,
+    resourceResolver: ResourceResolver): PluginCreator {
+    return descriptorResource.inputStream.use {
+      try {
+        val problemResolver = AnyProblemToWarningPluginCreationResultResolver
+        val descriptorXml = JDOMUtil.loadDocument(it)
+        createPlugin(
+          descriptorResource,
+          parentPlugin,
+          descriptorXml,
+          resourceResolver,
+          problemResolver
+        ).also {
+          //FIXME problem resolver might have collected lots of module issues. log them
+          it
+        }
+      } catch (e: IOException) {
+        with(descriptorResource) {
+          LOG.warn("Unable to read descriptor stream (source: '$uri')", e)
+          val problem = UnableToReadDescriptor(fileName, e.localizedMessage)
+          createInvalidPlugin(artifactFileName, fileName, problem)
+        }
+      }
     }
   }
 
@@ -324,9 +358,28 @@ class IdePluginManager private constructor(
     if (currentPlugin.isSuccess) {
       val contentModules = currentPlugin.contentModules
       for (module in contentModules) {
-        val configFile = module.configFile
-        val moduleCreator = loadPluginInfoFromJarOrDirectory(pluginFile, configFile, false, resourceResolver, currentPlugin, problemResolver)
-        currentPlugin.addModuleDescriptor(module.name, configFile, moduleCreator)
+        when (module) {
+          is FileBasedModule -> {
+            val configFile = module.configFile
+            val moduleCreator = loadPluginInfoFromJarOrDirectory(
+              pluginFile,
+              configFile,
+              false,
+              resourceResolver,
+              currentPlugin,
+              problemResolver
+            )
+            currentPlugin.addModuleDescriptor(module.name, configFile, moduleCreator)
+          }
+
+          is InlineModule -> {
+            val moduleCreator =
+              loadModuleFromDescriptorResource(module.toDescriptorResource(), currentPlugin, resourceResolver)
+            //FIXME plugin path
+            val moduleConfigurationFile = currentPlugin.descriptorPath + "#modules/" + module.name
+            currentPlugin.addModuleDescriptor(module, moduleCreator)
+          }
+        }
       }
     }
   }
@@ -396,6 +449,19 @@ class IdePluginManager private constructor(
     }.pluginCreationResult
   }
 
+  fun createInlineModule(
+    descriptorResource: DescriptorResource,
+    pluginFile: Path,
+    ideVersion: IdeVersion,
+    problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver()
+  ): PluginCreationResult<IdePlugin> {
+    //FIXME parent plugin is null
+    return loadModuleFromDescriptorResource(descriptorResource, parentPlugin = null, myResourceResolver).apply {
+      setPluginVersion(ideVersion.asStringWithoutProductCode())
+      setOriginalFile(pluginFile)
+    }.pluginCreationResult
+  }
+
   @Throws(PluginFileNotFoundException::class)
   private fun getPluginCreatorWithResult(
     pluginFile: Path,
@@ -448,6 +514,12 @@ class IdePluginManager private constructor(
       archiveFileSize = pluginFile.pluginSize
     }
   }
+
+  private fun InlineModule.toDescriptorResource(): DescriptorResource {
+    //FIXME fix uri
+    return DescriptorResource(this.textContent.byteInputStream(), URI(""))
+  }
+
 
   companion object {
     private val LOG = LoggerFactory.getLogger(IdePluginManager::class.java)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Module.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Module.kt
@@ -1,3 +1,14 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.intellij.plugin
 
-data class Module(val name: String, val configFile: String)
+sealed class Module(open val name: String) {
+  data class InlineModule(override val name: String, val textContent: String) : Module(name) {
+    override fun toString(): String = "$name (CDATA module, ${textContent.length} characters)"
+  }
+  data class FileBasedModule(override val name: String, val configFile: String) : Module(name) {
+    override fun toString(): String = "$name (file module, $configFile)"
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ModuleDescriptor.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/ModuleDescriptor.kt
@@ -1,8 +1,19 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
 
 data class ModuleDescriptor(
   val name: String,
   val dependencies: List<PluginDependency>,
   val module: IdePlugin,
   val configurationFilePath: String
-)
+) {
+  companion object {
+    fun of(moduleId: String, module: IdePlugin, moduleDescriptorResource: DescriptorResource): ModuleDescriptor =
+      ModuleDescriptor(moduleId, module.dependencies, module, moduleDescriptorResource.uri.toString())
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -210,10 +210,10 @@ internal class PluginCreator private constructor(
     }
   }
 
-  internal fun addModuleDescriptor(moduleReference: InlineModule, moduleCreator: PluginCreator) {
+  internal fun addModuleDescriptor(moduleReference: InlineModule, descriptorResource: DescriptorResource, moduleCreator: PluginCreator) {
     val pluginCreationResult = moduleCreator.pluginCreationResult
     if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
-      val moduleConfigurationFile = descriptorPath + "#modules/" + moduleReference.name
+      val moduleConfigurationFile = descriptorResource.uri.toString() + "#modules/" + moduleReference.name
       val moduleName = moduleReference.name
       val module = pluginCreationResult.plugin
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -210,15 +210,14 @@ internal class PluginCreator private constructor(
     }
   }
 
-  internal fun addModuleDescriptor(moduleReference: InlineModule, descriptorResource: DescriptorResource, moduleCreator: PluginCreator) {
+  internal fun addModuleDescriptor(moduleReference: InlineModule, moduleDescriptorResource: DescriptorResource, moduleCreator: PluginCreator) {
     val pluginCreationResult = moduleCreator.pluginCreationResult
     if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
-      val moduleConfigurationFile = descriptorResource.uri.toString() + "#modules/" + moduleReference.name
       val moduleName = moduleReference.name
       val module = pluginCreationResult.plugin
 
       plugin.addDependencies(module)
-      plugin.modulesDescriptors.add(ModuleDescriptor(moduleName, module.dependencies, module, moduleConfigurationFile))
+      plugin.modulesDescriptors.add(ModuleDescriptor.of(moduleName, module, moduleDescriptorResource))
       plugin.definedModules.add(moduleName)
 
       mergeContent(module)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginModuleResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginModuleResolver.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+
+/**
+ * Resolves Plugin V2 Model `<content>/<module>` elements.
+ */
+internal class PluginModuleResolver {
+  fun resolvePluginModules(pluginBean: PluginBean): List<Module> {
+    val modules = pluginBean.pluginContent.flatMap { it.modules }
+    return modules.filter { it.moduleName != null }
+      .map {
+        val name = it.moduleName!!
+        if (it.value.isNullOrBlank()) {
+          val configFile = "../${name.replace("/", ".")}.xml"
+          Module.FileBasedModule(name, configFile)
+        } else {
+          val cDataContent = it.value!!
+          Module.InlineModule(name, cDataContent)
+        }
+      }
+      .toList()
+  }
+
+  fun supports(pluginBean: PluginBean): Boolean = pluginBean.pluginContent != null
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/DescriptorResource.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/DescriptorResource.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.descriptors
+
+import java.io.InputStream
+import java.net.URI
+import java.nio.file.Path
+
+/**
+ * Represents a plugin descriptor as a [InputStream]-based resource identified by a specific [URI] and an optional
+ * parent that contains this plugin descriptor.
+ *
+ * @param inputStream stream of bytes that represents XML data of this descriptor
+ * @param uri an identifier of this byte stream, usually as a filesystem path in the `file` or `jar` scheme.
+ * @param parentDescriptorUri parent descriptor. A descriptor XML might occur within another descriptor as an inline XML CDATA.
+ * Then, the parent descriptor URI points to the filesystem path of that containing descriptor.
+ */
+data class DescriptorResource(val inputStream: InputStream, val uri: URI, val parentDescriptorUri: URI? = null) {
+  val fileName: String = extractFileName(uri)
+
+  val filePath: Path = Path.of(fileName)
+
+  val artifactFileName: String = extractArtifactFileName(uri)
+}
+
+private fun extractFileName(uri: URI): String = with(uri.toString()) {
+  if (startsWith("jar:")) {
+    substringAfterLast("!/").substringAfterLast("/")
+  } else {
+    substringAfterLast("/")
+  }
+}
+
+private fun extractArtifactFileName(uri: URI): String = with(uri.toString()) {
+  if (startsWith("jar:file")) {
+    uri.schemeSpecificPart.substringAfter(":").substringBeforeLast("!").removePrefix("//")
+  } else {
+    this
+  }
+}
+

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/MinorWarnings.kt
@@ -8,6 +8,8 @@ import com.jetbrains.plugin.structure.base.problems.InvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorResolutionError
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
+import com.jetbrains.plugin.structure.base.utils.pluralize
+import com.jetbrains.plugin.structure.intellij.plugin.Module
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 class NoModuleDependencies(descriptorPath: String) : InvalidDescriptorProblem(
@@ -95,6 +97,20 @@ class ModuleDescriptorResolutionProblem(
       } else {
         prefix + " is invalid: ${errors.joinToString { it.message }}"
       }
+    }
+}
+
+class ModuleDescriptorProblem(
+  private val module: Module,
+  private val errors: List<PluginProblem>
+) : PluginProblem() {
+  override val level
+    get() = Level.WARNING
+
+  override val message: String
+    get() {
+      val errorStr = "problem".pluralize(errors.size)
+      return "Module '${module.name}' has ${errors.size} $errorStr: ${errors.joinToString { it.message }}"
     }
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginCreatorTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginCreatorTest.kt
@@ -1,0 +1,71 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.URI
+import java.nio.file.Path
+
+class PluginCreatorTest {
+  @Test
+  fun `plugin is created from the descriptor resource`() {
+    val uri = URI("file:///plugins/somePlugin/META-INF/plugin.xml")
+
+    val descriptorResource = DescriptorResource(PLUGIN_XML.byteInputStream(), uri)
+    descriptorResource.inputStream.use { stream ->
+      val descriptorXml = JDOMUtil.loadDocument(stream)
+      PluginCreator.createPlugin(
+        descriptorResource,
+        parentPlugin = null,
+        descriptorXml,
+        resourceResolver,
+        problemResolver
+      ).run {
+        assertTrue(isSuccess)
+        assertEquals(5, resolvedProblems.size)
+      }
+    }
+  }
+
+  private val resourceResolver = object : ResourceResolver {
+    override fun resolveResource(
+      relativePath: String,
+      basePath: Path
+    ) = ResourceResolver.Result.NotFound
+  }
+
+  private val problemResolver = object : PluginCreationResultResolver {
+    override fun resolve(
+      plugin: IdePlugin,
+      problems: List<PluginProblem>
+    ): PluginCreationResult<IdePlugin> {
+      val problems = problems.map { problem ->
+        if (problem.level == PluginProblem.Level.ERROR) {
+          ReclassifiedPluginProblem(PluginProblem.Level.WARNING, problem)
+        } else {
+          problem
+        }
+      }
+      return PluginCreationSuccess(plugin, problems)
+    }
+  }
+}
+
+private const val PLUGIN_XML = """
+  <idea-plugin allow-bundled-update="true">
+    <id>com.intellij.ml.llm</id>
+    <version>251.SNAPSHOT</version>
+    <idea-version since-build="251.SNAPSHOT" until-build="251.SNAPSHOT" />
+    <name>JetBrains AI Assistant</name>
+    <vendor>JetBrains</vendor>
+    <description>JetBrains AI Assistant provides AI-powered features for software development based on the JetBrains AI Service.</description>
+  </idea-plugin>
+"""

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/descriptors/DescriptorResourceTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/descriptors/DescriptorResourceTest.kt
@@ -1,0 +1,41 @@
+package com.jetbrains.plugin.structure.intellij.plugin.descriptors
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.nio.file.Path
+
+class DescriptorResourceTest {
+  @Test
+  fun `JAR-based URI is parsed`() {
+    val uri = URI("jar:file:/some/absolute/path/to/plugin.jar!/META-INF/plugin.xml")
+    val descriptor = DescriptorResource(ByteArrayInputStream(ByteArray(0)), uri)
+    assertEquals("plugin.xml", descriptor.fileName)
+    assertEquals(Path.of("plugin.xml"), descriptor.filePath)
+    assertEquals("/some/absolute/path/to/plugin.jar", descriptor.artifactFileName)
+  }
+
+  @Test
+  fun `JAR-based URI with two slashes is parsed`() {
+    val uri = URI("jar:file:///some/absolute/path/to/plugin.jar!/META-INF/plugin.xml")
+    val descriptor = DescriptorResource(ByteArrayInputStream(ByteArray(0)), uri)
+    assertEquals("plugin.xml", descriptor.fileName)
+    assertEquals("/some/absolute/path/to/plugin.jar", descriptor.artifactFileName)
+  }
+
+  @Test
+  fun `JAR-based URI on Windows with two slashes is parsed`() {
+    val uri = URI("jar:file://C:/some/absolute/path/to/plugin.jar!/META-INF/plugin.xml")
+    val descriptor = DescriptorResource(ByteArrayInputStream(ByteArray(0)), uri)
+    assertEquals("plugin.xml", descriptor.fileName)
+    assertEquals("C:/some/absolute/path/to/plugin.jar", descriptor.artifactFileName)
+  }
+
+  @Test
+  fun `file-based URI is parsed`() {
+    val uri = URI("file:///some/absolute/path/to/plugin.jar!/META-INF/plugin.xml")
+    val descriptor = DescriptorResource(ByteArrayInputStream(ByteArray(0)), uri)
+    assertEquals("plugin.xml", descriptor.fileName)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/InlineModuleTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/InlineModuleTest.kt
@@ -1,0 +1,197 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.ContentBuilder
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.MockIdeBuilder
+import com.jetbrains.plugin.structure.ide.ProductInfoBasedIdeManager
+import com.jetbrains.plugin.structure.intellij.plugin.dependencies.Dependency
+import com.jetbrains.plugin.structure.intellij.plugin.dependencies.DependencyTree
+import com.jetbrains.plugin.structure.intellij.plugin.dependencies.PluginAware
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.mocks.MockIde
+import com.jetbrains.plugin.structure.mocks.MockIdePlugin
+import com.jetbrains.plugin.structure.mocks.SimplePluginCreatorResultResolver
+import org.intellij.lang.annotations.Language
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class InlineModuleTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var ide: Ide
+
+  private val pluginProblemRemapper = SimplePluginCreatorResultResolver()
+
+  @Before
+  fun setUp() {
+    val ideRoot = MockIdeBuilder(temporaryFolder).buildIdeaDirectory()
+    val ideManager = ProductInfoBasedIdeManager()
+    this.ide = ideManager.createIde(ideRoot)
+  }
+
+  @Test
+  fun `plugin with inline module is handled`() {
+    val plugin = buildCorrectPlugin {
+        dir("META-INF") {
+          file("plugin.xml", pluginXmlContent)
+        }
+    }.plugin
+
+    val modules = plugin.modulesDescriptors
+    assertEquals(1, modules.size)
+    val structureSearchModule = modules.first().module
+    with(structureSearchModule.dependencies) {
+      assertEquals(1, size)
+      assertEquals("com.intellij.modules.structuralsearch", first().id)
+    }
+    with(structureSearchModule.extensions) {
+      assertEquals(2, size)
+    }
+    with(structureSearchModule.appContainerDescriptor.services) {
+      assertEquals(1, size)
+      with(first()) {
+        assertEquals("com.intellij.structuralsearch.plugin.ui.StructuralSearchTemplateBuilder", serviceInterface)
+        assertEquals("com.intellij.structuralsearch.java.ui.JavaStructuralSearchTemplateBuilder", serviceImplementation)
+      }
+    }
+  }
+
+  @Test
+  fun `transitive dependencies of the plugin with inline module are handled`() {
+    val plugin = buildCorrectPlugin {
+      dir("META-INF") {
+        file("plugin.xml", pluginXmlContent)
+      }
+    }.plugin
+
+    val idePlugins = listOf(
+      MockIdePlugin(pluginId = "com.intellij.modules.lang"),
+      MockIdePlugin(
+        pluginId = "com.intellij.modules.idea.community",
+        // fictional dependency that will become a transitive one
+        dependencies = listOf(PluginDependencyImpl("com.intellij.transitiveDependency", false, false))
+      ),
+      MockIdePlugin(pluginId = "com.intellij.modules.structuralsearch"),
+      // fictional plugin that poses as a transitional dependency
+      MockIdePlugin(pluginId = "com.intellij.transitiveDependency")
+    )
+    val ideVersionStr = "IU-242.10180.25"
+    val ide = MockIde(IdeVersion.createIdeVersion(ideVersionStr), temporaryFolder.newFolder(ideVersionStr).toPath(), idePlugins)
+
+    val dependencyTree = DependencyTree(ide)
+    with(dependencyTree.getTransitiveDependencies(plugin)) {
+      assertEquals(4, size)
+      // optional v1 dependency
+      assertContains("com.intellij.modules.idea.community")
+      // optional v2 dependency
+      assertContains("com.intellij.modules.lang")
+      // dependency declared in a content module
+      assertContains("com.intellij.modules.structuralsearch")
+      // transitive dependency, declared by bundled plugin
+      assertContains("com.intellij.modules.transitiveDependency")
+    }
+  }
+
+  @Test
+  fun `transitive dependencies of the plugin with inline module are handled but some declared dependencies are missing`() {
+    val plugin = buildCorrectPlugin {
+      dir("META-INF") {
+        file("plugin.xml", pluginXmlContent)
+      }
+    }.plugin
+
+    val idePlugins = listOf(
+      MockIdePlugin(pluginId = "com.intellij.modules.lang"),
+      MockIdePlugin(pluginId = "com.intellij.modules.structuralsearch"),
+    )
+    val ideVersionStr = "IU-242.10180.25"
+    val ide = MockIde(IdeVersion.createIdeVersion(ideVersionStr), temporaryFolder.newFolder(ideVersionStr).toPath(), idePlugins)
+
+    with(plugin.dependencies) {
+      assertEquals(3, size)
+      // optional v1 dependency
+      assertContains("com.intellij.modules.idea.community")
+      // optional v2 dependency
+      assertContains("com.intellij.modules.lang")
+      // dependency declared in a content module
+      assertContains("com.intellij.modules.structuralsearch")
+    }
+
+    val dependencyTree = DependencyTree(ide)
+    with(dependencyTree.getTransitiveDependencies(plugin)) {
+      assertEquals(2, size)
+      // optional v1 dependency is not in the IDE as a bundled plugin
+      assertNotContains("com.intellij.modules.idea.community")
+      // optional v2 dependency
+      assertContains("com.intellij.modules.lang")
+      // dependency declared in a content module
+      assertContains("com.intellij.modules.structuralsearch")
+    }
+  }
+
+  private fun buildCorrectPlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationSuccess<IdePlugin> {
+    val pluginCreationResult = buildIdePlugin(pluginContentBuilder)
+    if (pluginCreationResult !is PluginCreationSuccess) {
+      fail("This plugin has not been created. Creation failed with error(s).")
+    }
+    return pluginCreationResult as PluginCreationSuccess
+  }
+
+  private fun buildIdePlugin(pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath(), pluginContentBuilder)
+    return IdePluginManager.createManager().createPlugin(pluginFile, validateDescriptor = true, problemResolver = pluginProblemRemapper)
+  }
+
+  @Language("XML")
+  val pluginXmlContent = """
+      <idea-plugin>
+          <id>com.intellij.java</id>
+          <vendor>JetBrains</vendor>
+          <dependencies>
+              <plugin id="com.intellij.modules.lang"/>
+          </dependencies>
+          <module value="com.intellij.modules.java"/>
+          <depends optional="true" config-file="community-integration.xml">com.intellij.modules.idea.community</depends>
+          <content>
+              <module name="intellij.java.structuralSearch"><![CDATA[<idea-plugin>
+                <dependencies>
+                  <plugin id="com.intellij.modules.structuralsearch" />
+                </dependencies>
+                <extensions defaultExtensionNs="com.intellij">
+                  <applicationService serviceInterface="com.intellij.structuralsearch.plugin.ui.StructuralSearchTemplateBuilder" serviceImplementation="com.intellij.structuralsearch.java.ui.JavaStructuralSearchTemplateBuilder" overrides="true" />
+                  <structuralsearch.profile implementation="com.intellij.structuralsearch.JavaStructuralSearchProfile" />
+                  <java.elementFinder implementation="com.intellij.structuralsearch.IdeaOpenApiClassFinder" />
+                </extensions>
+              </idea-plugin>]]>
+              </module>
+          </content>
+      </idea-plugin>
+    """.trimIndent()
+
+  @After
+  fun tearDown() {
+    this.pluginProblemRemapper.reset()
+  }
+
+  private fun Set<Dependency>.assertContains(id: String): Boolean =
+    filterIsInstance<PluginAware>()
+      .any { it.plugin.pluginId == id }
+
+  private fun Set<Dependency>.assertNotContains(id: String): Boolean =
+    filterIsInstance<PluginAware>()
+      .none { it.plugin.pluginId == id }
+
+  private fun List<PluginDependency>.assertContains(id: String): Boolean =
+    any { it.id == id }
+
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -646,39 +646,50 @@ class DependenciesTest {
 
     val dependencyTree = DependencyTree(ide)
     with(dependencyTree.getTransitiveDependencies(git4Idea)) {
-      assertEquals(31, size)
+      assertEquals(42, size)
       listOf(
-        "XPathView",
-        "com.intellij.copyright",
-        "com.intellij.java",
-        "com.intellij.modules.java",
-        "com.intellij.modules.java-capable",
-        "com.intellij.modules.json",
+        "com.jetbrains.performancePlugin",
         "com.intellij.modules.lang",
-        "com.intellij.modules.vcs",
-        "com.intellij.modules.xdebugger",
-        "com.intellij.modules.xml",
-        "com.intellij.platform.images",
-        "com.intellij.properties",
-        "com.jetbrains.performancePlugin",
-        "com.jetbrains.performancePlugin",
-        "com.jetbrains.sh",
-        "intellij.libraries.microba",
-        "intellij.performanceTesting.vcs",
-        "intellij.platform.collaborationTools",
-        "intellij.platform.coverage",
-        "intellij.platform.coverage.agent",
-        "intellij.platform.ide.newUiOnboarding",
-        "intellij.platform.vcs.dvcs.impl",
+        "kotlin.features-trainer",
+        "intellij.java.featuresTrainer",
+        "training",
+        "intellij.platform.lvcs.impl",
         "intellij.platform.vcs.impl",
+        "intellij.libraries.microba",
+        "Git4Idea",
+        "com.jetbrains.performancePlugin",
         "intellij.platform.vcs.log.impl",
-        "org.intellij.intelliLang",
+        "intellij.platform.collaborationTools",
+        "intellij.platform.vcs.dvcs.impl",
+        "com.intellij.modules.vcs",
+        "intellij.platform.ide.newUiOnboarding",
+        "org.jetbrains.plugins.terminal",
+        "com.jetbrains.sh",
+        "com.intellij.copyright",
+        "com.intellij.modules.xml",
+        "org.jetbrains.kotlin",
+        "com.intellij.java",
+        "com.intellij.platform.images",
+        "com.intellij.modules.idea.community",
+        "com.intellij.modules.xdebugger",
+        "com.intellij.modules.java-capable",
+        "intellij.performanceTesting.vcs",
         "org.intellij.plugins.markdown",
-        "org.jetbrains.plugins.terminal",
-        "org.jetbrains.plugins.terminal",
+        "org.intellij.intelliLang",
+        "com.intellij.modules.java",
         "org.jetbrains.plugins.yaml",
         "org.toml.lang",
         "tanvd.grazi",
+        "com.intellij.properties",
+        "intellij.platform.coverage",
+        "intellij.platform.coverage.agent",
+        "intellij.platform.ide.newUsersOnboarding",
+        "intellij.platform.experiment",
+        "intellij.platform.collaborationTools",
+        "com.intellij.modules.vcs",
+        "intellij.platform.ide.newUiOnboarding",
+        "org.jetbrains.plugins.terminal",
+        "intellij.platform.coverage",
       ).forEach(::assertContains)
     }
   }
@@ -703,7 +714,7 @@ class DependenciesTest {
 
     val dependencyTree = DependencyTree(ide)
     with(dependencyTree.getTransitiveDependencies(git4Idea)) {
-      assertEquals(32, size)
+      assertEquals(46, size)
       listOf(
         "XPathView",
         "com.intellij.copyright",
@@ -742,66 +753,97 @@ class DependenciesTest {
     val expectedDebugString = """
       * Plugin dependency: 'com.jetbrains.performancePlugin'
         * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij'
-        * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl'
-          * Module 'intellij.libraries.microba' provided by plugin 'intellij.libraries.microba'
-        * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl'
-          * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-      * Module 'intellij.platform.collaborationTools' provided by plugin 'intellij.platform.collaborationTools'
-        * Module 'intellij.platform.vcs.dvcs.impl' provided by plugin 'intellij.platform.vcs.dvcs.impl'
-          * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
-        * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
-      * Module 'com.intellij.modules.vcs' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-      * Module 'intellij.platform.ide.newUiOnboarding' provided by plugin 'intellij.platform.ide.newUiOnboarding'
-      * Plugin dependency: 'org.jetbrains.plugins.terminal'
-        * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-        * Plugin dependency: 'com.jetbrains.sh'
-          * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-          * Plugin dependency: 'org.jetbrains.plugins.terminal' (already visited)
-          * Plugin dependency: 'com.intellij.copyright'
-            * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-            * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-            * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-          * Plugin dependency: 'org.intellij.plugins.markdown'
-            * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-            * Plugin dependency: 'org.intellij.intelliLang'
-              * Plugin dependency: 'XPathView'
-                * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-              * Module 'com.intellij.modules.java' provided by plugin 'com.intellij.java'
-                * Plugin dependency: 'com.intellij.copyright' (already visited)
-                * Plugin dependency: 'com.intellij.platform.images'
-                  * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-                * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-                * Module 'com.intellij.modules.vcs' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-                * Module 'com.intellij.modules.xdebugger' provided by plugin 'com.intellij' (already visited)
-                * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-                * Module 'com.intellij.modules.java-capable' provided by plugin 'com.intellij' (already visited)
-                * Module 'intellij.performanceTesting.vcs' provided by plugin 'intellij.performanceTesting.vcs'
-                  * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-                  * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
-                * Plugin dependency: 'com.jetbrains.performancePlugin' (already visited)
+          * Plugin dependency: 'com.intellij.java'
+            * Plugin dependency: 'com.intellij.copyright'
+              * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
               * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-            * Plugin dependency: 'com.intellij.modules.json'
-            * Plugin dependency: 'org.jetbrains.plugins.yaml'
+              * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl'
+                * Module 'intellij.libraries.microba' provided by plugin 'intellij.libraries.microba'
+            * Plugin dependency: 'com.intellij.platform.images'
               * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-              * Plugin dependency: 'com.intellij.modules.json' (already visited)
-            * Plugin dependency: 'org.toml.lang'
-              * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
-              * Plugin dependency: 'com.intellij.modules.json' (already visited)
-              * Plugin dependency: 'tanvd.grazi'
-                * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
-                * Plugin dependency: 'com.intellij.java' (already visited)
-                * Plugin dependency: 'com.intellij.modules.json' (already visited)
-                * Plugin dependency: 'org.intellij.plugins.markdown' (already visited)
-                * Plugin dependency: 'com.intellij.properties'
-                  * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-                  * Plugin dependency: 'com.intellij.copyright' (already visited)
-                * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-                * Plugin dependency: 'org.jetbrains.plugins.yaml' (already visited)
-            * Plugin dependency: 'com.intellij.platform.images' (already visited)
+            * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+            * Module 'com.intellij.modules.vcs' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+            * Module 'com.intellij.modules.xdebugger' provided by plugin 'com.intellij' (already visited)
             * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
-      * Module 'intellij.platform.coverage' provided by plugin 'intellij.platform.coverage'
-        * Module 'intellij.platform.coverage.agent' provided by plugin 'intellij.platform.coverage.agent'
-
+            * Module 'com.intellij.modules.java-capable' provided by plugin 'com.intellij' (already visited)
+            * Plugin dependency: 'training'
+              * Module 'intellij.platform.lvcs.impl' provided by plugin 'intellij.platform.lvcs.impl'
+                * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+              * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+              * Plugin dependency: 'Git4Idea'
+                * Plugin dependency: 'com.jetbrains.performancePlugin' (already visited)
+                * Module 'intellij.platform.collaborationTools' provided by plugin 'intellij.platform.collaborationTools'
+                  * Module 'intellij.platform.vcs.dvcs.impl' provided by plugin 'intellij.platform.vcs.dvcs.impl'
+                    * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl'
+                      * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+                  * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
+                * Module 'com.intellij.modules.vcs' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+                * Module 'intellij.platform.ide.newUiOnboarding' provided by plugin 'intellij.platform.ide.newUiOnboarding'
+                * Plugin dependency: 'org.jetbrains.plugins.terminal'
+                  * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+                  * Plugin dependency: 'com.jetbrains.sh'
+                    * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+                    * Plugin dependency: 'org.jetbrains.plugins.terminal' (already visited)
+                    * Plugin dependency: 'com.intellij.copyright' (already visited)
+                    * Plugin dependency: 'org.intellij.plugins.markdown'
+                      * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+                      * Plugin dependency: 'org.intellij.intelliLang'
+                        * Plugin dependency: 'XPathView'
+                          * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
+                        * Module 'com.intellij.modules.java' provided by plugin 'com.intellij.java' (already visited)
+                        * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
+                      * Plugin dependency: 'com.intellij.modules.json'
+                      * Plugin dependency: 'org.jetbrains.plugins.yaml'
+                        * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+                        * Plugin dependency: 'com.intellij.modules.json' (already visited)
+                      * Plugin dependency: 'org.toml.lang'
+                        * Module 'com.intellij.modules.lang' provided by plugin 'com.intellij' (already visited)
+                        * Plugin dependency: 'com.intellij.modules.json' (already visited)
+                        * Plugin dependency: 'tanvd.grazi'
+                          * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+                          * Plugin dependency: 'com.intellij.java' (already visited)
+                          * Plugin dependency: 'com.intellij.modules.json' (already visited)
+                          * Plugin dependency: 'org.intellij.plugins.markdown' (already visited)
+                          * Plugin dependency: 'com.intellij.properties'
+                            * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
+                            * Plugin dependency: 'com.intellij.copyright' (already visited)
+                          * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
+                          * Plugin dependency: 'org.jetbrains.plugins.yaml' (already visited)
+                      * Plugin dependency: 'com.intellij.platform.images' (already visited)
+                      * Module 'com.intellij.modules.xml' provided by plugin 'com.intellij' (already visited)
+                      * Module 'intellij.platform.compose' provided by plugin 'intellij.platform.compose'
+                        * Module 'intellij.libraries.compose.desktop' provided by plugin 'intellij.libraries.compose.desktop'
+                          * Module 'intellij.libraries.skiko' provided by plugin 'intellij.libraries.skiko'
+                        * Module 'intellij.libraries.skiko' provided by plugin 'intellij.libraries.skiko' (already visited)
+                * Module 'intellij.platform.coverage' provided by plugin 'intellij.platform.coverage'
+                  * Module 'intellij.platform.coverage.agent' provided by plugin 'intellij.platform.coverage.agent'
+              * Module 'intellij.platform.ide.newUiOnboarding' provided by plugin 'intellij.platform.ide.newUiOnboarding' (already visited)
+              * Module 'intellij.platform.ide.newUsersOnboarding' provided by plugin 'intellij.platform.ide.newUsersOnboarding'
+                * Module 'intellij.platform.ide.newUiOnboarding' provided by plugin 'intellij.platform.ide.newUiOnboarding' (already visited)
+                * Module 'intellij.platform.experiment' provided by plugin 'intellij.platform.experiment'
+            * Module 'intellij.performanceTesting.vcs' provided by plugin 'intellij.performanceTesting.vcs'
+              * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+              * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
+            * Plugin dependency: 'com.jetbrains.performancePlugin' (already visited)
+            * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+          * Module 'kotlin.features-trainer' provided by plugin 'kotlin.features-trainer'
+            * Module 'intellij.java.featuresTrainer' provided by plugin 'intellij.java.featuresTrainer'
+              * Plugin dependency: 'training' (already visited)
+            * Plugin dependency: 'training' (already visited)
+          * Module 'intellij.java.featuresTrainer' provided by plugin 'intellij.java.featuresTrainer' (already visited)
+          * Plugin dependency: 'org.jetbrains.kotlin'
+            * Module 'intellij.platform.collaborationTools' provided by plugin 'intellij.platform.collaborationTools' (already visited)
+            * Plugin dependency: 'com.intellij.java' (already visited)
+          * Plugin dependency: 'com.intellij.platform.images' (already visited)
+          * Plugin dependency: 'com.intellij.copyright' (already visited)
+        * Module 'intellij.platform.vcs.impl' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+        * Module 'intellij.platform.vcs.log.impl' provided by plugin 'intellij.platform.vcs.log.impl' (already visited)
+      * Module 'intellij.platform.collaborationTools' provided by plugin 'intellij.platform.collaborationTools' (already visited)
+      * Module 'com.intellij.modules.vcs' provided by plugin 'intellij.platform.vcs.impl' (already visited)
+      * Module 'intellij.platform.ide.newUiOnboarding' provided by plugin 'intellij.platform.ide.newUiOnboarding' (already visited)
+      * Plugin dependency: 'org.jetbrains.plugins.terminal' (already visited)
+      * Module 'intellij.platform.coverage' provided by plugin 'intellij.platform.coverage' (already visited)
+      
     """.trimIndent()
 
     assertEquals(expectedDebugString, dependencyTree.toDebugString(git4Idea.pluginId!!).toString())
@@ -824,12 +866,11 @@ class DependenciesTest {
 
     val dependencyTree = DependencyTree(ide)
     with(dependencyTree.getTransitiveDependencies(coveragePlugin)) {
-      assertEquals(22, size)
+      assertEquals(44, size)
       assertContains("intellij.platform.coverage.agent")
     }
   }
 }
-
 
 private fun Set<Dependency>.assertContains(id: String): Boolean =
   filterIsInstance<PluginAware>()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimplePluginCreatorResultResolver.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/SimplePluginCreatorResultResolver.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.mocks
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level
+import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+
+class SimplePluginCreatorResultResolver : PluginCreationResultResolver {
+  private val _problems = mutableListOf<PluginProblem>()
+
+  val problems: List<PluginProblem> = _problems
+
+  override fun resolve(plugin: IdePlugin, problems: List<PluginProblem>): PluginCreationSuccess<IdePlugin> =
+    PluginCreationSuccess<IdePlugin>(plugin, problems.remapToWarnings())
+
+  override fun classify(plugin: IdePlugin, problems: List<PluginProblem>): List<ReclassifiedPluginProblem> =
+    problems.remapToWarnings()
+
+  private fun List<PluginProblem>.remapToWarnings() = map { problem ->
+    ReclassifiedPluginProblem(Level.WARNING, problem)
+  }
+
+  fun reset() = _problems.clear()
+}

--- a/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-modules-in-cdata.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-modules-in-cdata.xml
@@ -1,0 +1,673 @@
+<idea-plugin allow-bundled-update="true">
+    <id>com.intellij.ml.llm</id>
+    <version>251.SNAPSHOT</version>
+    <idea-version since-build="251.SNAPSHOT" until-build="251.SNAPSHOT" />
+    <name>JetBrains AI Assistant</name>
+    <vendor>JetBrains</vendor>
+    <description>JetBrains AI Assistant provides AI-powered features for software development based on the JetBrains AI Service.</description>
+    <content>
+        <module name="intellij.ml.llm.privacy"><![CDATA[<idea-plugin package="com.intellij.ml.llm.privacy">
+  <dependencies>
+    <module name="intellij.platform.vcs.impl" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.core"><![CDATA[<idea-plugin package="com.intellij.ml.llm" separate-jar="true">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <plugin id="com.intellij.platform.ide.provisioner" />
+    <plugin id="com.intellij.llmInstaller" />
+    <module name="intellij.libraries.ktor.client" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.impl"><![CDATA[<idea-plugin package="com.intellij.ml.llm.impl">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.devkit"><![CDATA[<idea-plugin package="com.intellij.ml.llm.devkit">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.devkit.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.go"><![CDATA[<idea-plugin package="com.intellij.ml.llm.go">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <plugin id="org.jetbrains.plugins.go" />
+    <module name="intellij.ml.llm.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.java"><![CDATA[<idea-plugin package="com.intellij.ml.llm.java">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.java" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javaee"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javaee">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.java" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.kotlin"><![CDATA[<idea-plugin package="com.intellij.ml.llm.kotlin">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.kotlin" />
+    <module name="intellij.ml.llm.java" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.python"><![CDATA[<idea-plugin package="com.intellij.ml.llm.python">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.python" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.python.ultimate"><![CDATA[<idea-plugin package="com.intellij.ml.llm.python.ultimate">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="PythonCore" />
+    <plugin id="Pythonid" />
+    <module name="intellij.ml.llm.python" />
+    <module name="intellij.python" />
+    <module name="intellij.django.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.jupyter.common"><![CDATA[<idea-plugin package="com.intellij.ml.llm.jupyter.common">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.jupyter.psi" />
+    <module name="intellij.jupyter.core" />
+    <module name="intellij.notebooks.jupyter.core" />
+    <module name="intellij.notebooks.ui" />
+    <module name="intellij.notebooks.visualization" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.scientific.tables" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.jupyter.kotlin"><![CDATA[<idea-plugin package="com.intellij.ml.llm.jupyter.kotlin">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.scientific.tables" />
+    <plugin id="org.jetbrains.plugins.kotlin.jupyter" />
+    <module name="intellij.ml.llm.jupyter.common" />
+    <module name="intellij.jupyter.core" />
+    <module name="intellij.notebooks.visualization" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.jupyter.python"><![CDATA[<idea-plugin package="com.intellij.ml.llm.jupyter.python">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.python" />
+    <module name="intellij.ml.llm.jupyter.common" />
+    <module name="intellij.ml.llm.chatInputLanguage" />
+    <plugin id="com.intellij.modules.python" />
+    <module name="intellij.jupyter.psi" />
+    <module name="intellij.jupyter.core" />
+    <module name="intellij.jupyter.py" />
+    <module name="intellij.jupyter.py.psi" />
+    <module name="intellij.scientific.tables" />
+    <module name="intellij.jupyter.tables" />
+    <module name="intellij.scientific.py.tables" />
+    <module name="intellij.notebooks.visualization" />
+    <module name="intellij.notebooks.jupyter.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.cpp"><![CDATA[<idea-plugin package="com.intellij.ml.llm.cpp">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.clion" />
+    <plugin id="com.intellij.cidr.lang" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.cpp.common"><![CDATA[<idea-plugin package="com.intellij.ml.llm.cpp.common">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.clion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="JavaScript" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.vue"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.vue">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.vue" />
+    <module name="intellij.ml.llm.javascript" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.android"><![CDATA[<idea-plugin package="com.intellij.ml.llm.android">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.android" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.sql"><![CDATA[<idea-plugin package="com.intellij.ml.llm.sql">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.chatInputLanguage" />
+    <plugin id="com.intellij.database" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.sql/embeddings"><![CDATA[<idea-plugin package="com.intellij.ml.llm.sql.embeddings">
+  <dependencies>
+    <module name="intellij.ml.llm.sql" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings"><![CDATA[<idea-plugin>
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.core"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.core" separate-jar="true">
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.searchEverywhere"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.searchEverywhere">
+  <resource-bundle>messages.searchEverywhereMlSemanticsBundle</resource-bundle>
+  <dependencies>
+    <module name="intellij.ml.llm.embeddings.core" />
+    <plugin id="com.intellij.searcheverywhere.ml" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.smartChat"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.smartChat">
+  <resource-bundle>messages.EmbeddingsLLMBundle</resource-bundle>
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.java"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.java">
+  <dependencies>
+    <plugin id="com.intellij.java" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.kotlin"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.kotlin">
+  <dependencies>
+    <plugin id="org.jetbrains.kotlin" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.python"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.python">
+  <dependencies>
+    <plugin id="com.intellij.modules.python" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.embeddings.testCommands"><![CDATA[<idea-plugin package="com.intellij.ml.llm.embeddings.testCommands">
+  <dependencies>
+    <plugin id="com.jetbrains.performancePlugin" />
+    <module name="intellij.ml.llm.embeddings.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.ruby"><![CDATA[<idea-plugin package="com.intellij.ml.llm.ruby">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.ruby" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.php"><![CDATA[<idea-plugin package="com.intellij.ml.llm.php">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.jetbrains.php" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.performanceTesting"><![CDATA[<idea-plugin package="com.intellij.ml.llm.performanceTesting">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.jetbrains.performancePlugin" />
+    <plugin id="org.jetbrains.completion.full.line" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.markdown"><![CDATA[<idea-plugin package="com.intellij.ml.llm.markdown">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.intellij.plugins.markdown" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.uiTestGeneration"><![CDATA[<idea-plugin package="com.intellij.ml.llm.uiTestGeneration">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.aqua.wi" />
+    <module name="intellij.aqua.frameworks.core" />
+    <module name="intellij.aqua.selenium.shared" />
+    <module name="intellij.aqua.runners.cypress" />
+    <module name="intellij.aqua.runners.playwright.js" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.httpClient"><![CDATA[<idea-plugin package="com.intellij.ml.llm.httpClient">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.jetbrains.restClient" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.microservices"><![CDATA[<idea-plugin package="com.intellij.ml.llm.microservices">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.microservices.ui" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.textmate"><![CDATA[<idea-plugin package="com.intellij.ml.llm.textmate">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.textmate" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.chatInputLanguage"><![CDATA[<idea-plugin package="com.intellij.ml.llm.chatInputLanguage">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.intellij.plugins.markdown" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.chatInputLanguage.grazie"><![CDATA[<idea-plugin package="com.intellij.ml.llm.chatInputLanguage.grazie">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="tanvd.grazi" />
+    <module name="intellij.ml.llm.chatInputLanguage" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.sh"><![CDATA[<idea-plugin package="com.intellij.ml.llm.sh">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.jetbrains.sh" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.structuralSearch"><![CDATA[<idea-plugin package="com.intellij.ml.llm.structuralSearch">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.structuralsearch" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.completion.cloud">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.ml.inline.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.java.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.java.completion.cloud" separate-jar="true">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.java" />
+    <module name="intellij.ml.inline.completion.java" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.kotlin.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.kotlin.completion.cloud" separate-jar="true">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.kotlin" />
+    <module name="intellij.ml.inline.completion.kotlin" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.latest"><![CDATA[<idea-plugin package="com.intellij.ml.llm.latest">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+  </dependencies>
+  <actions />
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.python.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.python.completion.cloud" separate-jar="true">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.python" />
+    <module name="intellij.ml.inline.completion.python" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.go.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.go.completion.cloud">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.go" />
+    <module name="intellij.ml.inline.completion.go" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.ruby.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.ruby.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.ruby" />
+    <module name="intellij.ml.inline.completion.ruby" />
+    <module name="intellij.ml.llm.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.php.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.php.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.inline.completion.php" />
+    <module name="intellij.ml.llm.completion" />
+    <plugin id="com.jetbrains.php" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.completion.cloud">
+  <dependencies>
+    <plugin id="JavaScript" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.inline.completion.js" />
+    <module name="intellij.ml.inline.completion.web" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.vue.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.vue.completion.cloud">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.vue" />
+    <module name="intellij.ml.llm.javascript.completion" />
+    <module name="intellij.ml.inline.completion.js.vue" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.astro.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.astro.completion.cloud">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.astro" />
+    <module name="intellij.ml.llm.javascript.completion" />
+    <module name="intellij.ml.inline.completion.js.astro" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.svelte.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.svelte.completion.cloud">
+  <dependencies>
+    <plugin id="dev.blachut.svelte.lang" />
+    <module name="intellij.ml.llm.javascript.completion" />
+    <module name="intellij.ml.inline.completion.js.svelte" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.css.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.css.completion.cloud">
+  <dependencies>
+    <plugin id="com.intellij.css" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.inline.completion.css" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.css.less.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.css.less.completion.cloud">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.less" />
+    <module name="intellij.ml.llm.css.completion" />
+    <module name="intellij.ml.inline.completion.css.less" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.css.sass.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.css.sass.completion.cloud">
+  <dependencies>
+    <plugin id="org.jetbrains.plugins.sass" />
+    <module name="intellij.ml.llm.css.completion" />
+    <module name="intellij.ml.inline.completion.css.sass" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.css.postcss.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.css.postcss.completion.cloud">
+  <dependencies>
+    <plugin id="org.intellij.plugins.postcss" />
+    <module name="intellij.ml.llm.css.completion" />
+    <module name="intellij.ml.inline.completion.css.postcss" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.html.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.html.completion.cloud">
+  <dependencies>
+    <plugin id="HtmlTools" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.inline.completion.html" />
+    <module name="intellij.ml.inline.completion.web" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.jupyter.python.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.jupyter.python.completion.cloud">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.llm.python.completion" />
+    <module name="intellij.ml.inline.completion.python" />
+    <module name="intellij.ml.inline.completion.python.jupyter" />
+    <plugin id="com.intellij.modules.python" />
+    <module name="intellij.jupyter.psi" />
+    <module name="intellij.jupyter.core" />
+    <module name="intellij.jupyter.py" />
+    <module name="intellij.notebooks.core" />
+    <module name="intellij.notebooks.visualization" />
+    <module name="intellij.notebooks.jupyter.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.terraform.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.terraform.completion.cloud">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <plugin id="org.intellij.plugins.hcl" />
+    <module name="intellij.ml.inline.completion.terraform" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.cpp.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.cpp.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.inline.completion.cpp" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.sql.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.sql.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <plugin id="com.intellij.database" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.terminal"><![CDATA[<idea-plugin package="com.intellij.ml.llm.terminal">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.terminal" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.gitlab"><![CDATA[<idea-plugin package="com.intellij.ml.llm.gitlab">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.gitlab" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.github"><![CDATA[<idea-plugin package="com.intellij.ml.llm.github">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <plugin id="org.jetbrains.plugins.github" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <plugin id="com.intellij.modules.rider.cpp.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider.cpp"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider.cpp">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.rider" />
+    <plugin id="org.jetbrains.plugins.clion.radler" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider.cpp.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider.cpp.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.llm.rider" />
+    <module name="intellij.ml.inline.completion.rider.cpp" />
+    <plugin id="org.jetbrains.plugins.clion.radler" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider.csharp"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider.csharp">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.rider" />
+    <plugin id="com.jetbrains.rider.razor" />
+    <module name="intellij.ml.llm.javascript" />
+    <module name="intellij.rider.plugins.appender/lang" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider.csharp.completion"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider.csharp.completion">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.completion" />
+    <module name="intellij.ml.llm.rider" />
+    <module name="intellij.ml.inline.completion.rider.csharp" />
+    <plugin id="rider.intellij.plugin.appender" />
+    <plugin id="com.jetbrains.rider.razor" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.rider.csharp.razor"><![CDATA[<idea-plugin package="com.intellij.ml.llm.rider.csharp.razor">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.rider" />
+    <module name="intellij.ml.llm.rider.csharp" />
+    <plugin id="com.jetbrains.rider.razor" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.experiments"><![CDATA[<idea-plugin package="com.intellij.ml.llm.experiments">
+  <dependencies>
+    <module name="intellij.ml.llm.completion" />
+    <plugin id="com.intellij.ml.inline.completion" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.experiments.platformAb"><![CDATA[<idea-plugin package="com.intellij.ml.llm.experiments.platformAb">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.platform.experiment" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.platform.collaborationTools" />
+    <plugin id="com.intellij.modules.json" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.java.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.java.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="com.intellij.java" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.kotlin.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.kotlin.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="org.jetbrains.kotlin" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.python.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.python.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="com.intellij.modules.python" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.groovy.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.groovy.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="org.intellij.groovy" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.javascript.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.javascript.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="JavaScript" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.yaml.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.yaml.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="org.jetbrains.plugins.yaml" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.go.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.go.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="org.jetbrains.plugins.go" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.php.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.php.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="com.jetbrains.php" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.ruby.inlinePromptDetector"><![CDATA[<idea-plugin package="com.intellij.ml.llm.ruby.inlinePromptDetector">
+  <dependencies>
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.inlinePromptDetector" />
+    <plugin id="org.jetbrains.plugins.ruby" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.domains" loading="required"><![CDATA[<idea-plugin package="com.intellij.ml.llm.domains">
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.domains.ide"><![CDATA[<idea-plugin package="com.intellij.ml.llm.domains.ide">
+  <dependencies>
+    <plugin id="com.intellij.java" />
+    <plugin id="com.intellij.modules.ultimate" />
+    <plugin id="com.intellij.modules.idea.ultimate" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.privacy" />
+  </dependencies>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.vcs"><![CDATA[<idea-plugin package="com.intellij.ml.llm.vcs">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+    <module name="intellij.ml.llm.chatInputLanguage" />
+    <plugin id="Git4Idea" />
+  </dependencies>
+  <resource-bundle>messages.LLMVcsBundle</resource-bundle>
+</idea-plugin>]]></module>
+        <module name="intellij.ml.llm.provider.ollama"><![CDATA[<idea-plugin package="com.intellij.ml.llm.provider.ollama">
+  <dependencies>
+    <module name="intellij.ml.llm.privacy" />
+    <module name="intellij.ml.llm.core" />
+  </dependencies>
+</idea-plugin>]]></module>
+    </content>
+    <dependencies>
+        <plugin id="com.intellij.modules.platform" />
+    </dependencies>
+</idea-plugin>

--- a/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-single-module-in-cdata.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-single-module-in-cdata.xml
@@ -1,0 +1,18 @@
+<idea-plugin allow-bundled-update="true">
+    <id>com.intellij.ml.llm</id>
+    <version>251.SNAPSHOT</version>
+    <idea-version since-build="251.SNAPSHOT" until-build="251.SNAPSHOT" />
+    <name>JetBrains AI Assistant</name>
+    <vendor>JetBrains</vendor>
+    <description>JetBrains AI Assistant provides AI-powered features for software development based on the JetBrains AI Service.</description>
+    <content>
+        <module name="intellij.ml.llm.privacy"><![CDATA[<idea-plugin package="com.intellij.ml.llm.privacy">
+  <dependencies>
+    <module name="intellij.platform.vcs.impl" />
+  </dependencies>
+</idea-plugin>]]></module>
+    </content>
+    <dependencies>
+        <plugin id="com.intellij.modules.platform" />
+    </dependencies>
+</idea-plugin>


### PR DESCRIPTION
- Support v2 content module declarations in CDATA content.
- Support CDATA-based text representations in the v2 plugin module bean in the `content/module` elements.
- Until now, only file-based plugin descriptors were supported. Introduce a `DescriptorResource` indicating a plugin descriptor backed by an arbitrary `InputStream` identified by `URI` (usually a `file:` based).
- Introduce loading of modules from arbitrary `DescriptorResource` both in IDE plugins and `PkuginCreator`.
- Introduce two types of modules: file-based module (as per original spec) and an `InlineModule` backed by CDATA. Resolve both types of modules when creating a plugin.
- Introduce `PluginModuleResolver` that extracts away the v2 plugin module parsing.
- Introduce a _warning_ plugin problem `ModuleDescriptorProblem` indicating an issue with inline CDATA declaration.

See [MP-7092](https://youtrack.jetbrains.com/issue/MP-7092) 