### PR TITLE
Support module aliases in class resolvers when used as dependencies

### DIFF
--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolver.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide.classes.resolver
 
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolver.kt
@@ -27,7 +27,9 @@ class PluginDependencyFilteredResolver(
     return dependenciesProvider
       .getDependencies(plugin)
       .map { dependency ->
-        productInfoClassResolver.layoutComponentResolvers.firstOrNull { component -> dependency.matches(component.name) }
+        productInfoClassResolver.layoutComponentNames.firstOrNull { dependency.matches(it) }
+          ?.let { productInfoClassResolver.getLayoutComponentResolver(it) }
+          ?.takeIf { productInfoClassResolver.hasNonEmptyResolver(it.name) }
           ?: productInfoClassResolver.bootClasspathResolver
       }
   }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -29,8 +29,9 @@ import java.util.*
 private val LOG: Logger = LoggerFactory.getLogger(ProductInfoClassResolver::class.java)
 
 private const val PRODUCT_INFO_JSON = "product-info.json"
-
 private const val CORE_IDE_PLUGIN_ID = "com.intellij"
+private const val PRODUCT_MODULE_V2 = "productModuleV2"
+private const val BOOTCLASSPATH_JAR_NAMES = "bootClassPathJarNames"
 
 class ProductInfoClassResolver(
   private val productInfo: ProductInfo, val ide: Ide,
@@ -50,7 +51,7 @@ class ProductInfoClassResolver(
     val corePluginResolver = find { it.name == CORE_IDE_PLUGIN_ID } ?: return emptyMap()
     val resolvers = mutableMapOf<String, NamedResolver>()
 
-    val productModules = filter { it.kind == "productModuleV2" }
+    val productModules = filter { it.kind == PRODUCT_MODULE_V2 }
       .map { it.resolver }
       .also { productModules ->
         productModules.forEach { resolvers.put(it.name, it) }
@@ -68,7 +69,7 @@ class ProductInfoClassResolver(
   }
 
   private fun List<KindedResolver>.resolveNonCoreAndNonProductModules(): Map<String, NamedResolver> {
-    return filter { it.kind != "productModuleV2" && it.name != CORE_IDE_PLUGIN_ID }
+    return filter { it.kind != PRODUCT_MODULE_V2 && it.name != CORE_IDE_PLUGIN_ID }
       .associateBy({ it.name }, { it.resolver })
   }
 
@@ -131,7 +132,7 @@ class ProductInfoClassResolver(
       val bootJars = productInfo.launches.firstOrNull()?.bootClassPathJarNames
       val bootResolver = bootJars?.map { getBootJarResolver(it) }?.asResolver()
         ?: EmptyResolver
-      return NamedResolver("bootClassPathJarNames", bootResolver)
+      return NamedResolver(BOOTCLASSPATH_JAR_NAMES, bootResolver)
     }
 
   private fun <C> C.toResolver(): KindedResolver
@@ -178,7 +179,7 @@ class ProductInfoClassResolver(
     @Throws(InvalidIdeException::class)
     private fun assertProductInfoPresent(idePath: Path) {
       if (!idePath.containsProductInfoJson()) {
-        throw InvalidIdeException(idePath, "The '${PRODUCT_INFO_JSON}' file is not available.")
+        throw InvalidIdeException(idePath, "The '$PRODUCT_INFO_JSON' file is not available.")
       }
     }
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.ide.classes.resolver
 
 import com.jetbrains.plugin.structure.base.utils.exists

--- a/intellij-plugin-structure/tests/src/test/resources/ide/productInfo/product-info_mini.json
+++ b/intellij-plugin-structure/tests/src/test/resources/ide/productInfo/product-info_mini.json
@@ -92,6 +92,10 @@
       "kind": "pluginAlias"
     },
     {
+      "name": "com.intellij.platform.ide.provisioner",
+      "kind": "pluginAlias"
+    },
+    {
       "name": "intellij.copyright.vcs",
       "kind": "moduleV2"
     },

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
@@ -114,7 +114,7 @@ class DependenciesGraphBuilder(private val dependencyFinder: DependencyFinder) {
       return registerMissingDependency(sameReason)
     }
 
-    return when (val result = dependencyFinder.findPluginDependency(depId.id, depId.isModule)) {
+    return when (val result = dependencyFinder.findPluginDependency(pluginDependency)) {
       is DependencyFinder.Result.FoundPlugin -> DepVertex(result.plugin, result)
       is DependencyFinder.Result.DetailsProvided -> {
         when (val cacheResult = result.pluginDetailsCacheResult) {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/BundledPluginDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/BundledPluginDependencyFinder.kt
@@ -5,6 +5,9 @@
 package com.jetbrains.pluginverifier.dependencies.resolution
 
 import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import com.jetbrains.plugin.structure.intellij.plugin.PluginV2Dependency
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPluginsRepository
@@ -12,7 +15,8 @@ import com.jetbrains.pluginverifier.repository.repositories.bundled.BundledPlugi
 /**
  * [DependencyFinder] that searches for plugins among bundled plugins of the [ide].
  */
-class BundledPluginDependencyFinder(val ide: Ide, private val pluginDetailsCache: PluginDetailsCache) : DependencyFinder {
+class BundledPluginDependencyFinder(val ide: Ide, private val pluginDetailsCache: PluginDetailsCache) :
+  DependencyFinder {
   private val bundledPluginsRepository = BundledPluginsRepository(ide)
 
   override val presentableName
@@ -25,16 +29,32 @@ class BundledPluginDependencyFinder(val ide: Ide, private val pluginDetailsCache
       bundledPluginsRepository.findPluginById(dependencyId)
     }
 
-    if (bundledPluginInfo != null) {
-      return DependencyFinder.Result.DetailsProvided(pluginDetailsCache.getPluginDetailsCacheEntry(bundledPluginInfo))
+    return bundledPluginInfo.toResult(dependencyId)
+  }
+
+  override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result {
+    return when (dependency) {
+      is ModuleV2Dependency,
+      is PluginV2Dependency -> bundledPluginsRepository
+        .findPluginOrModuleById(dependency.id)
+        .toResult(dependency.id)
+
+      else -> findPluginDependency(dependency.id, dependency.isModule)
     }
-    return DependencyFinder.Result.NotFound("Dependency $dependencyId is not found among the bundled plugins of $ide")
+  }
+
+  private fun BundledPluginInfo?.toResult(dependencyId: String): DependencyFinder.Result {
+    return if (this != null) {
+      DependencyFinder.Result.DetailsProvided(pluginDetailsCache.getPluginDetailsCacheEntry(this))
+    } else {
+      DependencyFinder.Result.NotFound("Dependency $dependencyId is not found among the bundled plugins of $ide")
+    }
   }
 
   private fun BundledPluginsRepository.findPluginOrModuleById(dependencyId: String): BundledPluginInfo? {
     // module can expose itself as a plugin with the corresponding ID
     return bundledPluginsRepository.findPluginById(dependencyId)
-      // if there is no such plugin, search in modules
+    // if there is no such plugin, search in modules
       ?: bundledPluginsRepository.findPluginByModule(dependencyId)
   }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/BundledPluginDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/BundledPluginDependencyFinder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.dependencies.resolution

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.dependencies.resolution

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
@@ -4,6 +4,8 @@
 
 package com.jetbrains.pluginverifier.dependencies.resolution
 
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+
 /**
  * [DependencyFinder] that subsequently delegates the search
  * to the [dependencyFinders] until the dependency is resolved.
@@ -26,6 +28,13 @@ class CompositeDependencyFinder(private val dependencyFinders: List<DependencyFi
     }
     return lastNotFound
       ?: DependencyFinder.Result.NotFound("Dependency '$dependencyId'${if (isModule) " (module)" else ""} is not resolved. It was searched in the following locations: $presentableName")
+  }
+
+  override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result {
+    return dependencyFinders.asSequence()
+      .map { it.findPluginDependency(dependency) }
+      .firstOrNull { it !is DependencyFinder.Result.NotFound }
+      ?: DependencyFinder.Result.NotFound("Dependency '$dependency' is not resolved. It was searched in the following locations: $presentableName")
   }
 
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/DependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/DependencyFinder.kt
@@ -6,7 +6,6 @@ package com.jetbrains.pluginverifier.dependencies.resolution
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
-import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder.Result.DetailsProvided
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import java.io.Closeable
 
@@ -25,6 +24,12 @@ interface DependencyFinder {
    * The possible results are represented as instances of the [Result].
    */
   fun findPluginDependency(dependencyId: String, isModule: Boolean): Result
+
+  /**
+   * Finds a plugin or a module that corresponds to the [dependency].
+   * The possible results are represented as instances of the [Result].
+   */
+  fun findPluginDependency(dependency: PluginDependency): Result
 
   /**
    * Represents possible results of the [findPluginDependency].

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.pluginverifier.dependencies.resolution
 
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.misc.retry
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginRepository
@@ -36,6 +37,9 @@ class RepositoryDependencyFinder(
         convertResult(pluginVersionSelector.selectPluginVersion(dependencyId, pluginRepository))
       }
     }
+
+  override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result =
+    findPluginDependency(dependency.id, dependency.isModule)
 
   private fun convertResult(selectResult: PluginVersionSelector.Result): DependencyFinder.Result =
     when (selectResult) {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.resolution

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -83,8 +83,7 @@ class DefaultClassResolverProvider(
 
   private fun createBundledPluginResolver(pluginDependency: PluginDetails): Resolver? {
     return if (ideDescriptor.ide is ProductInfoBasedIde && ideDescriptor.ideResolver is ProductInfoClassResolver) {
-      ideDescriptor.ideResolver.layoutComponentResolvers
-        .firstOrNull { resolver -> resolver.name == pluginDependency.pluginInfo.pluginId }
+      ideDescriptor.ideResolver.getLayoutComponentResolver(pluginDependency.pluginInfo.pluginId)
     } else null
   }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinderTest.kt
@@ -1,0 +1,47 @@
+package com.jetbrains.pluginverifier.dependencies.resolution
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginV2Dependency
+import com.jetbrains.pluginverifier.tests.BasePluginTest
+import com.jetbrains.pluginverifier.tests.mocks.MockDependencyFinder
+import com.jetbrains.pluginverifier.tests.mocks.RuleBasedDependencyFinder
+import com.jetbrains.pluginverifier.tests.mocks.buildCoreIde
+import com.jetbrains.pluginverifier.tests.mocks.buildIdePlugin
+import com.jetbrains.pluginverifier.tests.mocks.descriptor
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private const val PROVISIONER_PLUGIN_ID = "com.intellij.platform.ide.provisioner"
+
+class CompositeDependencyFinderTest : BasePluginTest() {
+  lateinit var ide: Ide
+
+  lateinit var dependencyFinder: DependencyFinder
+
+  @Before
+  fun setUp() {
+    ide = ideaPath.buildCoreIde()
+
+    val finder1 = RuleBasedDependencyFinder.create(
+      ide,
+      RuleBasedDependencyFinder.Rule(PROVISIONER_PLUGIN_ID, provisionerPlugin())
+    )
+    val finder2 = MockDependencyFinder()
+    dependencyFinder = CompositeDependencyFinder(listOf(finder1, finder2))
+  }
+
+  @Test
+  fun `simple dependency is resolved`() {
+    val result = dependencyFinder.findPluginDependency(PluginV2Dependency(PROVISIONER_PLUGIN_ID))
+    assertTrue(result is DependencyFinder.Result.DetailsProvided)
+  }
+
+  private fun provisionerPlugin(): IdePlugin {
+    val descriptor = ideaPlugin(PROVISIONER_PLUGIN_ID, "Provisioner")
+    return newJar("provisioner").buildIdePlugin {
+      descriptor(descriptor)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
@@ -33,6 +33,9 @@ abstract class BasePluginTest {
   protected val ideaPath: Path
     get() = temporaryFolder.newFolder("idea").toPath()
 
+  protected fun newJar(name: String): Path =
+    temporaryFolder.newFile("$name.jar").toPath()
+
   protected fun buildPluginWithResult(problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver(),
                                       pluginContentBuilder: ContentBuilder.() -> Unit): PluginCreationResult<IdePlugin> {
     val pluginFile = buildZipFile(pluginJarPath, pluginContentBuilder)
@@ -147,7 +150,8 @@ abstract class BasePluginTest {
                   <id>com.intellij</id>
                   <name>IDEA CORE</name>
                   <version>1.0</version>
-                  <module value="com.intellij.modules.all"/>                
+                  <module value="com.intellij.modules.all"/>   
+                  <module value="com.intellij.platform.ide.provisioner"/>
                 </idea-plugin>
                 """.trimIndent()
             }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/BundledModuleDependencyTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/BundledModuleDependencyTest.kt
@@ -1,0 +1,56 @@
+package com.jetbrains.pluginverifier.tests.dependencies
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.tests.BasePluginTest
+import com.jetbrains.pluginverifier.tests.VerificationRunner
+import com.jetbrains.pluginverifier.tests.mocks.buildCoreIde
+import com.jetbrains.pluginverifier.tests.mocks.buildIdePlugin
+import com.jetbrains.pluginverifier.tests.mocks.descriptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BundledModuleDependencyTest : BasePluginTest() {
+  lateinit var plugin: IdePlugin
+
+  @Before
+  fun setUp() {
+    val pluginId = "pluginverifier"
+    val descriptor = ideaPlugin(pluginId, "Mock Classpath") +
+      """
+        <dependencies>
+          <plugin id="com.intellij.platform.ide.provisioner" />
+        </dependencies>        
+      """.trimIndent()
+    plugin = pluginJarPath.buildIdePlugin {
+      descriptor(descriptor)
+    }
+  }
+
+  @Test
+  fun `plugin declares plugin dependency on a bundled plugin via v2 semantics`() {
+    val ide = ideaPath.buildCoreIde(additionalPluginXmlContent = """
+      <module value="com.intellij.platform.ide.provisioner"/>
+    """.trimIndent())
+    val verificationResult = VerificationRunner().runPluginVerification(ide, plugin)
+    assertTrue(verificationResult is PluginVerificationResult.Verified)
+    val verifiedResult = verificationResult as PluginVerificationResult.Verified
+    assertEmpty("Compatibility problems", verifiedResult.compatibilityProblems)
+    assertEmpty("Direct Missing Mandatory Dependencies", verifiedResult.directMissingMandatoryDependencies)
+  }
+
+  @Test
+  fun `plugin declares plugin dependency on a bundled plugin via v2 semantics but that plugin is not in the IDE`() {
+    val ide = ideaPath.buildCoreIde()
+    val verificationResult = VerificationRunner().runPluginVerification(ide, plugin)
+    assertTrue(verificationResult is PluginVerificationResult.Verified)
+    val verifiedResult = verificationResult as PluginVerificationResult.Verified
+    assertEmpty("Compatibility problems", verifiedResult.compatibilityProblems)
+    with(verifiedResult.directMissingMandatoryDependencies) {
+      assertEquals(1, size)
+      assertEquals(first().dependency.id, "com.intellij.platform.ide.provisioner")
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/OptionalDependenciesTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/OptionalDependenciesTest.kt
@@ -1,9 +1,14 @@
 package com.jetbrains.pluginverifier.tests.dependencies
 
 import com.jetbrains.plugin.structure.intellij.plugin.OptionalPluginDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.pluginverifier.dependencies.*
+import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.DependenciesGraphBuilder
+import com.jetbrains.pluginverifier.dependencies.DependencyEdge
+import com.jetbrains.pluginverifier.dependencies.DependencyNode
+import com.jetbrains.pluginverifier.dependencies.MissingDependency
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
 import com.jetbrains.pluginverifier.tests.mocks.MockIde
 import com.jetbrains.pluginverifier.tests.mocks.MockIdePlugin
@@ -118,6 +123,10 @@ class OptionalDependenciesTest {
           "missingOptionalPluginId" -> DependencyFinder.Result.NotFound("missingOptionalPluginId optional plugin is not found")
           else -> throw IllegalArgumentException("Unknown test dependency $dependencyId")
         }
+      }
+
+      override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result {
+        return findPluginDependency(dependency.id, dependency.isModule)
       }
     }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockDependencyFinder.kt
@@ -1,10 +1,14 @@
 package com.jetbrains.pluginverifier.tests.mocks
 
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
 
 class MockDependencyFinder : DependencyFinder {
   override val presentableName: String = "Mock Dependency Finder"
 
   override fun findPluginDependency(dependencyId: String, isModule: Boolean) =
+    DependencyFinder.Result.NotFound("Mock Dependency Finder does not support any dependencies")
+
+  override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result =
     DependencyFinder.Result.NotFound("Mock Dependency Finder does not support any dependencies")
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/PluginBuilders.kt
@@ -29,8 +29,9 @@ internal fun Path.buildIdePlugin(pluginContentBuilder: (ContentBuilder).() -> Un
  * that represents a shared functionality.
  *
  * @receiver a path where the IDE will reside, usually with a `idea` name.
+ * @param additionalPluginXmlContent additional raw XML content that will appear in the Core plugin descriptor.
  */
-internal fun Path.buildCoreIde(): Ide {
+internal fun Path.buildCoreIde(additionalPluginXmlContent: String = ""): Ide {
   val ideaDirectory = buildDirectory(directory = this) {
     file("build.txt", "IU-192.1")
     dir("lib") {
@@ -42,7 +43,8 @@ internal fun Path.buildCoreIde(): Ide {
                   <id>com.intellij</id>
                   <name>IDEA CORE</name>
                   <version>1.0</version>
-                  <module value="com.intellij.modules.platform"/>                
+                  <module value="com.intellij.modules.platform"/>    
+                  $additionalPluginXmlContent                              
                 </idea-plugin>
                 """.trimIndent()
           }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/RuleBasedDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/RuleBasedDependencyFinder.kt
@@ -3,6 +3,7 @@ package com.jetbrains.pluginverifier.tests.mocks
 import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder.Result.NotFound
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
@@ -18,6 +19,9 @@ class RuleBasedDependencyFinder(private val ide: Ide, private val rules: List<Ru
       ?.toDependencyResolution()
       ?: NotFound("Dependency $dependencyId is not found by $presentableName")
   }
+
+  override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result =
+    findPluginDependency(dependency.id, dependency.isModule)
 
   private fun findRule(dependencyId: String): Rule? =
     rules.find { it.dependencyId == dependencyId }


### PR DESCRIPTION
A plugin might declare a dependency on a V1 plugin via V2 semantics.

```
<dependencies>
          <plugin id="com.intellij.platform.ide.provisioner" />
</dependencies>       
````

However, such plugin isan alias of the Core plugin. Add support for such scenario when resolving classes.

In `ProductInfoClassResolver`, group all `productModuleV2` from the Product Info under a single logical `Resolver`. In addition, maintain the list of mappings between product layout entries and their actual resolvers.

Thus, `com.intellij.platform.ide.provisioner` maps to the `Resolver` of the Core plugin with the nested resolvers still being available by their corresponding IDs.