### PR TITLE
Split DTO and bean for Edu tasks field

### DIFF
--- a/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/EduPlugin.kt
+++ b/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/EduPlugin.kt
@@ -4,11 +4,11 @@
 
 package com.jetbrains.plugin.structure.edu
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.jetbrains.plugin.structure.base.plugin.Plugin
 import com.jetbrains.plugin.structure.base.plugin.PluginIcon
 import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
 import com.jetbrains.plugin.structure.edu.bean.EduPluginDescriptor
-import com.jetbrains.plugin.structure.edu.bean.EduTask
 
 
 data class EduPlugin(
@@ -67,14 +67,24 @@ data class EduStat(
       val lessons = allItems.filter {
         it.type == ItemType.LESSON.id || it.type == ItemType.FRAMEWORK.id || it.type.isBlank()
       }.map { it.presentableName }
+
       val tasks = allItems.filter { 
         it.type == ItemType.LESSON.id || it.type == ItemType.FRAMEWORK.id || it.type.isBlank()
-      }.associate { it.presentableName to it.taskList }
+      }.associate { it.presentableName to it.taskList.map { task ->
+        EduTask(name = task.name, customName = task.customName, taskType = task.taskType)
+      }}
 
       return EduStat(sections, lessons, tasks)
     }
   }
 }
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+data class EduTask(
+  val name: String = "",
+  val customName: String = "",
+  var taskType: String = ""
+)
 
 data class Section(val title: String, val items: List<String>)
 

--- a/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/bean/EduPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-edu/src/main/kotlin/com/jetbrains/plugin/structure/edu/bean/EduPluginDescriptor.kt
@@ -9,17 +9,14 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.jetbrains.plugin.structure.edu.*
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EduTask(
+data class EduTaskField(
   @JsonProperty(NAME)
   val name: String = "",
   @JsonProperty(CUSTOM_NAME)
   val customName: String = "",
   @JsonProperty(TASK_TYPE)
   var taskType: String = ""
-) {
-  val presentableName: String
-    get() = customName.takeIf { it.isNotBlank() } ?: name
-}
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class EduItem(
@@ -32,7 +29,7 @@ data class EduItem(
   @JsonProperty(ITEMS)
   val items: List<EduItem> = mutableListOf(),
   @JsonProperty(TASK_LIST)
-  var taskList: List<EduTask> = mutableListOf()
+  var taskList: List<EduTaskField> = mutableListOf()
 ) {
   val presentableName: String
     get() = customName.takeIf { it.isNotBlank() } ?: title

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/edu/mock/EduPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/edu/mock/EduPluginMockTest.kt
@@ -2,11 +2,7 @@ package com.jetbrains.plugin.structure.edu.mock
 
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.edu.EduPlugin
-import com.jetbrains.plugin.structure.edu.EduPluginManager
-import com.jetbrains.plugin.structure.edu.ItemType
-import com.jetbrains.plugin.structure.edu.TaskType
-import com.jetbrains.plugin.structure.edu.bean.EduTask
+import com.jetbrains.plugin.structure.edu.*
 import com.jetbrains.plugin.structure.mocks.BasePluginManagerTest
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*


### PR DESCRIPTION
Is needed to allow changing the plugin descriptor and validate it without affecting the structure - MP communication.