### PR TITLE
Add validation for xml ids

### DIFF
--- a/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/Validator.kt
+++ b/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/Validator.kt
@@ -4,17 +4,15 @@
 
 package com.jetbrains.plugin.structure.dotnet
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.MAX_CHANGE_NOTES_LENGTH
-import com.jetbrains.plugin.structure.base.problems.MAX_NAME_LENGTH
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.validatePropertyLength
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.dotnet.beans.ReSharperPluginBean
 import com.jetbrains.plugin.structure.dotnet.problems.InvalidDependencyVersionError
 import com.jetbrains.plugin.structure.dotnet.problems.InvalidIdError
 import com.jetbrains.plugin.structure.dotnet.problems.InvalidVersionError
 import com.jetbrains.plugin.structure.dotnet.problems.NullIdDependencyError
 import com.jetbrains.plugin.structure.dotnet.version.VersionMatching
+
+private val ID_REGEX = "^([A-Za-z\\d\\-._-]+)\$".toRegex()
 
 internal fun validateDotNetPluginBean(bean: ReSharperPluginBean): List<PluginProblem> {
   val problems = mutableListOf<PluginProblem>()
@@ -24,6 +22,10 @@ internal fun validateDotNetPluginBean(bean: ReSharperPluginBean): List<PluginPro
 
   if (id.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("id"))
+  } else {
+    if (!ID_REGEX.matches(id)) {
+      problems.add(InvalidPluginIDProblem(id))
+    }
   }
 
   if (bean.getAllDependencies().any { it.id == "Wave" }) {

--- a/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/Validator.kt
+++ b/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/Validator.kt
@@ -12,7 +12,7 @@ import com.jetbrains.plugin.structure.dotnet.problems.InvalidVersionError
 import com.jetbrains.plugin.structure.dotnet.problems.NullIdDependencyError
 import com.jetbrains.plugin.structure.dotnet.version.VersionMatching
 
-private val ID_REGEX = "^([A-Za-z\\d\\-._-]+)\$".toRegex()
+private val ID_REGEX = "^([\\w\\-.]+)\$".toRegex()
 
 internal fun validateDotNetPluginBean(bean: ReSharperPluginBean): List<PluginProblem> {
   val problems = mutableListOf<PluginProblem>()

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -20,7 +20,7 @@ data class FleetPluginDescriptor(
   val meta: FleetMeta? = null,
 ) {
   companion object {
-    private val NON_ID_SYMBOL_REGEX = "^[A-Za-z\\d_.]+$".toRegex()
+    private val ID_REGEX = "^[\\w.]+$".toRegex()
 
     fun parse(serializedDescriptor: String): FleetPluginDescriptor {
       return jacksonObjectMapper().readValue(serializedDescriptor, FleetPluginDescriptor::class.java)
@@ -34,7 +34,7 @@ data class FleetPluginDescriptor(
         problems.add(PropertyNotSpecified("id"))
       }
 
-      !NON_ID_SYMBOL_REGEX.matches(id) -> {
+      !ID_REGEX.matches(id) -> {
         problems.add(InvalidPluginIDProblem(id))
       }
     }

--- a/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
+++ b/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
@@ -28,7 +28,7 @@ import kotlin.streams.asSequence
  */
 private val AUTHOR_REGEX = "^([^<(]+)\\s*(<[^>]+>)?\\s*(\\([^)]+\\))?\\s*$".toRegex()
 
-private val ID_REGEX = "^([A-Za-z\\d\\-._-]+)\$".toRegex()
+private val ID_REGEX = "^([\\w\\-.]+)\$".toRegex()
 
 internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProblem> {
   val problems = mutableListOf<PluginProblem>()

--- a/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
+++ b/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
@@ -28,11 +28,18 @@ import kotlin.streams.asSequence
  */
 private val AUTHOR_REGEX = "^([^<(]+)\\s*(<[^>]+>)?\\s*(\\([^)]+\\))?\\s*$".toRegex()
 
+private val ID_REGEX = "^([A-Za-z\\d\\-._-]+)\$".toRegex()
+
 internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProblem> {
   val problems = mutableListOf<PluginProblem>()
 
-  if (manifest.pluginId.isNullOrBlank()) {
+  val id = manifest.pluginId
+  if (id.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("key"))
+  } else {
+    if (!ID_REGEX.matches(id)) {
+      problems.add(InvalidPluginIDProblem(id))
+    }
   }
 
   if (manifest.pluginName.isNullOrBlank()) {

--- a/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
@@ -20,7 +20,7 @@ data class ToolboxPluginDescriptor(
   val meta: ToolboxMeta? = null,
 ) {
   companion object {
-    private val NON_ID_SYMBOL_REGEX = "^[A-Za-z\\d_.]+$".toRegex()
+    private val ID_REGEX = "^[\\w.]+$".toRegex()
 
     fun parse(serializedDescriptor: String): ToolboxPluginDescriptor {
       return jacksonObjectMapper().readValue(serializedDescriptor, ToolboxPluginDescriptor::class.java)
@@ -34,7 +34,7 @@ data class ToolboxPluginDescriptor(
         problems.add(PropertyNotSpecified("id"))
       }
 
-      !NON_ID_SYMBOL_REGEX.matches(id) -> {
+      !ID_REGEX.matches(id) -> {
         problems.add(InvalidPluginIDProblem(id))
       }
     }

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
@@ -9,7 +9,7 @@ import com.jetbrains.plugin.structure.youtrack.problems.*
 import com.vdurmont.semver4j.Semver
 
 
-private val ID_REGEX = "^([a-z\\d\\-._~]+)\$".toRegex()
+private val ID_REGEX = "^([a-z\\d\\-._]+)\$".toRegex()
 
 fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem> {
   val problems = mutableListOf<PluginProblem>()

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/problems/YouTrackPluginErrors.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/problems/YouTrackPluginErrors.kt
@@ -47,7 +47,7 @@ open class InvalidWidgetKeyProblem(message: String) : InvalidDescriptorProblem(
 
 class UnsupportedSymbolsWidgetKeyProblem(key: String) : InvalidWidgetKeyProblem(
   "The app widget key '$key' contains unsupported symbols. " +
-    "Please use lowercase characters, numbers, and '.'/'-'/'_'/'~' symbols only."
+    "Please use lowercase characters, numbers, and '.'/'-'/'_' symbols only."
 )
 
 open class WidgetKeyNotSpecified : InvalidDescriptorProblem(

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/dotnet/mock/DotNetPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/dotnet/mock/DotNetPluginTest.kt
@@ -216,7 +216,8 @@ class DotNetPluginTest(fileSystemType: FileSystemType) : BasePluginManagerTest<R
     val invalidIds = listOf(
       "abc1324_.-",
       "abc.123",
-      "ABC.123"
+      "ABC.123",
+      "test-test.test-test"
     )
     invalidIds.forEach {
       testValidPluginXML(perfectDotNetBuilder.modify { id = "<id>$it</id>" }) {}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubInvalidPluginsTest.kt
@@ -63,6 +63,26 @@ class HubInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerT
   }
 
   @Test
+  fun `invalid id`() {
+    val invalidIds = listOf(
+      "hello!world",
+      "123@abc",
+      "A#B%",
+      "first second",
+      "newline\nhere",
+      "tab\there",
+      "slash/backslash",
+      "colon:semicolon;",
+      "quote\"apostrophe'",
+      "test~test"
+    )
+
+    invalidIds.forEach {
+      checkInvalidPlugin(InvalidPluginIDProblem(it)) { key = it }
+    }
+  }
+
+  @Test
   fun `name is not specified`() {
     checkInvalidPlugin(PropertyNotSpecified("name")) { name = null }
     checkInvalidPlugin(PropertyNotSpecified("name")) { name = "" }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubMockPluginBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubMockPluginBuilder.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.plugin.structure.hub.mock
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
 data class HubPluginJsonBuilder(
     var key: String? = "key",
     var name: String? = "name",
@@ -12,15 +14,7 @@ data class HubPluginJsonBuilder(
     var products: Map<String, String>? = mapOf("a" to "1.0"),
     var view: Map<String, String>? = emptyMap()
 ) {
-
-  private fun Map<*, *>.asJson(indent: String = ""): String =
-    entries.joinToString(prefix = "$indent{\n", postfix = "\n$indent}", separator = ",\n") { (key, value) ->
-      "$indent  " + when (value) {
-        is String -> """"$key": "$value""""
-        is Map<*, *> -> """"$key": ${value.asJson("$indent  ")}"""
-        else -> ""
-      }
-    }
+  private val objectMapper = jacksonObjectMapper()
 
   fun asString(): String {
     val nonEmptyKeyValues = mapOf(
@@ -35,7 +29,7 @@ data class HubPluginJsonBuilder(
       "products" to products,
       "view" to view
     ).filterValues { value -> value != null }
-    return nonEmptyKeyValues.asJson()
+    return objectMapper.writeValueAsString(nonEmptyKeyValues)
   }
 }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -100,10 +100,11 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `invalid widget key`() {
-    val widgets = listOf(widget.copy(key = "AAA"), widget.copy(key = "???"), widget.copy("a.b_c-d~1"))
+    val widgets = listOf(widget.copy(key = "AAA"), widget.copy(key = "???"), widget.copy("a.b_c-d~1"), widget.copy("a.b_c-d123"))
     checkInvalidPlugin(
       UnsupportedSymbolsWidgetKeyProblem("AAA"),
-      UnsupportedSymbolsWidgetKeyProblem("???")
+      UnsupportedSymbolsWidgetKeyProblem("???"),
+      UnsupportedSymbolsWidgetKeyProblem("a.b_c-d~1")
     ) { it.copy(widgets = widgets) }
   }
 


### PR DESCRIPTION
Validate plugin identifiers for Hub, YouTrack and .NET plugins. 

- For .NET and Hub: Allow alphanumeric characters, dash (`-`), dot `.`, underscore (`_`).
- For YouTrack: Allow lowercase alphanumeric characters, dash (`-`), dot `.`, underscore (`_`).
