### PR TITLE
Plugin Verifier cannot find org.jetbrains.android plugin

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
@@ -6,7 +6,10 @@ import java.nio.file.Path
 class DispatchingIdeManager(configuration: IdeManagerConfiguration = IdeManagerConfiguration()) : IdeManager() {
   private val standardIdeManager = IdeManagerImpl()
 
-  private val productInfoBasedIdeManager = ProductInfoBasedIdeManager(configuration.missingLayoutFileMode)
+  private val productInfoBasedIdeManager = ProductInfoBasedIdeManager(
+    missingLayoutFileMode = configuration.missingLayoutFileMode,
+    additionalPluginReader = UndeclaredInLayoutPluginReader(supportedProductCodes = setOf("AI")),
+  )
 
   override fun createIde(idePath: Path): Ide = createIde(idePath, version = null)
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -96,7 +96,7 @@ class IdeManagerImpl : IdeManager() {
    * But rarely `nearby.xml` may reside in another platform's jar file. Apparently, IDE handles such a case accidentally:
    * an ugly fallback hack is used `com.intellij.util.io.URLUtil.openResourceStream(URL)`.
    */
-  private class PlatformResourceResolver(platformJarFiles: List<Path>) : ResourceResolver {
+  class PlatformResourceResolver(platformJarFiles: List<Path>) : ResourceResolver {
     private val jarFilesResourceResolver = JarFilesResourceResolver(platformJarFiles)
 
     override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -94,7 +94,7 @@ class IdeManagerImpl : IdeManager() {
    * But rarely `nearby.xml` may reside in another platform's jar file. Apparently, IDE handles such a case accidentally:
    * an ugly fallback hack is used `com.intellij.util.io.URLUtil.openResourceStream(URL)`.
    */
-  class PlatformResourceResolver(val platformJarFiles: List<Path>, platformModuleJarFiles: List<Path>) : ResourceResolver {
+  internal class PlatformResourceResolver(val platformJarFiles: List<Path>, platformModuleJarFiles: List<Path>) : ResourceResolver {
     private val jarFilesResourceResolver = JarFilesResourceResolver(platformJarFiles + platformModuleJarFiles)
 
     override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -66,11 +66,9 @@ class IdeManagerImpl : IdeManager() {
   }
 
   private fun readDistributionBundledPlugins(idePath: Path, product: IntelliJPlatformProduct, ideVersion: IdeVersion): List<IdePlugin> {
-    val platformJarFiles = idePath.resolve("lib").listJars()
-    val platformModuleJarFiles = idePath.resolve("lib").resolve("modules").listJars()
-    val platformResourceResolver = PlatformResourceResolver(platformJarFiles + platformModuleJarFiles)
+    val platformResourceResolver = PlatformResourceResolver.of(idePath)
     val bundledPlugins = readBundledPlugins(idePath, platformResourceResolver, ideVersion)
-    val platformPlugins = readPlatformPlugins(idePath, product, platformJarFiles, platformResourceResolver, ideVersion)
+    val platformPlugins = readPlatformPlugins(idePath, product, platformResourceResolver.platformJarFiles, platformResourceResolver, ideVersion)
     return bundledPlugins + platformPlugins
   }
 
@@ -96,8 +94,8 @@ class IdeManagerImpl : IdeManager() {
    * But rarely `nearby.xml` may reside in another platform's jar file. Apparently, IDE handles such a case accidentally:
    * an ugly fallback hack is used `com.intellij.util.io.URLUtil.openResourceStream(URL)`.
    */
-  class PlatformResourceResolver(platformJarFiles: List<Path>) : ResourceResolver {
-    private val jarFilesResourceResolver = JarFilesResourceResolver(platformJarFiles)
+  class PlatformResourceResolver(val platformJarFiles: List<Path>, platformModuleJarFiles: List<Path>) : ResourceResolver {
+    private val jarFilesResourceResolver = JarFilesResourceResolver(platformJarFiles + platformModuleJarFiles)
 
     override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {
       val resolveResult = jarFilesResourceResolver.resolveResource(relativePath, basePath)
@@ -116,6 +114,14 @@ class IdeManagerImpl : IdeManager() {
         return jarFilesResourceResolver.resolveResource("/META-INF/$relativePath", basePath)
       }
       return ResourceResolver.Result.NotFound
+    }
+
+    companion object {
+      fun of(idePath: Path): PlatformResourceResolver {
+        val platformJarFiles = idePath.resolve("lib").listJars()
+        val platformModuleJarFiles = idePath.resolve("lib").resolve("modules").listJars()
+        return PlatformResourceResolver(platformJarFiles, platformModuleJarFiles)
+      }
     }
   }
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/UndeclaredInLayoutPluginReader.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/UndeclaredInLayoutPluginReader.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.ide.IdeManagerImpl.PlatformResourceResolver
+import com.jetbrains.plugin.structure.ide.plugin.DefaultPluginIdProvider
+import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
+import com.jetbrains.plugin.structure.intellij.plugin.BundledPluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArtifactPath
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(UndeclaredInLayoutPluginReader::class.java)
+
+class UndeclaredInLayoutPluginReader(private val supportedProductCodes: Set<String>) : ProductInfoBasedIdeManager.PluginReader {
+  private val pluginIdProvider = DefaultPluginIdProvider()
+
+  private val bundledPluginManager = BundledPluginManager(pluginIdProvider)
+
+  override fun readPlugins(idePath: Path, productInfo: ProductInfo, ideVersion: IdeVersion): List<IdePlugin> {
+    if (!supports(productInfo)) return emptyList()
+
+    val resourceResolver = PlatformResourceResolver.of(idePath)
+
+    val identifiersInPluginsDir = bundledPluginManager.getBundledPluginIds(idePath)
+    val identifiersInLayout = productInfo.layout.map { it.name }
+
+    return identifiersInPluginsDir
+      .filterNotIn(identifiersInLayout)
+      .mapNotNull {
+        try {
+          createBundledPlugin(idePath, it.path, resourceResolver, ideVersion)
+        } catch (e: InvalidIdeException) {
+          // TODO layout issues log level should be configurable
+          LOG.debug(e.reason)
+          null
+        }
+      }
+  }
+
+  private fun supports(product: ProductInfo): Boolean = product.productCode in supportedProductCodes
+
+  private fun Set<PluginArtifactPath>.filterNotIn(layoutIdentifiers: List<String>): List<PluginArtifactPath> {
+    return filterNot { it.pluginId in layoutIdentifiers }
+  }
+
+  @Throws(InvalidIdeException::class)
+  private fun createBundledPlugin(
+    idePath: Path,
+    pluginFile: Path,
+    resourceResolver: ResourceResolver,
+    ideVersion: IdeVersion
+  ): IdePlugin = when (val creationResult = IdePluginManager
+    .createManager(resourceResolver)
+    // TODO consolidate bundled plugin construction across multiple invocations
+    .createBundledPlugin(
+      pluginFile,
+      ideVersion,
+      PLUGIN_XML,
+      problemResolver = AnyProblemToWarningPluginCreationResultResolver
+    )
+  ) {
+    is PluginCreationSuccess -> creationResult.plugin
+    is PluginCreationFail -> throw InvalidIdeException(
+      idePath,
+      "Plugin '${idePath.relativize(pluginFile)}' is invalid: " +
+        creationResult.errorsAndWarnings.filter { it.level == PluginProblem.Level.ERROR }.joinToString { it.message }
+    )
+  }
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleLoadingContext.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleLoadingContext.kt
@@ -1,5 +1,8 @@
 package com.jetbrains.plugin.structure.ide.layout
 
+import com.jetbrains.plugin.structure.base.utils.exists
 import java.nio.file.Path
 
-internal data class ModuleLoadingContext(val artifactPath: Path, val descriptorName: String)
+internal data class ModuleLoadingContext(val artifactPath: Path, val descriptorName: String) {
+  fun exists(): Boolean = artifactPath.exists()
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
@@ -17,13 +17,14 @@ import javax.xml.stream.XMLStreamConstants.COMMENT
 import javax.xml.stream.XMLStreamConstants.START_DOCUMENT
 
 private const val pluginIdXPath = "/idea-plugin/id"
+private const val pluginNameXPath = "/idea-plugin/name"
 
 class DefaultPluginIdProvider : PluginIdProvider {
   private val xmlStreamEventFilter = XmlStreamEventFilter()
 
   @Throws(IOException::class)
   override fun getPluginId(pluginDescriptorStream: InputStream): String {
-    val elementTextContentFilter = ElementTextContentFilter(pluginIdXPath)
+    val elementTextContentFilter = ElementTextContentFilter(listOf(pluginIdXPath, pluginNameXPath))
     val eventFilter = mutableListOf<EventFilter>().apply {
       add(elementTextContentFilter)
       add(EventTypeExcludingEventFilter(START_DOCUMENT))

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
@@ -39,7 +39,7 @@ class DefaultPluginIdProvider : PluginIdProvider {
 
   private fun getPluginId(elementTextContentFilter: ElementTextContentFilter): String {
     return elementTextContentFilter.captureGroups.values.firstOrNull()
-      ?: throw MissingPluginIdException("Neither plugin ID nor plugin is set in the plugin descriptor")
+      ?: throw MissingPluginIdException("Neither plugin ID nor plugin name is set in the plugin descriptor")
   }
 
   private object NullOutputStream : OutputStream() {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
@@ -22,7 +22,7 @@ private const val pluginNameXPath = "/idea-plugin/name"
 class DefaultPluginIdProvider : PluginIdProvider {
   private val xmlStreamEventFilter = XmlStreamEventFilter()
 
-  @Throws(IOException::class)
+  @Throws(IOException::class, MissingPluginIdException::class)
   override fun getPluginId(pluginDescriptorStream: InputStream): String {
     val elementTextContentFilter = ElementTextContentFilter(listOf(pluginIdXPath, pluginNameXPath))
     val eventFilter = mutableListOf<EventFilter>().apply {
@@ -34,7 +34,12 @@ class DefaultPluginIdProvider : PluginIdProvider {
 
     xmlStreamEventFilter.filter(eventFilter, pluginDescriptorStream, NullOutputStream)
 
-    return elementTextContentFilter.value
+    return getPluginId(elementTextContentFilter)
+  }
+
+  private fun getPluginId(elementTextContentFilter: ElementTextContentFilter): String {
+    return elementTextContentFilter.captureGroups.values.firstOrNull()
+      ?: throw MissingPluginIdException("Neither plugin ID nor plugin is set in the plugin descriptor")
   }
 
   private object NullOutputStream : OutputStream() {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
@@ -1,5 +1,10 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide.plugin
 
+import com.jetbrains.plugin.structure.intellij.plugin.PluginIdProvider
 import com.jetbrains.plugin.structure.xml.ElementTextContentFilter
 import com.jetbrains.plugin.structure.xml.EventTypeExcludingEventFilter
 import com.jetbrains.plugin.structure.xml.LogicalAndXmlEventFilter
@@ -13,11 +18,11 @@ import javax.xml.stream.XMLStreamConstants.START_DOCUMENT
 
 private const val pluginIdXPath = "/idea-plugin/id"
 
-class PluginIdExtractor {
+class DefaultPluginIdProvider : PluginIdProvider {
   private val xmlStreamEventFilter = XmlStreamEventFilter()
 
   @Throws(IOException::class)
-  fun extractId(pluginXmlInputStream: InputStream): String {
+  override fun getPluginId(pluginDescriptorStream: InputStream): String {
     val elementTextContentFilter = ElementTextContentFilter(pluginIdXPath)
     val eventFilter = mutableListOf<EventFilter>().apply {
       add(elementTextContentFilter)
@@ -26,7 +31,7 @@ class PluginIdExtractor {
     }
       .let { LogicalAndXmlEventFilter(it) }
 
-    xmlStreamEventFilter.filter(eventFilter, pluginXmlInputStream, NullOutputStream)
+    xmlStreamEventFilter.filter(eventFilter, pluginDescriptorStream, NullOutputStream)
 
     return elementTextContentFilter.value
   }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/MissingPluginIdException.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/MissingPluginIdException.kt
@@ -1,0 +1,3 @@
+package com.jetbrains.plugin.structure.ide.plugin
+
+class MissingPluginIdException(message: String) : RuntimeException(message)

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/PluginIdExtractor.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/PluginIdExtractor.kt
@@ -1,0 +1,37 @@
+package com.jetbrains.plugin.structure.ide.plugin
+
+import com.jetbrains.plugin.structure.xml.ElementTextContentFilter
+import com.jetbrains.plugin.structure.xml.EventTypeExcludingEventFilter
+import com.jetbrains.plugin.structure.xml.LogicalAndXmlEventFilter
+import com.jetbrains.plugin.structure.xml.XmlStreamEventFilter
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import javax.xml.stream.EventFilter
+import javax.xml.stream.XMLStreamConstants.COMMENT
+import javax.xml.stream.XMLStreamConstants.START_DOCUMENT
+
+private const val pluginIdXPath = "/idea-plugin/id"
+
+class PluginIdExtractor {
+  private val xmlStreamEventFilter = XmlStreamEventFilter()
+
+  @Throws(IOException::class)
+  fun extractId(pluginXmlInputStream: InputStream): String {
+    val elementTextContentFilter = ElementTextContentFilter(pluginIdXPath)
+    val eventFilter = mutableListOf<EventFilter>().apply {
+      add(elementTextContentFilter)
+      add(EventTypeExcludingEventFilter(START_DOCUMENT))
+      add(EventTypeExcludingEventFilter(COMMENT))
+    }
+      .let { LogicalAndXmlEventFilter(it) }
+
+    xmlStreamEventFilter.filter(eventFilter, pluginXmlInputStream, NullOutputStream)
+
+    return elementTextContentFilter.value
+  }
+
+  private object NullOutputStream : OutputStream() {
+    override fun write(b: Int) = Unit
+  }
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementNamesFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementNamesFilter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.xml
@@ -45,32 +45,4 @@ class ElementNamesFilter(private val elementLocalNames: List<String>) : Deduplic
   }
 
   private val isRoot: Boolean get() = eventStack.size == 1
-
-  private class ElementStack {
-    private val stack = ArrayDeque<StartElement>()
-
-    val size: Int get() = stack.size
-
-    fun push(event: StartElement) {
-      if (isEmpty() || peek() !== event) {
-        // no need to push the same event twice
-        stack.addLast(event)
-      }
-    }
-
-    fun popIf(currentEvent: EndElement) {
-      if (isEmpty()) return
-      val peek = stack.last()
-      if (peek.name == currentEvent.name) {
-        stack.removeLast()
-      }
-    }
-
-    fun isEmpty() = stack.isEmpty()
-
-    @Throws(NoSuchElementException::class)
-    fun peek(): StartElement = stack.last()
-
-    fun toPath() = stack.joinToString(prefix = "/", separator = "/") { it.name.localPart }
-  }
 }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementStack.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementStack.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.xml
+
+import javax.xml.stream.events.EndElement
+import javax.xml.stream.events.StartElement
+
+internal class ElementStack {
+    private val stack = ArrayDeque<StartElement>()
+
+    val size: Int get() = stack.size
+
+    fun push(event: StartElement) {
+      if (isEmpty() || peek() !== event) {
+        // no need to push the same event twice
+        stack.addLast(event)
+      }
+    }
+
+    fun popIf(currentEvent: EndElement) {
+      if (isEmpty()) return
+      val peek = stack.last()
+      if (peek.name == currentEvent.name) {
+        stack.removeLast()
+      }
+    }
+
+    fun isEmpty() = stack.isEmpty()
+
+    @Throws(NoSuchElementException::class)
+    fun peek(): StartElement = stack.last()
+
+    fun toPath() = stack.joinToString(prefix = "/", separator = "/") { it.name.localPart }
+  }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.xml
 
 import java.util.*

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
@@ -1,18 +1,25 @@
 package com.jetbrains.plugin.structure.xml
 
+import java.util.*
 import javax.xml.stream.events.Characters
 import javax.xml.stream.events.EndElement
 import javax.xml.stream.events.StartElement
 import javax.xml.stream.events.XMLEvent
 
-class ElementTextContentFilter(private val elementXPath: String) : DeduplicatingEventFilter() {
+class ElementTextContentFilter(private val elementXPaths: List<String>) : DeduplicatingEventFilter() {
   private val eventStack = ElementStack()
 
   private var isAccepting = true
 
-  private var captureCompleted = false
+  private val captureCompleted
+    get() = captureGroups.size == elementXPaths.size
 
   private val capturedContent = StringBuilder()
+
+  // The ordering of keys in this map matches the ordering of values in the `elementXPaths`.
+  private val captureGroups = TreeMap<String, String> { key, otherKey ->
+    elementXPaths.indexOf(key).compareTo(elementXPaths.indexOf(otherKey))
+  }
 
   override fun doAccept(event: XMLEvent): Boolean = if (captureCompleted) false else {
     when (event) {
@@ -23,8 +30,12 @@ class ElementTextContentFilter(private val elementXPath: String) : Deduplicating
       }
 
       is EndElement -> {
+        if (matchesXPath()) {
+          val xPath = eventStack.toPath()
+          captureGroups[xPath] = capturedContent.toString().trim()
+          capturedContent.clear()
+        }
         eventStack.popIf(currentEvent = event)
-        if (matchesXPath()) captureCompleted = true
         isAccepting = false
         isAccepting
       }
@@ -42,7 +53,10 @@ class ElementTextContentFilter(private val elementXPath: String) : Deduplicating
     }
   }
 
-  private fun matchesXPath(): Boolean = elementXPath == eventStack.toPath()
+  private fun matchesXPath(): Boolean {
+    val xPath = eventStack.toPath()
+    return elementXPaths.any { it == xPath }
+  }
 
-  val value: String get() = capturedContent.toString().trim()
+  val value: String get() = captureGroups.values.first()
 }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
@@ -19,7 +19,7 @@ class ElementTextContentFilter(private val elementXPaths: List<String>) : Dedupl
   private val capturedContent = StringBuilder()
 
   // The ordering of keys in this map matches the ordering of values in the `elementXPaths`.
-  private val captureGroups = TreeMap<String, String> { key, otherKey ->
+  val captureGroups: SortedMap<String, String> = TreeMap<String, String> { key, otherKey ->
     elementXPaths.indexOf(key).compareTo(elementXPaths.indexOf(otherKey))
   }
 
@@ -51,6 +51,4 @@ class ElementTextContentFilter(private val elementXPaths: List<String>) : Dedupl
     val xPath = eventStack.toPath()
     return elementXPaths.any { it == xPath }
   }
-
-  val value: String get() = captureGroups.values.first()
 }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
@@ -9,8 +9,6 @@ import javax.xml.stream.events.XMLEvent
 class ElementTextContentFilter(private val elementXPaths: List<String>) : DeduplicatingEventFilter() {
   private val eventStack = ElementStack()
 
-  private var isAccepting = true
-
   private val captureCompleted
     get() = captureGroups.size == elementXPaths.size
 
@@ -25,8 +23,6 @@ class ElementTextContentFilter(private val elementXPaths: List<String>) : Dedupl
     when (event) {
       is StartElement -> {
         eventStack.push(event)
-        isAccepting = matchesXPath()
-        isAccepting
       }
 
       is EndElement -> {
@@ -36,21 +32,15 @@ class ElementTextContentFilter(private val elementXPaths: List<String>) : Dedupl
           capturedContent.clear()
         }
         eventStack.popIf(currentEvent = event)
-        isAccepting = false
-        isAccepting
       }
 
       is Characters -> {
-        if (isAccepting) {
+        if (matchesXPath()) {
           capturedContent.append(event.data)
         }
-        isAccepting
-      }
-
-      else -> {
-        isAccepting
       }
     }
+    true
   }
 
   private fun matchesXPath(): Boolean {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/xml/ElementTextContentFilter.kt
@@ -1,0 +1,45 @@
+package com.jetbrains.plugin.structure.xml
+
+import javax.xml.stream.events.Characters
+import javax.xml.stream.events.EndElement
+import javax.xml.stream.events.StartElement
+import javax.xml.stream.events.XMLEvent
+
+class ElementTextContentFilter(private val elementXPath: String) : DeduplicatingEventFilter() {
+  private val eventStack = ElementStack()
+
+  private var isAccepting = true
+
+  private val capturedContent = StringBuilder()
+
+  override fun doAccept(event: XMLEvent): Boolean = when (event) {
+    is StartElement -> {
+      eventStack.push(event)
+      isAccepting = supports()
+      isAccepting
+    }
+
+    is EndElement -> {
+      isAccepting = supports()
+      eventStack.popIf(currentEvent = event)
+      isAccepting
+    }
+
+    is Characters -> {
+      if (isAccepting) {
+        capturedContent.append(event.data)
+      }
+      isAccepting
+    }
+
+    else -> {
+      isAccepting
+    }
+  }
+
+  private fun supports(): Boolean {
+    return elementXPath == eventStack.toPath()
+  }
+
+  val value: String get() = capturedContent.toString().trim()
+}

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdExtractorTests.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdExtractorTests.kt
@@ -1,0 +1,43 @@
+package com.jetbrains.plugin.structure.ide.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PluginIdExtractorTests {
+  @Test
+  fun `plugin XML ID is extracted`() {
+    val pluginXml = """
+        <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+          <name>Java</name>
+          <id>com.intellij.java</id>
+        </idea-plugin>
+    """.trimIndent()
+
+    val pluginIdExtractor = PluginIdExtractor()
+    val pluginId = pluginIdExtractor.extractId(pluginXml.byteInputStream())
+
+    assertEquals("com.intellij.java", pluginId)
+  }
+
+  @Test
+  fun `plugin XML ID is extracted when there is inline CDATA with ID`() {
+    val pluginXml = """
+        <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+          <name>Java</name>
+          <id>com.intellij.java</id>
+          <content>
+            <module name="intellij.ml.llm.privacy"><![CDATA[
+              <idea-plugin package="com.intellij.ml.llm.privacy">
+                <id>com.intellij.ml.llm.privacy</id>
+              </idea-plugin>]]>
+            </module>
+          </content>                      
+        </idea-plugin>
+    """.trimIndent()
+
+    val pluginIdExtractor = PluginIdExtractor()
+    val pluginId = pluginIdExtractor.extractId(pluginXml.byteInputStream())
+
+    assertEquals("com.intellij.java", pluginId)
+  }
+}

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
@@ -3,7 +3,9 @@ package com.jetbrains.plugin.structure.ide.plugin
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class PluginIdExtractorTests {
+class PluginIdProviderTest {
+  private val pluginIdProvider = DefaultPluginIdProvider()
+
   @Test
   fun `plugin XML ID is extracted`() {
     val pluginXml = """
@@ -13,9 +15,7 @@ class PluginIdExtractorTests {
         </idea-plugin>
     """.trimIndent()
 
-    val pluginIdExtractor = PluginIdExtractor()
-    val pluginId = pluginIdExtractor.extractId(pluginXml.byteInputStream())
-
+    val pluginId = pluginIdProvider.getPluginId(pluginXml.byteInputStream())
     assertEquals("com.intellij.java", pluginId)
   }
 
@@ -35,9 +35,7 @@ class PluginIdExtractorTests {
         </idea-plugin>
     """.trimIndent()
 
-    val pluginIdExtractor = PluginIdExtractor()
-    val pluginId = pluginIdExtractor.extractId(pluginXml.byteInputStream())
-
+    val pluginId = pluginIdProvider.getPluginId(pluginXml.byteInputStream())
     assertEquals("com.intellij.java", pluginId)
   }
 }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.plugin.structure.ide.plugin
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class PluginIdProviderTest {
@@ -49,5 +50,17 @@ class PluginIdProviderTest {
 
     val pluginId = pluginIdProvider.getPluginId(pluginXml.byteInputStream())
     assertEquals("Java", pluginId)
+  }
+
+  @Test
+  fun `plugin XML ID is not extracted, since neither 'name' nor 'id' is available`() {
+    val pluginXml = """
+        <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+        </idea-plugin>
+    """.trimIndent()
+
+    assertThrows(MissingPluginIdException::class.java) {
+      pluginIdProvider.getPluginId(pluginXml.byteInputStream())
+    }
   }
 }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/plugin/PluginIdProviderTest.kt
@@ -38,4 +38,16 @@ class PluginIdProviderTest {
     val pluginId = pluginIdProvider.getPluginId(pluginXml.byteInputStream())
     assertEquals("com.intellij.java", pluginId)
   }
+
+  @Test
+  fun `plugin XML ID is extracted from 'name' when 'id' is missing`() {
+    val pluginXml = """
+        <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+          <name>Java</name>
+        </idea-plugin>
+    """.trimIndent()
+
+    val pluginId = pluginIdProvider.getPluginId(pluginXml.byteInputStream())
+    assertEquals("Java", pluginId)
+  }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
@@ -12,7 +12,6 @@ import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.intellij.plugin.jar.PluginDescriptorProvider
 import com.jetbrains.plugin.structure.intellij.problems.PluginLibDirectoryIsEmpty
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
-import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
@@ -61,14 +60,8 @@ class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
 
   @Throws(BundledPluginException::class)
   private fun loadPluginIdFromJar(jarPath: Path): String? {
-    val descriptorResult = descriptorProvider.getDescriptorFromJar(jarPath)
-    return if (descriptorResult is PluginDescriptorResult.Found) {
-      descriptorResult.inputStream.use {
-        pluginIdProvider.getPluginId(it)
-      }
-    } else {
-      // JAR does not contain the plugin.xml, skip it.
-      null
+    return descriptorProvider.resolveFromJar(jarPath) { (_, inputStream) ->
+      pluginIdProvider.getPluginId(inputStream)
     }
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
@@ -1,0 +1,77 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.base.utils.listJars
+import com.jetbrains.plugin.structure.intellij.plugin.jar.PluginDescriptorProvider
+import com.jetbrains.plugin.structure.intellij.problems.PluginLibDirectoryIsEmpty
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+private val LOG = LoggerFactory.getLogger(BundledPluginManager::class.java)
+
+class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
+  private val descriptorProvider = PluginDescriptorProvider()
+
+  fun getBundledPluginIds(idePath: Path): Set<String> {
+    return readBundledPluginsIds(idePath)
+  }
+
+  private fun readBundledPluginsIds(
+    idePath: Path
+  ): Set<String> {
+    return idePath
+      .resolve("plugins")
+      .listFiles()
+      .filter { it.isDirectory }
+      .mapNotNull { resolveBundledPluginId(idePath, it) }
+      .toSet()
+  }
+
+  private fun resolveBundledPluginId(idePath: Path, pluginDirectory: Path): String? {
+    return try {
+      loadPluginIdFromDirectory(pluginDirectory)
+    } catch (e: BundledPluginException) {
+      LOG.debug("Plugin [{}] has invalid descriptor: {}", pluginDirectory, e.message)
+       null
+    }
+  }
+
+  @Throws(BundledPluginException::class)
+  private fun loadPluginIdFromDirectory(pluginPath: Path): String? {
+    val libDir: Path = pluginPath.resolve("lib")
+    if (!libDir.isDirectory) {
+      throw BundledPluginException(PluginDescriptorIsNotFound(PLUGIN_XML))
+    }
+    val jars = libDir.listJars()
+    if (jars.isEmpty()) {
+      throw BundledPluginException(PluginLibDirectoryIsEmpty())
+    }
+    for (jarPath in jars) {
+      val pluginId = loadPluginIdFromJar(jarPath)
+      if (pluginId != null) {
+        return pluginId
+      }
+    }
+    return null
+  }
+
+  @Throws(BundledPluginException::class)
+  private fun loadPluginIdFromJar(jarPath: Path): String? {
+    val descriptorResult = descriptorProvider.getDescriptorFromJar(jarPath)
+    return if (descriptorResult is PluginDescriptorResult.Found) {
+      descriptorResult.inputStream.use {
+        pluginIdProvider.getPluginId(it)
+      }
+    } else {
+      // JAR does not contain the plugin.xml, skip it.
+      null
+    }
+  }
+
+  private class BundledPluginException(val problem: PluginProblem) : RuntimeException()
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
@@ -17,6 +17,9 @@ import java.nio.file.Path
 
 private val LOG = LoggerFactory.getLogger(BundledPluginManager::class.java)
 
+private const val PLUGINS_DIRECTORY = "plugins"
+private const val LIB_DIRECTORY = "lib"
+
 class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
   private val descriptorProvider = PluginDescriptorProvider()
 
@@ -28,7 +31,7 @@ class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
     idePath: Path
   ): Set<PluginArtifactPath> {
     return idePath
-      .resolve("plugins")
+      .resolve(PLUGINS_DIRECTORY)
       .listFiles()
       .filter { it.isDirectory }
       .mapNotNull { resolveBundledPluginId(it) }
@@ -67,7 +70,7 @@ class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
 
   @Throws(BundledPluginException::class)
   private fun getPluginJars(pluginPath: Path): List<Path> {
-    val libDir: Path = pluginPath.resolve("lib")
+    val libDir: Path = pluginPath.resolve(LIB_DIRECTORY)
     if (!libDir.isDirectory) {
       throw BundledPluginException(PluginDescriptorIsNotFound(PLUGIN_XML))
     }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
@@ -31,11 +31,11 @@ class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
       .resolve("plugins")
       .listFiles()
       .filter { it.isDirectory }
-      .mapNotNull { resolveBundledPluginId(idePath, it) }
+      .mapNotNull { resolveBundledPluginId(it) }
       .toSet()
   }
 
-  private fun resolveBundledPluginId(idePath: Path, pluginDirectory: Path): PluginArtifactPath? {
+  private fun resolveBundledPluginId(pluginDirectory: Path): PluginArtifactPath? {
     return try {
       loadPluginIdFromDirectory(pluginDirectory)?.let {
         PluginArtifactPath(it, pluginDirectory)
@@ -78,5 +78,8 @@ class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
     return jars
   }
 
-  private class BundledPluginException(val problem: PluginProblem) : RuntimeException()
+  private class BundledPluginException(val problem: PluginProblem) : RuntimeException() {
+    override val message: String
+      get() = problem.message
+  }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginArtifactPath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginArtifactPath.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import java.nio.file.Path
+
+data class PluginArtifactPath(val pluginId: String, val path: Path)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginIdProvider.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import java.io.InputStream
+
+interface PluginIdProvider {
+  fun getPluginId(pluginDescriptorStream: InputStream): String
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/jar/PluginDescriptorProvider.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/jar/PluginDescriptorProvider.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.jar
+
+import com.jetbrains.plugin.structure.base.utils.getShortExceptionMessage
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
+import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
+import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Failed
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
+import com.jetbrains.plugin.structure.jar.PluginJar
+import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+import kotlin.io.inputStream
+import kotlin.use
+
+private val LOG = LoggerFactory.getLogger(PluginDescriptorProvider::class.java)
+
+class PluginDescriptorProvider(private val fileSystemProvider: JarFileSystemProvider = SingletonCachingJarFileSystemProvider) {
+  fun getDescriptorFromJar(
+    jarFile: Path,
+    descriptorPath: String = "$META_INF/$PLUGIN_XML",
+  ): PluginDescriptorResult = try {
+    PluginJar(jarFile, fileSystemProvider).use { jar ->
+      when (val descriptor = jar.getPluginDescriptor(descriptorPath)) {
+        is Found -> descriptor.clone()
+        else -> descriptor.also {
+          LOG.debug("Unable to resolve descriptor [{}] from [{}] ({})", descriptorPath, jarFile, descriptor)
+        }
+      }
+    }
+  } catch (e: JarArchiveCannotBeOpenException) {
+    LOG.warn("Unable to extract {} (searching for {}): {}", jarFile, descriptorPath, e.getShortExceptionMessage())
+    Failed(jarFile, e)
+  }
+
+  private fun Found.clone(): Found = inputStream.use {
+    Found(this.path, it.readAllBytes().inputStream())
+  }
+}
+

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/MockIdeBuilder.kt
@@ -202,37 +202,17 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
         "bundledPlugins": [],
         "modules": [],
         "fileExtensions": [],
-        "layout": [
-          {
-            "name": "intellij.notebooks.ui",
-            "kind": "productModuleV2",
-            "classPath": [
-              "lib/modules/intellij.notebooks.ui.jar"
-            ]
-          },
-          {
-            "name": "intellij.notebooks.visualization",
-            "kind": "productModuleV2",
-            "classPath": [
-              "lib/modules/intellij.notebooks.visualization.jar"
-            ]
-          },
-          {
-            "name": "intellij.java.featuresTrainer",
-            "kind": "moduleV2",
-            "classPath": [
-              "plugins/java/lib/modules/intellij.java.featuresTrainer.jar"
-            ]
-          },
-          {
-            "name": "com.jetbrains.codeWithMe",
-            "kind": "plugin",
-            "classPath": [
-              "plugins/cwm-plugin/lib/cwm-plugin.jar"
-            ]
-          }      
-          $layoutJson                  
-        ]
+        ${
+          if (replaceLayout) {
+            """
+              "layout": [
+                 $layout
+              ]
+            """.trimIndent()
+          } else {
+            getDefaultLayout(layout)
+          }            
+        }
       } 
     """.trimIndent()
   }
@@ -244,14 +224,42 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
       """.trimIndent()
     } ?: ""
 
-  private val ProductInfo.layoutJson: String
-    get() {
-      return if (layout.isEmpty()) {
-        layout
-      } else {
-        ", $layout"
-      }
-    }
+  private fun getDefaultLayout(additionalLayoutEntries: String = ""): String {
+    val moreEntries = if (additionalLayoutEntries.isEmpty()) "" else ", $additionalLayoutEntries"
+    return """
+      "layout": [
+        {
+          "name": "intellij.notebooks.ui",
+          "kind": "productModuleV2",
+          "classPath": [
+            "lib/modules/intellij.notebooks.ui.jar"
+          ]
+        },
+        {
+          "name": "intellij.notebooks.visualization",
+          "kind": "productModuleV2",
+          "classPath": [
+            "lib/modules/intellij.notebooks.visualization.jar"
+          ]
+        },
+        {
+          "name": "intellij.java.featuresTrainer",
+          "kind": "moduleV2",
+          "classPath": [
+            "plugins/java/lib/modules/intellij.java.featuresTrainer.jar"
+          ]
+        },
+        {
+          "name": "com.jetbrains.codeWithMe",
+          "kind": "plugin",
+          "classPath": [
+            "plugins/cwm-plugin/lib/cwm-plugin.jar"
+          ]
+        }
+        $moreEntries
+      ]
+    """.trimIndent()
+  }
 
   private val platformLangPluginXml: String
     get() = """
@@ -270,6 +278,8 @@ class MockIdeBuilder(private val temporaryFolder: TemporaryFolder, private val f
     var versionSuffix: String? = "EAP"
 
     var layout: String = ""
+
+    var replaceLayout: Boolean = false
 
     fun omitVersionSuffix() {
       versionSuffix = null

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -6,7 +6,6 @@ import ch.qos.logback.core.spi.AppenderAttachable
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.ide.IdeManagerImpl.PlatformResourceResolver
 import com.jetbrains.plugin.structure.ide.plugin.PluginIdExtractor
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
@@ -177,10 +176,7 @@ class ProductInfoBasedIdeManagerTest {
     }
 
     fun getIdePluginManager(idePath: Path): ResourceResolver {
-      val platformJarFiles = idePath.resolve("lib").listJars()
-      val platformModuleJarFiles = idePath.resolve("lib").resolve("modules").listJars()
-      val platformResourceResolver = PlatformResourceResolver(platformJarFiles + platformModuleJarFiles)
-      return platformResourceResolver
+      return PlatformResourceResolver.of(idePath)
     }
 
     val additionalPluginReader = object : ProductInfoBasedIdeManager.PluginReader {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -151,7 +151,7 @@ class ProductInfoBasedIdeManagerTest {
       layout = ""
     }
 
-    val ideManager = ProductInfoBasedIdeManager(additionalPluginReader = UndeclaredInLayoutPluginReader())
+    val ideManager = ProductInfoBasedIdeManager(additionalPluginReader = UndeclaredInLayoutPluginReader(supportedProductCodes = setOf("IU", "IC")))
 
     val ide = ideManager.createIde(ideRoot)
     assertEquals(3, ide.bundledPlugins.size)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -3,13 +3,31 @@ package com.jetbrains.plugin.structure.ide
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import ch.qos.logback.core.spi.AppenderAttachable
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.listJars
+import com.jetbrains.plugin.structure.ide.IdeManagerImpl.PlatformResourceResolver
+import com.jetbrains.plugin.structure.ide.plugin.PluginIdExtractor
+import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
+import com.jetbrains.plugin.structure.intellij.plugin.BundledPluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArtifactPath
+import com.jetbrains.plugin.structure.intellij.plugin.PluginIdProvider
 import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.slf4j.LoggerFactory
+import java.io.InputStream
 import java.nio.file.Path
 import java.time.LocalDate
 
@@ -140,6 +158,98 @@ class ProductInfoBasedIdeManagerTest {
     }
     val ide = ideManager.createIde(ideRoot)
     assertIdeAndPluginsIsCreated(ide)
+  }
+
+  @Test
+  fun `create IDE manager with plugins in 'plugins' dir, but not declared in the product info jSON`() {
+    val ideRoot = MockIdeBuilder(temporaryFolder, "-missing-layout-entry-for-plugin").buildIdeaDirectory {
+      replaceLayout = true
+      //language=JSON
+      layout = ""
+    }
+
+    val pluginIdExtractor = PluginIdExtractor()
+    // TODO unify this into a single interface
+    val pluginIdProvider = object : PluginIdProvider {
+      override fun getPluginId(pluginDescriptorStream: InputStream): String {
+        return pluginIdExtractor.extractId(pluginDescriptorStream)
+      }
+    }
+
+    fun getIdePluginManager(idePath: Path): ResourceResolver {
+      val platformJarFiles = idePath.resolve("lib").listJars()
+      val platformModuleJarFiles = idePath.resolve("lib").resolve("modules").listJars()
+      val platformResourceResolver = PlatformResourceResolver(platformJarFiles + platformModuleJarFiles)
+      return platformResourceResolver
+    }
+
+    val additionalPluginReader = object : ProductInfoBasedIdeManager.PluginReader {
+      private val bundledPluginManager = BundledPluginManager(pluginIdProvider)
+
+      override fun readPlugins(idePath: Path, productInfo: ProductInfo, ideVersion: IdeVersion): List<IdePlugin> {
+        val resourceResolver = getIdePluginManager(idePath)
+
+        val identifiersInPluginsDir = bundledPluginManager.getBundledPluginIds(idePath)
+        val identifiersInLayout = productInfo.layout.map { it.name }
+
+        val filtered = filter(identifiersInPluginsDir, identifiersInLayout)
+        return if (filtered.isNotEmpty()) {
+          filtered.mapNotNull {
+            try {
+              createBundledPluginExceptionally(idePath, it.path, resourceResolver, PLUGIN_XML, ideVersion)
+            } catch (e: InvalidIdeException) {
+              // FIXME replace with logger
+              println(e.reason)
+              null
+            }
+          }
+        } else {
+          emptyList()
+        }
+      }
+
+      private fun filter(artifacts: Set<PluginArtifactPath>, layoutIdentifiers: List<String>): List<PluginArtifactPath> {
+        return artifacts.filterNot { it.pluginId in layoutIdentifiers }
+      }
+
+      // TODO copied from IdeManagerImpl
+      @Throws(InvalidIdeException::class)
+      private fun createBundledPluginExceptionally(
+        idePath: Path,
+        pluginFile: Path,
+        resourceResolver: ResourceResolver,
+        descriptorPath: String,
+        ideVersion: IdeVersion
+      ): IdePlugin = when (val creationResult = IdePluginManager
+        .createManager(resourceResolver)
+        .createBundledPlugin(pluginFile, ideVersion, descriptorPath, problemResolver = AnyProblemToWarningPluginCreationResultResolver)
+      ) {
+        is PluginCreationSuccess -> creationResult.plugin
+        is PluginCreationFail -> throw InvalidIdeException(
+          idePath,
+          "Plugin '${idePath.relativize(pluginFile)}' is invalid: " +
+            creationResult.errorsAndWarnings.filter { it.level == PluginProblem.Level.ERROR }.joinToString { it.message }
+        )
+      }
+    }
+
+    val ideManager = ProductInfoBasedIdeManager(additionalPluginReader = additionalPluginReader)
+
+    val ide = ideManager.createIde(ideRoot)
+    assertEquals(3, ide.bundledPlugins.size)
+    val javaPlugin = ide.findPluginById("com.intellij.java")
+    assertNotNull(javaPlugin)
+    assertTrue(javaPlugin is IdePluginImpl)
+    with(javaPlugin as IdePluginImpl) {
+      assertEquals("Java", pluginName)
+    }
+
+    val cwmPlugin = ide.findPluginById("com.jetbrains.codeWithMe")
+    assertNotNull(cwmPlugin)
+    assertTrue(cwmPlugin is IdePluginImpl)
+    with(cwmPlugin as IdePluginImpl) {
+      assertEquals("Code With Me", pluginName)
+    }
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -3,30 +3,14 @@ package com.jetbrains.plugin.structure.ide
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import ch.qos.logback.core.spi.AppenderAttachable
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.ide.IdeManagerImpl.PlatformResourceResolver
-import com.jetbrains.plugin.structure.ide.plugin.PluginIdExtractor
-import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
-import com.jetbrains.plugin.structure.intellij.plugin.BundledPluginManager
-import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
-import com.jetbrains.plugin.structure.intellij.plugin.PluginArtifactPath
-import com.jetbrains.plugin.structure.intellij.plugin.PluginIdProvider
 import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
-import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
-import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
-import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.slf4j.LoggerFactory
-import java.io.InputStream
 import java.nio.file.Path
 import java.time.LocalDate
 
@@ -167,69 +151,7 @@ class ProductInfoBasedIdeManagerTest {
       layout = ""
     }
 
-    val pluginIdExtractor = PluginIdExtractor()
-    // TODO unify this into a single interface
-    val pluginIdProvider = object : PluginIdProvider {
-      override fun getPluginId(pluginDescriptorStream: InputStream): String {
-        return pluginIdExtractor.extractId(pluginDescriptorStream)
-      }
-    }
-
-    fun getIdePluginManager(idePath: Path): ResourceResolver {
-      return PlatformResourceResolver.of(idePath)
-    }
-
-    val additionalPluginReader = object : ProductInfoBasedIdeManager.PluginReader {
-      private val bundledPluginManager = BundledPluginManager(pluginIdProvider)
-
-      override fun readPlugins(idePath: Path, productInfo: ProductInfo, ideVersion: IdeVersion): List<IdePlugin> {
-        val resourceResolver = getIdePluginManager(idePath)
-
-        val identifiersInPluginsDir = bundledPluginManager.getBundledPluginIds(idePath)
-        val identifiersInLayout = productInfo.layout.map { it.name }
-
-        val filtered = filter(identifiersInPluginsDir, identifiersInLayout)
-        return if (filtered.isNotEmpty()) {
-          filtered.mapNotNull {
-            try {
-              createBundledPluginExceptionally(idePath, it.path, resourceResolver, PLUGIN_XML, ideVersion)
-            } catch (e: InvalidIdeException) {
-              // FIXME replace with logger
-              println(e.reason)
-              null
-            }
-          }
-        } else {
-          emptyList()
-        }
-      }
-
-      private fun filter(artifacts: Set<PluginArtifactPath>, layoutIdentifiers: List<String>): List<PluginArtifactPath> {
-        return artifacts.filterNot { it.pluginId in layoutIdentifiers }
-      }
-
-      // TODO copied from IdeManagerImpl
-      @Throws(InvalidIdeException::class)
-      private fun createBundledPluginExceptionally(
-        idePath: Path,
-        pluginFile: Path,
-        resourceResolver: ResourceResolver,
-        descriptorPath: String,
-        ideVersion: IdeVersion
-      ): IdePlugin = when (val creationResult = IdePluginManager
-        .createManager(resourceResolver)
-        .createBundledPlugin(pluginFile, ideVersion, descriptorPath, problemResolver = AnyProblemToWarningPluginCreationResultResolver)
-      ) {
-        is PluginCreationSuccess -> creationResult.plugin
-        is PluginCreationFail -> throw InvalidIdeException(
-          idePath,
-          "Plugin '${idePath.relativize(pluginFile)}' is invalid: " +
-            creationResult.errorsAndWarnings.filter { it.level == PluginProblem.Level.ERROR }.joinToString { it.message }
-        )
-      }
-    }
-
-    val ideManager = ProductInfoBasedIdeManager(additionalPluginReader = additionalPluginReader)
+    val ideManager = ProductInfoBasedIdeManager(additionalPluginReader = UndeclaredInLayoutPluginReader())
 
     val ide = ideManager.createIde(ideRoot)
     assertEquals(3, ide.bundledPlugins.size)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
@@ -1,0 +1,66 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.ide.plugin.PluginIdExtractor
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.InputStream
+import java.nio.file.Path
+
+class BundledPluginManagerTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Before
+  fun setUp() {
+    val javaLibDir = temporaryFolder.newFolder("plugins", "java", "lib")
+    val javaImplJar = javaLibDir.resolve("java-impl.jar").toPath()
+    buildZipFile(javaImplJar) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              <id>com.intellij.java</id>
+            </idea-plugin>
+            """.trimIndent()
+        }
+      }
+    }
+
+    val javaCoverageDir = temporaryFolder.newFolder("plugins", "java-coverage", "lib")
+    val javaCoverageJar = javaCoverageDir.resolve("java-coverage.jar").toPath()
+    buildZipFile(javaCoverageJar) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              <name>Code Coverage for Java</name>
+              <id>Coverage</id>
+            </idea-plugin>
+          """.trimIndent()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `plugin identifiers are retrieved`() {
+    val pluginIdExtractor = PluginIdExtractor()
+    val pluginIdProvider = object : PluginIdProvider {
+      override fun getPluginId(pluginDescriptorStream: InputStream): String {
+        return pluginIdExtractor.extractId(pluginDescriptorStream)
+      }
+    }
+    val pluginManager = BundledPluginManager(pluginIdProvider)
+    val pluginIdentifiers = pluginManager.getBundledPluginIds(idePath)
+    assertTrue(pluginIdentifiers.contains("com.intellij.java"))
+    assertTrue(pluginIdentifiers.contains("Coverage"))
+  }
+
+  private val idePath: Path
+    get() = temporaryFolder.root.toPath()
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
@@ -5,13 +5,12 @@
 package com.jetbrains.plugin.structure.intellij.plugin
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.ide.plugin.PluginIdExtractor
+import com.jetbrains.plugin.structure.ide.plugin.DefaultPluginIdProvider
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.InputStream
 import java.nio.file.Path
 
 class BundledPluginManagerTest {
@@ -53,12 +52,7 @@ class BundledPluginManagerTest {
 
   @Test
   fun `plugin identifiers are retrieved`() {
-    val pluginIdExtractor = PluginIdExtractor()
-    val pluginIdProvider = object : PluginIdProvider {
-      override fun getPluginId(pluginDescriptorStream: InputStream): String {
-        return pluginIdExtractor.extractId(pluginDescriptorStream)
-      }
-    }
+    val pluginIdProvider = DefaultPluginIdProvider()
     val pluginManager = BundledPluginManager(pluginIdProvider)
     val pluginIdentifiers = pluginManager.getBundledPluginIds(idePath).map { it.pluginId }
     assertTrue(pluginIdentifiers.contains("com.intellij.java"))

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManagerTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.intellij.plugin
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
@@ -56,7 +60,7 @@ class BundledPluginManagerTest {
       }
     }
     val pluginManager = BundledPluginManager(pluginIdProvider)
-    val pluginIdentifiers = pluginManager.getBundledPluginIds(idePath)
+    val pluginIdentifiers = pluginManager.getBundledPluginIds(idePath).map { it.pluginId }
     assertTrue(pluginIdentifiers.contains("com.intellij.java"))
     assertTrue(pluginIdentifiers.contains("Coverage"))
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginVerifierTelemetryTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginVerifierTelemetryTest.kt
@@ -59,7 +59,7 @@ class PluginVerifierTelemetryTest {
       if (pluginVerificationDuration !is Duration) {
         fail("Plugin telemetry must contain the '$PLUGIN_VERIFICATION_TIME' value")
       } else {
-        assertTrue(pluginVerificationDuration.toMillis() > 0)
+        assertTrue(pluginVerificationDuration.toMillis() >= 0)
       }
     }
   }


### PR DESCRIPTION
Android Studio contains a plugin in the `plugins` folder that is not declared in the `product-info.json`.

- For explicitly enumerated product codes, traverse `plugins` folder. Discover plugins that are not declared in the Product Info and load them into the IDE.
- Introduce the `UndeclaredInLayoutPluginReader` that handles loading logic for undeclared plugins that will be loaded from `plugins` folder.
- Introduce a StAX-based parser of `plugin.xml` to quicky identify plugin identifiers without unnecessary parsing of the full plugin descriptor. See `ElementTextContentFilter` for filtering logic in StAX streams

Additional fixes:

- When a module descriptor refers to non-existent _resource root_, warn, and do not load the corresponding module.

See [MP-7024](https://youtrack.jetbrains.com/issue/MP-7024)