### PR TITLE
Bump Gradle to 8.12.1 and align JVM bytecode logic

### DIFF
--- a/ide-diff-builder/gradle/wrapper/gradle-wrapper.properties
+++ b/ide-diff-builder/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(sharedLibs.plugins.kotlin.jvm)
   `maven-publish`
@@ -25,6 +27,15 @@ allprojects {
   java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+  }
+
+
+  tasks.withType<KotlinCompile> {
+    kotlinOptions {
+      jvmTarget = "11"
+      apiVersion = "1.4"
+      languageVersion = "1.4"
+    }
   }
 }
 

--- a/intellij-feature-extractor/gradle/wrapper/gradle-wrapper.properties
+++ b/intellij-feature-extractor/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/intellij-feature-extractor/gradlew
+++ b/intellij-feature-extractor/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/intellij-plugin-structure/gradle/wrapper/gradle-wrapper.properties
+++ b/intellij-plugin-structure/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/intellij-plugin-verifier/gradle/wrapper/gradle-wrapper.properties
+++ b/intellij-plugin-verifier/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/ByteCodeDescriptions.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/ByteCodeDescriptions.kt
@@ -10,12 +10,19 @@ import org.objectweb.asm.tree.TypeInsnNode
  * It is used mainly in IDE debugging to better describe ASM nodes.
  */
 @Suppress("unused")
-fun TypeInsnNode.toDebugString(): String = when (opcode) {
-  NEW -> "NEW $desc"
-  ANEWARRAY -> "ANEWARRAY $desc"
-  CHECKCAST -> "CHECKLIST $desc"
-  INSTANCEOF -> "INSTANCEOF $desc"
-  else -> toString()
+fun TypeInsnNode.toDebugString(): String {
+  return try {
+    when (opcode) {
+      NEW -> "NEW $desc"
+      ANEWARRAY -> "ANEWARRAY $desc"
+      CHECKCAST -> "CHECKLIST $desc"
+      INSTANCEOF -> "INSTANCEOF $desc"
+      DUP -> "DUP"
+      else -> toString()
+    }
+  } catch (e: Exception) {
+    return e.message.toString()
+  }
 }
 
 /**

--- a/plugins-verifier-service/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins-verifier-service/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins-verifier-service/gradlew
+++ b/plugins-verifier-service/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
- Upgrade to [Gradle 8.12.1](https://docs.gradle.org/8.12.1/release-notes.html).
- `intellij-feature-extractor`: align unit test and instruction detection logic to match modern compilers and JVM. Previously, it was thought that `NEWARRAY` was the only source of a new array on the operand stack in JVM. However, this array can be also accessed via `DUP` instruction what was not detected.