### PR TITLE
Deprecate `JarFilesResourceResolver`

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileSystemsPool.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileSystemsPool.kt
@@ -15,6 +15,7 @@ import java.time.Instant
  *
  * No more than [MAX_OPEN_JAR_FILE_SYSTEMS] will be open in the running application simultaneously.
  */
+@Deprecated("Use 'JarFileSystemProvider' implementations")
 internal object JarFileSystemsPool {
   private const val MAX_OPEN_JAR_FILE_SYSTEMS = 256
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
@@ -13,7 +13,7 @@ import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
-@Deprecated("Use 'JarsResourceLoader' instead.", replaceWith = ReplaceWith("JarsResourceLoader", "com.jetbrains.plugin.structure.intellij.resources.JarsResourceLoader"))
+@Deprecated("Use 'JarsResourceLoader' instead.", replaceWith = ReplaceWith("JarsResourceResolver", "com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver"))
 class JarFilesResourceResolver(private val jarFiles: List<Path>) : ResourceResolver {
 
   override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
@@ -13,6 +13,7 @@ import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
+@Deprecated("Use 'JarsResourceLoader' instead.", replaceWith = ReplaceWith("JarsResourceLoader", "com.jetbrains.plugin.structure.intellij.resources.JarsResourceLoader"))
 class JarFilesResourceResolver(private val jarFiles: List<Path>) : ResourceResolver {
 
   override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/resources/JarResourceResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/resources/JarResourceResolverTest.kt
@@ -2,7 +2,6 @@ package com.jetbrains.plugin.structure.intellij.resources
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.withZipFsSeparator
-import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.plugin.structure.classes.resolvers.jar.initializeSampleJarContent
 import com.jetbrains.plugin.structure.intellij.plugin.JarFilesResourceResolver
 import com.jetbrains.plugin.structure.jar.DefaultJarFileSystemProvider
@@ -22,10 +21,6 @@ class JarResourceResolverTest {
   val temporaryFolder = TemporaryFolder()
 
   private lateinit var byteBuddy: ByteBuddy
-
-  private val fileOrigin = object : FileOrigin {
-    override val parent: FileOrigin? = null
-  }
 
   private val fileSystemProvider = DefaultJarFileSystemProvider()
 


### PR DESCRIPTION
- Deprecate `JarFilesResourceResolver`
- Replace implementations with `JarsResourceResolver` in production code
- Deprecate `JarFileSystemsPool` as the internal implementation detail of `JarFilesResourceResolver`