### PR TITLE
Track classpath for IDE plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Added
 
-### Changed
-
-### Fixed
+- Track classpath for IDE plugins. ([#1230](https://github.com/JetBrains/intellij-plugin-verifier/pull/1230), [MP-7299](https://youtrack.jetbrains.com/issue/MP-7299))
 
 ## 1.383 - 2025-03-07
 

--- a/intellij-feature-extractor/src/test/java/com/intellij/featureExtractor/MockIdePlugin.kt
+++ b/intellij-feature-extractor/src/test/java/com/intellij/featureExtractor/MockIdePlugin.kt
@@ -2,6 +2,7 @@ package com.intellij.featureExtractor
 
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
@@ -43,6 +44,7 @@ data class MockIdePlugin(
   override val definedModules: Set<String> = emptySet()
   override val originalFile: Path? = null
   override val useIdeClassLoader = false
+  override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail = false
   override val isV2: Boolean = false
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
@@ -5,7 +5,7 @@ import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
 import com.jetbrains.plugin.structure.base.plugin.parseThirdPartyDependenciesByPath
 import com.jetbrains.plugin.structure.base.utils.exists
-import com.jetbrains.plugin.structure.base.utils.extension
+import com.jetbrains.plugin.structure.base.utils.hasExtension
 import com.jetbrains.plugin.structure.base.utils.inputStream
 import com.jetbrains.plugin.structure.base.utils.readBytes
 import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
@@ -48,7 +48,7 @@ class PluginJar(private val jarPath: Path, private val jarFileSystemProvider: Ja
 
     val xmlInRoots: List<Path> = jarFileSystem.rootDirectories.flatMap { root ->
       Files.list(root)
-        .filter { it.extension == XML_EXTENSION }
+        .filter { it.hasExtension(XML_EXTENSION) }
         .filter(descriptorFilter::accept)
         .use {
           it.toList()

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
@@ -5,6 +5,7 @@ import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
 import com.jetbrains.plugin.structure.base.plugin.parseThirdPartyDependenciesByPath
 import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.extension
 import com.jetbrains.plugin.structure.base.utils.inputStream
 import com.jetbrains.plugin.structure.base.utils.readBytes
 import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
@@ -15,9 +16,11 @@ import java.nio.file.FileSystem
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.streams.toList
 
 const val META_INF = "META-INF"
 const val PLUGIN_XML = "plugin.xml"
+private const val XML_EXTENSION = "xml"
 val PLUGIN_XML_RESOURCE_PATH = META_INF + File.separator + PLUGIN_XML
 
 private val THIRD_PARTY_LIBRARIES_FILE_NAME = "dependencies.json"
@@ -37,6 +40,22 @@ class PluginJar(private val jarPath: Path, private val jarFileSystemProvider: Ja
     } else {
       null
     }
+  }
+
+  fun resolveDescriptors(descriptorFilter: PluginDescriptorFilter = AcceptAnyXmlFileAsDescriptor): List<Path> {
+    val metaInfPluginXmlPaths = listOfNotNull(resolveDescriptorPath(PLUGIN_XML_RESOURCE_PATH))
+      .filter(descriptorFilter::accept)
+
+    val xmlInRoots: List<Path> = jarFileSystem.rootDirectories.flatMap { root ->
+      Files.list(root)
+        .filter { it.extension == XML_EXTENSION }
+        .filter(descriptorFilter::accept)
+        .use {
+          it.toList()
+        }
+    }
+
+    return metaInfPluginXmlPaths + xmlInRoots
   }
 
   fun getPluginDescriptor(descriptorPathValue: String = PLUGIN_XML_RESOURCE_PATH): PluginDescriptorResult {
@@ -90,5 +109,13 @@ class PluginJar(private val jarPath: Path, private val jarFileSystemProvider: Ja
 
   override fun close() {
     jarFileSystemProvider.close(jarPath)
+  }
+
+  fun interface PluginDescriptorFilter {
+    fun accept(descriptorPath: Path): Boolean
+  }
+
+  object AcceptAnyXmlFileAsDescriptor : PluginDescriptorFilter {
+    override fun accept(descriptorPath: Path) = true
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/CountingXmlEventWriter.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/CountingXmlEventWriter.kt
@@ -1,10 +1,5 @@
-/*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
- */
-
 package com.jetbrains.plugin.structure.xml
 
-import com.jetbrains.plugin.structure.ide.dependencies.PluginXmlDependencyFilter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.Closeable
@@ -12,7 +7,7 @@ import javax.xml.stream.XMLEventWriter
 import javax.xml.stream.XMLStreamException
 import javax.xml.stream.events.XMLEvent
 
-private val LOG: Logger = LoggerFactory.getLogger(PluginXmlDependencyFilter::class.java)
+private val LOG: Logger = LoggerFactory.getLogger(CountingXmlEventWriter::class.java)
 
 /**
  * STaX Event Writer that counts occurrences of STaX events.

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlEvents.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlEvents.kt
@@ -1,0 +1,3 @@
+package com.jetbrains.plugin.structure.xml
+
+typealias XmlEventType = Int

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamEventFilter.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamEventFilter.kt
@@ -1,7 +1,3 @@
-/*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
- */
-
 package com.jetbrains.plugin.structure.xml
 
 import com.jetbrains.plugin.structure.base.utils.closeAll
@@ -58,10 +54,5 @@ class XmlStreamEventFilter {
       LOG.error("Cannot retrieve next event", e)
       false
     }
-  }
-
-  private fun newXmlInputFactory() = XMLInputFactory.newInstance().apply {
-    setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
-    setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
   }
 }

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Plugins.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Plugins.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide
+
+/**
+ * Indicates the `lib` directory of the IntelliJ Platform plugin.
+ *
+ * See [Plugin Content](https://plugins.jetbrains.com/docs/intellij/plugin-content.html#plugin-with-dependencies).
+ */
+const val LIB_DIRECTORY = "lib"

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -211,8 +211,7 @@ class ProductInfoBasedIdeManager(
   }
 
   private fun resolvePluginArtifact(path: Path): Path {
-    //FIXME remove hardwired string in favour of constant
-    return if (path.isJar() && path.parent.fileName.toString() == "lib") {
+    return if (path.isJar() && path.parent.fileName.toString() == LIB_DIRECTORY) {
       path.parent.parent
     } else {
       path

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/ModuleFactory.kt
@@ -5,6 +5,7 @@ import com.jetbrains.plugin.structure.ide.layout.PluginWithArtifactPathResult.Su
 import com.jetbrains.plugin.structure.intellij.beans.ModuleBean
 import com.jetbrains.plugin.structure.intellij.platform.BundledModulesManager
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
@@ -35,10 +36,9 @@ internal class ModuleFactory(private val moduleLoader: LayoutComponentLoader, pr
     return when (moduleLoadingResult) {
       is Success -> {
         IdeModule
-          .clone(moduleLoadingResult.plugin, moduleName)
+          .clone(moduleLoadingResult.plugin, moduleName, classpath = getClasspath(moduleName, idePath))
           .apply {
             definedModules += moduleName
-            classpath += classpathProvider.getClasspath(moduleName).map { idePath.resolve(it) }
             moduleDependencies += moduleDescriptor.dependencies
             resources += moduleDescriptor.resources
           }
@@ -81,4 +81,9 @@ internal class ModuleFactory(private val moduleLoader: LayoutComponentLoader, pr
     return Success(resolvedIdeModule.pluginArtifactPath, this)
   }
 
+  private fun getClasspath(moduleName: String, idePath: Path): Classpath {
+    val paths = classpathProvider.getClasspath(moduleName)
+      .map { idePath.resolve(it) }
+    return Classpath.of(paths)
+  }
 }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibDirectories.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibDirectories.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.classes.locator
+
+import com.jetbrains.plugin.structure.intellij.classes.locator.LibDirectoryLocator.LibDirectoryFilter
+import java.nio.file.Path
+
+internal const val MODULES_DIR = "modules"
+internal const val LIB_DIR = "lib"
+
+object NotAModulesDirectoryFilter : LibDirectoryFilter {
+  override fun accept(path: Path): Boolean {
+    return path.fileName.toString() != MODULES_DIR
+  }
+}

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/locator/LibModulesDirectoryLocator.kt
@@ -20,7 +20,7 @@ class LibModulesDirectoryLocator(
   override val locationKey = LibModulesDirectoryKey
 
   override fun findClasses(idePlugin: IdePlugin, pluginFile: Path): List<Resolver> {
-    val modulesDir = pluginFile.resolve("lib").resolve("modules")
+    val modulesDir = pluginFile.resolve(LIB_DIR).resolve(MODULES_DIR)
     if (!modulesDir.isDirectory) {
       return emptyList()
     }
@@ -33,7 +33,7 @@ class LibModulesDirectoryLocator(
 }
 
 object LibModulesDirectoryKey : LocationKey {
-  override val name: String = "lib/modules directory"
+  override val name: String = "$LIB_DIR/$MODULES_DIR directory"
 
   override fun getLocator(readMode: Resolver.ReadMode) = LibModulesDirectoryLocator(readMode)
 }

--- a/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/BundledPluginClassesFinder.kt
+++ b/intellij-plugin-structure/structure-intellij-classes/src/main/java/com/jetbrains/plugin/structure/intellij/classes/plugin/BundledPluginClassesFinder.kt
@@ -6,13 +6,16 @@ import com.jetbrains.plugin.structure.ide.classes.IdeFileOrigin
 import com.jetbrains.plugin.structure.intellij.classes.locator.FileOriginProvider
 import com.jetbrains.plugin.structure.intellij.classes.locator.JarPluginLocator
 import com.jetbrains.plugin.structure.intellij.classes.locator.LibDirectoryLocator
+import com.jetbrains.plugin.structure.intellij.classes.locator.LibModulesDirectoryLocator
 import com.jetbrains.plugin.structure.intellij.classes.locator.LocationKey
+import com.jetbrains.plugin.structure.intellij.classes.locator.MODULES_DIR
+import com.jetbrains.plugin.structure.intellij.classes.locator.NotAModulesDirectoryFilter
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import java.nio.file.Path
 
 class BundledPluginClassesFinder {
   companion object {
-    val LOCATION_KEYS = listOf(BundledPluginJarKey, BundledPluginDirectoryKey)
+    val LOCATION_KEYS = listOf(BundledPluginJarKey, BundledPluginDirectoryKey, BundledPluginLibModulesDirectoryKey)
 
     fun findPluginClasses(
       idePlugin: IdePlugin,
@@ -29,12 +32,19 @@ class BundledPluginClassesFinder {
 
   object BundledPluginDirectoryKey : LocationKey {
     override val name: String = "Bundled Plugin Directory"
-    override fun getLocator(readMode: Resolver.ReadMode) = LibDirectoryLocator(readMode, BundledPluginOriginator)
+    override fun getLocator(readMode: Resolver.ReadMode) =
+      LibDirectoryLocator(readMode, BundledPluginOriginator, NotAModulesDirectoryFilter)
   }
 
   object BundledPluginOriginator : FileOriginProvider {
     override fun getFileOrigin(idePlugin: IdePlugin, pluginFile: Path): FileOrigin {
       return IdeFileOrigin.BundledPlugin(pluginFile, idePlugin)
     }
+  }
+
+  object BundledPluginLibModulesDirectoryKey : LocationKey {
+    override val name: String = "Bundled Plugin lib/$MODULES_DIR directory"
+
+    override fun getLocator(readMode: Resolver.ReadMode) = LibModulesDirectoryLocator(readMode)
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/BundledPluginManager.kt
@@ -18,7 +18,7 @@ import java.nio.file.Path
 private val LOG = LoggerFactory.getLogger(BundledPluginManager::class.java)
 
 private const val PLUGINS_DIRECTORY = "plugins"
-private const val LIB_DIRECTORY = "lib"
+internal const val LIB_DIRECTORY = "lib"
 
 class BundledPluginManager(private val pluginIdProvider: PluginIdProvider) {
   private val descriptorProvider = PluginDescriptorProvider()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -16,6 +16,10 @@ class Classpath private constructor(val entries: List<ClasspathEntry> = emptyLis
 
   val size: Int = entries.size
 
+  val paths: List<Path> = entries.map { it.path }
+
+  val uniquePaths: Set<Path> = paths.distinct().toSet()
+
   override fun toString(): String = entries.joinToString(separator = ":", prefix = "[", postfix = "]")
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -1,0 +1,29 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.intellij.plugin.ClasspathOrigin.IMPLICIT
+import java.nio.file.Path
+
+class Classpath private constructor(val entries: List<ClasspathEntry> = emptyList<ClasspathEntry>()) {
+  companion object {
+    @JvmField
+    val EMPTY = Classpath()
+
+    fun of(paths: Collection<Path>, origin: ClasspathOrigin = IMPLICIT): Classpath {
+      val entries = paths.map { ClasspathEntry(it, origin) }
+      return Classpath(entries)
+    }
+  }
+
+  val size: Int = entries.size
+}
+
+class ClasspathEntry(val path: Path, val origin: ClasspathOrigin = IMPLICIT)
+
+enum class ClasspathOrigin {
+  IMPLICIT,
+
+  /**
+   * Declared in `product-info.json`
+   */
+  PRODUCT_INFO
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -16,9 +16,7 @@ class Classpath private constructor(val entries: List<ClasspathEntry> = emptyLis
 
   val size: Int = entries.size
 
-  val paths: List<Path> = entries.map { it.path }
-
-  val uniquePaths: Set<Path> = paths.distinct().toSet()
+  val paths: Set<Path> = entries.map { it.path }.toSet()
 
   override fun toString(): String = entries.joinToString(separator = ":", prefix = "[", postfix = "]")
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -15,9 +15,13 @@ class Classpath private constructor(val entries: List<ClasspathEntry> = emptyLis
   }
 
   val size: Int = entries.size
+
+  override fun toString(): String = entries.joinToString(separator = ":", prefix = "[", postfix = "]")
 }
 
-class ClasspathEntry(val path: Path, val origin: ClasspathOrigin = IMPLICIT)
+class ClasspathEntry(val path: Path, val origin: ClasspathOrigin = IMPLICIT) {
+  override fun toString() = "$path ($origin)"
+}
 
 enum class ClasspathOrigin {
   IMPLICIT,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
@@ -63,6 +63,8 @@ interface IdePlugin : Plugin {
 
   val useIdeClassLoader: Boolean
 
+  val classpath: Classpath
+
   val isImplementationDetail: Boolean
 
   val isV2: Boolean

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
@@ -37,6 +37,9 @@ interface IdePlugin : Plugin {
 
   val incompatibleModules: List<String>
 
+  /**
+   * Plugin aliases.
+   */
   val definedModules: Set<String>
 
   val optionalDescriptors: List<OptionalPluginDescriptor>

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -54,6 +54,9 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
 
   override val declaredThemes: MutableList<IdeTheme> = arrayListOf()
 
+  /**
+   * Plugin aliases mapped from the `idea-plugin/module` element.
+   */
   override val definedModules: MutableSet<String> = hashSetOf()
 
   override val dependencies: MutableList<PluginDependency> = arrayListOf()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -42,6 +42,8 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
 
   override var useIdeClassLoader: Boolean = false
 
+  override var classpath: Classpath = Classpath.EMPTY
+
   override var isImplementationDetail: Boolean = false
 
   override var isV2: Boolean = false
@@ -116,6 +118,7 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
         changeNotes = old.changeNotes
         url = old.url
         useIdeClassLoader = old.useIdeClassLoader
+        classpath = old.classpath
         isImplementationDetail = old.isImplementationDetail
         isV2 = old.isV2
         kotlinPluginMode = old.kotlinPluginMode

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
@@ -44,6 +44,7 @@ class InvalidPlugin(override val underlyingDocument: Document) : IdePlugin, Stru
   override val productDescriptor: ProductDescriptor? = null
   override val declaredThemes: List<IdeTheme> = emptyList()
   override val useIdeClassLoader: Boolean = false
+  override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail: Boolean = false
   override val isV2: Boolean = false
   override val kotlinPluginMode: KotlinPluginMode = Implicit

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -288,6 +288,10 @@ internal class PluginCreator private constructor(
     plugin.hasDotNetPart = hasDotNetPart
   }
 
+  fun setClasspath(classpath: Classpath) {
+    plugin.classpath = classpath
+  }
+
   fun setPluginIdIfNull(id: String) {
     if (plugin.pluginId == null) {
       plugin.pluginId = id

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
@@ -1,0 +1,75 @@
+package com.jetbrains.plugin.structure.intellij.plugin.descriptors
+
+import com.jetbrains.plugin.structure.base.utils.closeAll
+import com.jetbrains.plugin.structure.base.utils.inputStream
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.nio.file.Path
+import javax.xml.stream.XMLEventReader
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamException
+import javax.xml.stream.events.StartElement
+import javax.xml.stream.events.XMLEvent
+
+private val LOG: Logger = LoggerFactory.getLogger(IdeaPluginXmlDetector::class.java)
+
+private const val IDEA_PLUGIN_ROOT_ELEMENT = "idea-plugin"
+
+class IdeaPluginXmlDetector {
+  fun isPluginDescriptor(descriptorPath: Path): Boolean {
+    val closeables = mutableListOf<Closeable>()
+    try {
+      val inputFactory: XMLInputFactory = newXmlInputFactory()
+      val eventReader = inputFactory.newEventReader(descriptorPath).also { closeables += it }
+
+      while (eventReader.hasNextEvent()) {
+        val event: XMLEvent = eventReader.nextEvent()
+        if (event.isIdeaPluginElement()) {
+          return true
+        }
+      }
+      return false
+    } catch (e: Exception) {
+      LOG.warn("Unable to read plugin descriptor $descriptorPath", e)
+      return false
+    } finally {
+      closeables.closeAll()
+    }
+  }
+
+  private fun XMLEvent.isIdeaPluginElement(): Boolean =
+    this is StartElement && name.localPart == IDEA_PLUGIN_ROOT_ELEMENT
+
+  private fun XMLInputFactory.newEventReader(descriptorPath: Path): CloseableXmlEventReader {
+    return CloseableXmlEventReader(createXMLEventReader(descriptorPath.inputStream()))
+  }
+
+
+  // FIXME duplicate with XmlStreamEventFilter
+  private fun newXmlInputFactory() = XMLInputFactory.newInstance().apply {
+    setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
+    setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+  }
+
+  // FIXME duplicate with XmlStreamings
+  class CloseableXmlEventReader(private val delegate: XMLEventReader) : XMLEventReader by delegate, Closeable {
+    @Throws(XMLStreamException::class)
+    override fun close() {
+      delegate.close()
+    }
+  }
+
+  // FIXME duplicate with XmlStreamEventFilter
+  private fun CloseableXmlEventReader.hasNextEvent(): Boolean {
+    return try {
+      hasNext()
+    } catch (e: XMLStreamException) {
+      LOG.error("Cannot retrieve next event", e)
+      false
+    } catch (e: RuntimeException) {
+      LOG.error("Cannot retrieve next event", e)
+      false
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
@@ -30,8 +30,16 @@ class IdeaPluginXmlDetector {
         }
       }
       return false
+    } catch (e: XMLStreamException) {
+      if (e.message?.contains("is reserved by the xml specification") == true) {
+        LOG.debug("Unable to read plugin descriptor '{}': {}", descriptorPath, e.message)
+        return false;
+      } else {
+        LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
+        return false
+      }
     } catch (e: Exception) {
-      LOG.warn("Unable to read plugin descriptor $descriptorPath", e)
+      LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
       return false
     } finally {
       closeables.closeAll()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
@@ -32,13 +32,8 @@ class IdeaPluginXmlDetector {
       }
       return false
     } catch (e: XMLStreamException) {
-      if (e.message?.contains("is reserved by the xml specification") == true) {
-        LOG.debug("Unable to read plugin descriptor '{}': {}", descriptorPath, e.message)
-        return false;
-      } else {
-        LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
-        return false
-      }
+      LOG.debug("Unable to read plugin descriptor '{}': {}", descriptorPath, e.message)
+      return false
     } catch (e: Exception) {
       LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
       return false

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
@@ -2,11 +2,12 @@ package com.jetbrains.plugin.structure.intellij.plugin.descriptors
 
 import com.jetbrains.plugin.structure.base.utils.closeAll
 import com.jetbrains.plugin.structure.base.utils.inputStream
+import com.jetbrains.plugin.structure.xml.CloseableXmlEventReader
+import com.jetbrains.plugin.structure.xml.newXmlInputFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.nio.file.Path
-import javax.xml.stream.XMLEventReader
 import javax.xml.stream.XMLInputFactory
 import javax.xml.stream.XMLStreamException
 import javax.xml.stream.events.StartElement
@@ -51,33 +52,5 @@ class IdeaPluginXmlDetector {
 
   private fun XMLInputFactory.newEventReader(descriptorPath: Path): CloseableXmlEventReader {
     return CloseableXmlEventReader(createXMLEventReader(descriptorPath.inputStream()))
-  }
-
-
-  // FIXME duplicate with XmlStreamEventFilter
-  private fun newXmlInputFactory() = XMLInputFactory.newInstance().apply {
-    setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false)
-    setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
-  }
-
-  // FIXME duplicate with XmlStreamings
-  class CloseableXmlEventReader(private val delegate: XMLEventReader) : XMLEventReader by delegate, Closeable {
-    @Throws(XMLStreamException::class)
-    override fun close() {
-      delegate.close()
-    }
-  }
-
-  // FIXME duplicate with XmlStreamEventFilter
-  private fun CloseableXmlEventReader.hasNextEvent(): Boolean {
-    return try {
-      hasNext()
-    } catch (e: XMLStreamException) {
-      LOG.error("Cannot retrieve next event", e)
-      false
-    } catch (e: RuntimeException) {
-      LOG.error("Cannot retrieve next event", e)
-      false
-    }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModule.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModule.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import java.nio.file.Path
+
+data class ContentModule(val id: String, val artifactPath: Path, val descriptorPath: Path)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -1,0 +1,68 @@
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.listJars
+import com.jetbrains.plugin.structure.intellij.plugin.LIB_DIRECTORY
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.jar.PluginJar
+import java.nio.file.Path
+
+
+private const val MODULES_DIR = "modules"
+
+class ContentModuleScanner {
+  private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
+
+  fun getContentModules(pluginArtifact: Path) : ContentModules {
+    val libDir = pluginArtifact.resolve(LIB_DIRECTORY)
+    if (!libDir.exists()) {
+      return ContentModules(pluginArtifact, emptyList())
+    }
+    val jarPaths = libDir.listJars()
+    val moduleJarPaths = libDir.resolve(MODULES_DIR).listJars()
+    val contentModules = (jarPaths + moduleJarPaths).flatMap { jarPath ->
+      PluginJar(jarPath).use { jar ->
+        val descriptorPaths = jar.resolveDescriptors { it.matches() }
+        descriptorPaths.map {
+          val moduleName = if (it.isMetaInfPluginXml()) {
+            "ROOT"
+          } else {
+            it.getModuleName()
+          }
+          ContentModule(moduleName, jarPath, it)
+        }
+      }
+    }
+
+    return ContentModules(pluginArtifact, contentModules)
+  }
+
+  private fun Path.matches(): Boolean {
+    return when (this.nameCount) {
+      1 -> getName(0).isPluginDescriptorInJarRoot()
+      2 -> isMetaInfPluginXml()
+      else -> false
+    }
+  }
+
+  private fun Path.matches(vararg pathComponents: String): Boolean {
+    val thisComponents = map {
+      it.toString()
+    }
+    return thisComponents == pathComponents.toList()
+  }
+
+  // TODO constant
+  private fun Path.isMetaInfPluginXml(): Boolean = matches("META-INF", "plugin.xml")
+
+  private fun Path.isPluginDescriptorInJarRoot(): Boolean {
+    // TODO constant
+    val isXml = toString().endsWith(".xml", true)
+    return isXml && ideaPluginXmlDetector.isPluginDescriptor(this)
+  }
+
+  private fun Path.getModuleName(): String {
+    // TODO constant
+    return this.fileName.toString().removeSuffix(".xml")
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -1,14 +1,19 @@
 package com.jetbrains.plugin.structure.intellij.plugin.module
 
 import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.hasExtension
 import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.intellij.plugin.LIB_DIRECTORY
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.jar.META_INF
+import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.plugin.structure.jar.PluginJar
 import java.nio.file.Path
 
 
 private const val MODULES_DIR = "modules"
+
+private const val XML_EXTENSION = "xml"
 
 class ContentModuleScanner {
   private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
@@ -38,7 +43,7 @@ class ContentModuleScanner {
   }
 
   private fun Path.matches(): Boolean {
-    return when (this.nameCount) {
+    return when (nameCount) {
       1 -> getName(0).isPluginDescriptorInJarRoot()
       2 -> isMetaInfPluginXml()
       else -> false
@@ -52,17 +57,14 @@ class ContentModuleScanner {
     return thisComponents == pathComponents.toList()
   }
 
-  // TODO constant
-  private fun Path.isMetaInfPluginXml(): Boolean = matches("META-INF", "plugin.xml")
+  private fun Path.isMetaInfPluginXml(): Boolean = matches(META_INF, PLUGIN_XML)
 
   private fun Path.isPluginDescriptorInJarRoot(): Boolean {
-    // TODO constant
-    val isXml = toString().endsWith(".xml", true)
+    val isXml = hasExtension(XML_EXTENSION)
     return isXml && ideaPluginXmlDetector.isPluginDescriptor(this)
   }
 
   private fun Path.getModuleName(): String {
-    // TODO constant
-    return this.fileName.toString().removeSuffix(".xml")
+    return this.fileName.toString().removeSuffix(".$XML_EXTENSION")
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModules.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModules.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
+import java.nio.file.Path
+
+data class ContentModules(val pluginArtifact: Path, val modules: List<ContentModule>) {
+  val resolvedClassPath: List<Path>
+    get() = modules.map { it.artifactPath }
+
+  fun asClasspath(): Classpath = Classpath.of(resolvedClassPath)
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
@@ -3,6 +3,8 @@ package com.jetbrains.plugin.structure.intellij.plugin.module
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
 import com.jetbrains.plugin.structure.intellij.beans.ModuleBean
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath.Companion.EMPTY
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
@@ -14,13 +16,11 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import org.jdom2.Document
 import org.jdom2.Element
-import java.nio.file.Path
 
 typealias Dependency = ModuleBean.ModuleDependency
 typealias Resource = ModuleBean.ResourceRoot
 
-class IdeModule(override val pluginId: String) : IdePlugin {
-  val classpath = mutableListOf<Path>()
+class IdeModule(override val pluginId: String, override val classpath: Classpath = EMPTY) : IdePlugin {
   val moduleDependencies = mutableListOf<Dependency>()
   val resources = mutableListOf<Resource>()
   override var underlyingDocument = Document()
@@ -61,8 +61,8 @@ class IdeModule(override val pluginId: String) : IdePlugin {
 
   companion object {
     @Throws(IllegalArgumentException::class)
-    fun clone(plugin: IdePlugin, pluginId: String): IdeModule {
-      return IdeModule(pluginId).apply {
+    fun clone(plugin: IdePlugin, pluginId: String, classpath: Classpath): IdeModule {
+      return IdeModule(pluginId,classpath).apply {
         underlyingDocument = plugin.underlyingDocument.clone()
 
         extensions.putAll(plugin.extensions)

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
@@ -18,11 +18,12 @@ class ClasspathTest {
   }
 
   @Test
-  fun `classpath paths are retrieved`() {
+  fun `classpath paths are retrieved without duplicates`() {
     val pluginPath = Path.of("lib", "plugin.jar")
     val modulePath = Path.of("lib", "modules", "module.jar")
+    val v2ModulePathAsADuplicate = Path.of("lib", "modules", "module.jar")
 
-    val cp = Classpath.of(listOf(pluginPath, modulePath))
+    val cp = Classpath.of(listOf(pluginPath, modulePath, v2ModulePathAsADuplicate))
 
     with(cp.paths) {
       assertEquals(2, size)

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
@@ -1,0 +1,48 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Path
+
+class ClasspathTest {
+  @Test
+  fun `classpath is created`() {
+    val pluginPath = Path.of("lib", "plugin.jar")
+    val modulePath = Path.of("lib", "modules", "module.jar")
+
+    val cp = Classpath.of(listOf(pluginPath, modulePath))
+    assertEquals(2, cp.size)
+    assertTrue("Classpath must contain the plugin artifact",cp.entries.any { it.path == pluginPath })
+    assertTrue("Classpath must contain the module artifact", cp.entries.any { it.path == modulePath })
+  }
+
+  @Test
+  fun `classpath paths are retrieved`() {
+    val pluginPath = Path.of("lib", "plugin.jar")
+    val modulePath = Path.of("lib", "modules", "module.jar")
+
+    val cp = Classpath.of(listOf(pluginPath, modulePath))
+
+    with(cp.paths) {
+      assertEquals(2, size)
+      assertTrue("Classpath paths must contain the plugin artifact",any { it == pluginPath })
+      assertTrue("Classpath paths must contain the module artifact", any { it == modulePath })
+    }
+  }
+
+  @Test
+  fun `duplicate paths are retrieved`() {
+    val pluginPath = Path.of("lib", "plugin.jar")
+    val duplicatePluginPath = Path.of("lib", "plugin.jar")
+    val modulePath = Path.of("lib", "modules", "module.jar")
+
+    val cp = Classpath.of(listOf(pluginPath, duplicatePluginPath, modulePath))
+
+    with(cp.uniquePaths) {
+      assertEquals(2, size)
+      assertTrue("Classpath paths must contain the plugin artifact",any { it == pluginPath })
+      assertTrue("Classpath paths must contain the module artifact", any { it == modulePath })
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ClasspathTest.kt
@@ -39,7 +39,7 @@ class ClasspathTest {
 
     val cp = Classpath.of(listOf(pluginPath, duplicatePluginPath, modulePath))
 
-    with(cp.uniquePaths) {
+    with(cp.paths) {
       assertEquals(2, size)
       assertTrue("Classpath paths must contain the plugin artifact",any { it == pluginPath })
       assertTrue("Classpath paths must contain the module artifact", any { it == modulePath })

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarDescriptorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarDescriptorTest.kt
@@ -1,0 +1,68 @@
+package com.jetbrains.plugin.structure.base.utils
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.jar.PluginJar
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+class PluginJarDescriptorTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var pluginJarPath: Path
+
+  private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
+
+  @Before
+  fun setUp() {
+    pluginJarPath = buildZipFile(temporaryFolder.newFile("plugin.jar").toPath()) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+          <idea-plugin>
+            <name>JSON</name>
+            <id>com.intellij.modules.json</id>
+            <version>251.21418.62</version>
+          </idea-plugin>            
+          """.trimIndent()
+        }
+      }
+      file("intellij.json.xml") {
+        """
+        <idea-plugin>
+          <dependencies>
+            <module name="intellij.json.split"/>
+          </dependencies>
+        </idea-plugin>                    
+        """.trimIndent()
+      }
+    }
+  }
+
+  @Test
+  fun `descriptors in META-INF and in roots are resolved`() {
+    val descriptors = PluginJar(pluginJarPath).resolveDescriptors()
+    assertEquals(2, descriptors.size)
+    assertTrue(descriptors.any { it.hasFileName("plugin.xml") })
+    assertTrue(descriptors.any { it.hasFileName("intellij.json.xml") })
+  }
+
+  @Test
+  fun `descriptors in META-INF and in roots are resolved with 'idea-plugin' detectiom`() {
+    val descriptors = PluginJar(pluginJarPath).resolveDescriptors(ideaPluginXmlDetector::isPluginDescriptor)
+    assertEquals(2, descriptors.size)
+    assertTrue(descriptors.any { it.hasFileName("plugin.xml") })
+    assertTrue(descriptors.any { it.hasFileName("intellij.json.xml") })
+  }
+
+  private fun Path.hasFileName(fileName: String): Boolean {
+    return fileName.toString() == fileName
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/PluginDependencyFilteredResolverTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent.Plugin
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent.PluginAlias
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
@@ -35,6 +36,8 @@ class PluginDependencyFilteredResolverTest {
   val temporaryFolder = TemporaryFolder()
 
   private lateinit var ideRoot: Path
+
+  private lateinit var ideaCorePluginFile: Path
 
   private lateinit var ideaCorePlugin: IdePlugin
   private lateinit var javaPlugin: IdePlugin
@@ -74,15 +77,17 @@ class PluginDependencyFilteredResolverTest {
 
     ideRoot = temporaryFolder.newFolder("idea").toPath()
 
+    ideaCorePluginFile = temporaryFolder.newTemporaryFile("idea/lib/product.jar")
     ideaCorePlugin = MockIdePlugin(
       pluginId = "com.intellij",
       pluginName = "IDEA CORE",
-      originalFile = temporaryFolder.newTemporaryFile("idea/lib/product.jar"),
+      originalFile = ideaCorePluginFile,
       definedModules = setOf(
         "com.intellij.modules.platform",
         "com.intellij.modules.lang",
         "com.intellij.modules.java",
-      )
+      ),
+      classpath = Classpath.of(listOf(ideaCorePluginFile))
     ).also {
       it.writeEmptyClass("com.intellij.openapi.editor.Caret")
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
@@ -1,0 +1,55 @@
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ContentModuleScannerTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `root module and 2 additional modules are resolved`() {
+    val root = temporaryFolder.root.toPath()
+
+    val pluginPath = buildDirectory(temporaryFolder.newFolder("json").toPath()) {
+      dir("lib") {
+        dir("modules") {
+          zip("intellij.json.split.jar") {
+            file("intellij.json.split.xml", "<idea-plugin />")
+          }
+        }
+        zip("json.jar") {
+          dir("META-INF") {
+            file("plugin.xml", "<idea-plugin />")
+          }
+          file("intellij.json.xml", "<idea-plugin />")
+        }
+      }
+    }
+
+    val contentModuleScanner = ContentModuleScanner()
+    val contentModules = contentModuleScanner.getContentModules(pluginPath)
+
+    with(contentModules.modules) {
+      assertEquals(3, size)
+      val identifiers = map { it.id }
+      assertTrue(identifiers.contains("intellij.json.split"))
+      assertTrue(identifiers.contains("intellij.json"))
+    }
+
+    /*
+    json.jar is intentionally put twice:
+    - once for the plugin itself,
+    - and another time as a module with descriptor in the root of JAR
+    */
+    val expectedClassPath = listOf("json/lib/json.jar", "json/lib/json.jar", "json/lib/modules/intellij.json.split.jar")
+    val resolvedClassPath = contentModules.resolvedClassPath.map { root.relativize(it).toString() }.sorted()
+
+    assertEquals(expectedClassPath, resolvedClassPath)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
@@ -44,11 +44,11 @@ data class MockIdePlugin(
   override val thirdPartyDependencies: List<ThirdPartyDependency> = emptyList(),
   override val modulesDescriptors: List<ModuleDescriptor> = emptyList(),
   override val isV2: Boolean = false,
-  override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit
+  override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit,
+  override val classpath: Classpath = Classpath.EMPTY
 ) : IdePlugin {
 
   override val useIdeClassLoader = false
-  override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail = false
   override val hasDotNetPart: Boolean = false
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
@@ -2,6 +2,7 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
@@ -47,6 +48,7 @@ data class MockIdePlugin(
 ) : IdePlugin {
 
   override val useIdeClassLoader = false
+  override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail = false
   override val hasDotNetPart: Boolean = false
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/BundledPluginClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/BundledPluginClassResolverProvider.kt
@@ -1,11 +1,12 @@
 /*
- * Copyright 2000-2024 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.resolution
 
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 import com.jetbrains.pluginverifier.filtering.ExternalBuildClassesSelector
 import com.jetbrains.pluginverifier.filtering.MainClassesSelector
 import com.jetbrains.pluginverifier.plugin.PluginDetails
@@ -14,8 +15,11 @@ class BundledPluginClassResolverProvider {
   private val bundledClassesSelectors = listOf(MainClassesSelector.forBundledPlugin(), ExternalBuildClassesSelector())
 
   fun getResolver(pluginDetails: PluginDetails): Resolver {
-    val classLocations = pluginDetails.pluginClassesLocations
+    return getResolver(pluginDetails.pluginClassesLocations, pluginDetails.pluginInfo.pluginId)
+  }
+
+  fun getResolver(classLocations: IdePluginClassesLocations, resolverName: String): Resolver {
     return bundledClassesSelectors.flatMap { it.getClassLoader(classLocations) }
-      .let { CompositeResolver.create(it, pluginDetails.pluginInfo.pluginId) }
+      .let { CompositeResolver.create(it, resolverName) }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
@@ -95,7 +95,7 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
       hasModuleDescriptors = true
     )
     assertEquals(2, targetIde.bundledPlugins.size)
-    targetIde.assertHasBundledPluginWithPath(Paths.get("plugins/json/lib/json.jar"))
+    targetIde.assertHasBundledPluginWithPath(targetIde.resolvePath("plugins/json/lib/json.jar"))
 
     assertVerified {
       ide = targetIde
@@ -118,7 +118,7 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
       hasModuleDescriptors = true
     )
     assertEquals(2, targetIde.bundledPlugins.size)
-    targetIde.assertHasBundledPluginWithPath(Paths.get("plugins/json/lib/json.jar"))
+    targetIde.assertHasBundledPluginWithPath(targetIde.resolvePath("plugins/json/lib/json.jar"))
 
 
     val pluginSpec = IdeaPluginSpec("com.intellij.plugin", "JetBrains s.r.o.", dependencies = listOf(JSON_PLUGIN_ID))
@@ -133,10 +133,21 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
   }
 
   private fun Ide.assertHasBundledPluginWithPath(path: Path) {
-    val hasPlugin = bundledPlugins.any {
-      it.originalFile?.endsWith(path) ?: false
+    var hasPlugin = bundledPlugins.any {
+      it.originalFile?.endsWith(path) == true
     }
+    if (!hasPlugin) {
+      val paths = bundledPlugins.flatMap { it.classpath.uniquePaths }
+      hasPlugin = paths.any { it == path }
+    }
+
     if (!hasPlugin) throw AssertionError("IDE does not contain plugin that has a path ending with '$path'")
+  }
+
+  private fun Ide.resolvePath(path: String): Path {
+    val components = path.split("/")
+    val path = Paths.get("", *components.toTypedArray())
+    return idePath.resolve(path)
   }
 
   fun findAfterIdeaBuildClassPath(): Path {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/JsonPluginUsageTest.kt
@@ -137,8 +137,7 @@ class JsonPluginUsageTest : BaseBytecodeTest() {
       it.originalFile?.endsWith(path) == true
     }
     if (!hasPlugin) {
-      val paths = bundledPlugins.flatMap { it.classpath.uniquePaths }
-      hasPlugin = paths.any { it == path }
+      hasPlugin = bundledPlugins.flatMap { it.classpath.paths }.any { it == path }
     }
 
     if (!hasPlugin) throw AssertionError("IDE does not contain plugin that has a path ending with '$path'")

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.LibModulesDirectoryLocator
 import com.jetbrains.plugin.structure.intellij.classes.plugin.BundledPluginClassesFinder
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.pluginverifier.createPluginResolver
@@ -151,5 +152,33 @@ class PluginClasspathTest : BasePluginTest() {
         }
       }
     }
+  }
+
+  @Test
+  fun name() {
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        dir("modules") {
+          zip("intellij.json.split.jar") {
+            file("intellij.json.split.xml", "<idea-plugin />")
+          }
+        }
+        zip("json.jar") {
+          descriptor(ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON"))
+          file("intellij.json.xml", "<idea-plugin />")
+        }
+      }
+    }
+    assertSuccess(result) {
+      with(plugin.classpath) {
+        assertEquals(3, size)
+        assertTrue(containsFileName("json.jar"))
+        assertTrue(containsFileName("intellij.json.split.jar"))
+      }
+    }
+  }
+
+  fun Classpath.containsFileName(fileName: String): Boolean {
+    return entries.any { it.path.fileName.toString() == fileName }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -7,13 +7,14 @@ import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.LibModulesDirectoryLocator
+import com.jetbrains.plugin.structure.intellij.classes.plugin.BundledPluginClassesFinder
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesFinder
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.pluginverifier.createPluginResolver
+import com.jetbrains.pluginverifier.resolution.BundledPluginClassResolverProvider
 import com.jetbrains.pluginverifier.tests.mocks.classBytes
 import com.jetbrains.pluginverifier.tests.mocks.descriptor
-import com.jetbrains.pluginverifier.tests.mocks.ideaPlugin
 import net.bytebuddy.ByteBuddy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -91,5 +92,64 @@ class PluginClasspathTest : BasePluginTest() {
       .flatMap { it.allClasses }
     assertEquals(1, classes.size)
     assertEquals("Module", classes.first())
+  }
+
+  @Test
+  fun `classes in lib, lib_modules are discovered`() {
+    val pluginId = "pluginverifier"
+    val descriptor = ideaPlugin(pluginId, "Mock Classpath")
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        zip("plugin.jar") {
+          descriptor(descriptor)
+          classBytes("PluginCore", byteBuddy)
+        }
+        dir("modules") {
+          zip("plugin-module.jar") {
+            classBytes("Module", byteBuddy)
+          }
+        }
+      }
+    }
+    assertSuccess(result) {
+      IdePluginClassesFinder.findPluginClasses(plugin).use { classLocations ->
+        classLocations.createPluginResolver().use {
+          val pluginClasses = it.allClasses
+          assertEquals(2, pluginClasses.size)
+          assertTrue(pluginClasses.containsAll(setOf("PluginCore", "Module")))
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `classes in lib, lib_modules are discovered in a bundled plugin`() {
+    val pluginId = "pluginverifier"
+    val descriptor = ideaPlugin(pluginId, "Mock Classpath")
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        zip("plugin.jar") {
+          descriptor(descriptor)
+          classBytes("PluginCore", byteBuddy)
+        }
+        dir("modules") {
+          zip("plugin-module.jar") {
+            classBytes("Module", byteBuddy)
+          }
+        }
+      }
+    }
+
+    val classResolverProvider = BundledPluginClassResolverProvider()
+
+    assertSuccess(result) {
+      BundledPluginClassesFinder.findPluginClasses(plugin).use { classLocations ->
+        classResolverProvider.getResolver(classLocations, resolverName = pluginId).use {
+          val pluginClasses = it.allClasses
+          assertEquals(2, pluginClasses.size)
+          assertTrue(pluginClasses.containsAll(setOf("PluginCore", "Module")))
+        }
+      }
+    }
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockIdePlugin.kt
@@ -2,6 +2,7 @@ package com.jetbrains.pluginverifier.tests.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.intellij.plugin.Classpath
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
@@ -46,6 +47,7 @@ data class MockIdePlugin(
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit
 ) : IdePlugin {
 
+  override val classpath: Classpath = Classpath.EMPTY
   override val useIdeClassLoader = false
   override val isImplementationDetail = false
   override val hasDotNetPart: Boolean = false


### PR DESCRIPTION
Track classpath for IDE plugin.

- add `classpath` to IDE plugin that keeps track of all JARs corresponding to that plugin
- discover JARs for content modules in `lib` and `lib/modules` and add them to the plugin classpath
- when constructing a dependency tree for plugin in `PluginDependencyFilteredResolver`, use the plugin classpath along with classpath of dependencies. This resolves multiple scenarios when classes in `lib/modules` are not properly filtered.

See [MP-7299](https://youtrack.jetbrains.com/issue/MP-7299)