### PR TITLE
Discover bundled plugins in 'plugins' directory in CLion

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/DispatchingIdeManager.kt
@@ -8,7 +8,7 @@ class DispatchingIdeManager(configuration: IdeManagerConfiguration = IdeManagerC
 
   private val productInfoBasedIdeManager = ProductInfoBasedIdeManager(
     missingLayoutFileMode = configuration.missingLayoutFileMode,
-    additionalPluginReader = UndeclaredInLayoutPluginReader(supportedProductCodes = setOf("AI")),
+    additionalPluginReader = UndeclaredInLayoutPluginReader(  supportedProductCodes = setOf("AI", "CL")),
   )
 
   override fun createIde(idePath: Path): Ide = createIde(idePath, version = null)


### PR DESCRIPTION
Discover plugins that are not declared in the Product Info and load them into the IDE for CLion.

See [MP-7275](https://youtrack.jetbrains.com/issue/MP-7275) Structure: Resolve CLion bundled plugins undeclared in `product-info.json`.

See also #1214.