### PR TITLE
Refine requirements for v2 modules

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -207,7 +207,7 @@ internal class PluginCreator private constructor(
     if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
       val module = pluginCreationResult.plugin
 
-      plugin.addDependencies(module)
+      plugin.addDependencies(module, loadingRule)
       plugin.modulesDescriptors.add(
         ModuleDescriptor(
           moduleName,
@@ -236,7 +236,7 @@ internal class PluginCreator private constructor(
       val moduleName = moduleReference.name
       val module = pluginCreationResult.plugin
 
-      plugin.addDependencies(module)
+      plugin.addDependencies(module, loadingRule)
       plugin.modulesDescriptors.add(ModuleDescriptor.of(moduleName, loadingRule, module, moduleDescriptorResource))
       plugin.definedModules.add(moduleName)
 
@@ -726,10 +726,13 @@ internal class PluginCreator private constructor(
     problems += problem
   }
 
-  private fun IdePluginImpl.addDependencies(module: IdePlugin) {
+  private fun IdePluginImpl.addDependencies(module: IdePlugin, loadingRule: ModuleLoadingRule) {
     module.dependencies
       .filter { dependency -> dependencies.none { it.id == dependency.id } }
-      .forEach { dependencies += it.asOptional() }
+      .forEach { 
+        val dependency = if (loadingRule.required) it else it.asOptional()
+        dependencies += dependency 
+      }
   }
 
   private val PluginCreationResult<IdePlugin>.errors: List<PluginProblem>

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -205,24 +205,21 @@ internal class PluginCreator private constructor(
   ) {
     val pluginCreationResult = moduleCreator.pluginCreationResult
     if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
-      // Content module should be in v2 model
-      if (pluginCreationResult.plugin.isV2) {
-        val module = pluginCreationResult.plugin
+      val module = pluginCreationResult.plugin
 
-        plugin.addDependencies(module)
-        plugin.modulesDescriptors.add(
-          ModuleDescriptor(
-            moduleName,
-            loadingRule,
-            module.dependencies,
-            module,
-            configurationFile
-          )
+      plugin.addDependencies(module)
+      plugin.modulesDescriptors.add(
+        ModuleDescriptor(
+          moduleName,
+          loadingRule,
+          module.dependencies,
+          module,
+          configurationFile
         )
-        plugin.definedModules.add(moduleName)
+      )
+      plugin.definedModules.add(moduleName)
 
-        mergeContent(module)
-      }
+      mergeContent(module)
     } else {
       registerProblem(ModuleDescriptorResolutionProblem(moduleName, configurationFile, pluginCreationResult.errors))
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -29,6 +29,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
   private val mockPluginRoot = Paths.get(this::class.java.getResource("/mock-plugin-v2").toURI())
   private val metaInfDir = mockPluginRoot.resolve("META-INF")
   private val v2ModuleFile = mockPluginRoot.resolve("intellij.v2.module.xml")
+  private val v2RequiredModuleFile = mockPluginRoot.resolve("intellij.v2.required.module.xml")
   private val v2ModuleFileUltimate = mockPluginRoot.resolve("intellij.v2.module-ultimate.xml")
   private val xiIncludeDir = mockPluginRoot.resolve("xiIncludeDir")
 
@@ -48,6 +49,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
     val plugin = buildPluginSuccess(expectedWarnings) {
       buildZipFile(temporaryFolder.newFile("plugin.jar")) {
         file("intellij.v2.module.xml", v2ModuleFile)
+        file("intellij.v2.required.module.xml", v2RequiredModuleFile)
         file("intellij.v2.module-ultimate.xml", v2ModuleFileUltimate)
         dir("META-INF", metaInfDir)
         dir("xiIncludeDir", xiIncludeDir)
@@ -67,6 +69,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
     val plugin = buildPluginSuccess(expectedWarnings) {
       buildDirectory(temporaryFolder.newFolder("plugin")) {
         file("intellij.v2.module.xml", v2ModuleFile)
+        file("intellij.v2.required.module.xml", v2RequiredModuleFile)
         file("intellij.v2.module-ultimate.xml", v2ModuleFileUltimate)
         dir("META-INF", metaInfDir)
         dir("xiIncludeDir", xiIncludeDir)
@@ -190,7 +193,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
     assertThat(
       moduleConfigs, `is`(
         listOf(
-          "../intellij.v2.module-ultimate.xml", "../intellij.v2.module.xml"
+          "../intellij.v2.module-ultimate.xml", "../intellij.v2.module.xml", "../intellij.v2.required.module.xml"
         )
       )
     )
@@ -230,7 +233,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
   }
 
   private fun checkDependenciesAndModules(plugin: IdePlugin) {
-    assertEquals(5, plugin.dependencies.size.toLong())
+    assertEquals(7, plugin.dependencies.size.toLong())
     //check plugin and module dependencies
     val expectedDependencies = listOf(
       ModuleV2Dependency("intellij.module.dependency", isOptional = false),
@@ -238,6 +241,8 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
       PluginV2Dependency("com.intellij.modules.mandatoryDependencyV2", isOptional = false),
       ModuleV2Dependency("intellij.clouds.docker.remoteRun", isOptional = true),
       PluginV2Dependency("com.intellij.copyright", isOptional = true),
+      ModuleV2Dependency("intellij.platform.backend", isOptional = false),
+      PluginV2Dependency("com.intellij.java", isOptional = false),
     )
     assertThat(plugin.dependencies, `is`(expectedDependencies))
 

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <content>
         <module name="intellij.v2.module"/>
+        <module name="intellij.v2.required.module" loading="required"/>
         <module name="intellij.v2.missing"/>
     </content>
     

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/intellij.v2.module.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/intellij.v2.module.xml
@@ -1,4 +1,4 @@
-<idea-plugin package="com.intellij.kubernetes.helm.gotpl">
+<idea-plugin>
     <dependencies>
         <plugin id="com.intellij.copyright"/>
         <module name="intellij.clouds.docker.remoteRun"/>

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/intellij.v2.required.module.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/intellij.v2.required.module.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <dependencies>
+        <plugin id="com.intellij.java"/>
+        <module name="intellij.platform.backend"/>
+    </dependencies>
+</idea-plugin>


### PR DESCRIPTION
This pull requests addresses two problem with handling 'content' v2 modules:
* 'package' attribute is actually optional;
* if `required` (or `embedded`) loading rule is specified for a module, its dependencies must be treated as non-optional dependencies of the plugin.