### PR TITLE
Improve caching in singleton JAR filesystem provider

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -1,37 +1,137 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.jar
 
 import com.jetbrains.plugin.structure.base.utils.withSuperScheme
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.Closeable
 import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * File system provider that maintains open file systems in an internal cache.
- */
-class CachingJarFileSystemProvider : JarFileSystemProvider, AutoCloseable {
-  private val fsCache: MutableMap<URI, FileSystem> = ConcurrentHashMap()
+private const val MAX_OPEN_JAR_FILE_SYSTEMS = 256
+
+private const val UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE = 64
+
+const val RETENTION_TIME_PROPERTY_NAME = "com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime"
+
+private val LOG: Logger = LoggerFactory.getLogger(CachingJarFileSystemProvider::class.java)
+
+class CachingJarFileSystemProvider(
+  val retentionTimeInSeconds: Long = System.getProperty(RETENTION_TIME_PROPERTY_NAME)
+    ?.toLongOrNull() ?: 10L
+) : JarFileSystemProvider, AutoCloseable {
+
+  private val fsCache = ConcurrentHashMap<URI, FSHandle>()
+
+  private val clock = Clock.systemUTC()
 
   private val delegateJarFileSystemProvider = UriJarFileSystemProvider { it.toUri().withSuperScheme(JAR_SCHEME) }
 
   override fun getFileSystem(jarPath: Path): FileSystem {
+    return getOrOpenFsHandler(jarPath).fs
+  }
+
+  @Synchronized
+  private fun getOrOpenFsHandler(jarPath: Path): FSHandle {
     val jarUri = jarPath.toJarFileUri()
-    try {
-      return fsCache.computeIfAbsent(jarUri) { delegateJarFileSystemProvider.getFileSystem(jarPath) }
-    } catch (e: Throwable) {
-      throw JarArchiveCannotBeOpenException(jarPath, jarUri, e)
+
+    val fsHandle = fsCache.getOrPut(jarUri) {
+      val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
+        LOG.debug("Opening a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.size)
+      }
+      FSHandle(jarFs, jarUri, clock.instant(), 0)
+    }
+
+    fsHandle.users++
+    fsHandle.lastAccessTime = clock.instant()
+    cleanup()
+    return fsHandle
+  }
+
+  @Synchronized
+  private fun cleanup() {
+    if (fsCache.size <= MAX_OPEN_JAR_FILE_SYSTEMS) return
+
+    val handlesToExpire = fsCache.values
+      .filter { it.shouldExpire }
+      .sortedBy { it.lastAccessTime }
+      .take(UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE)
+      .also(::logHandles)
+
+    handlesToExpire.forEach {
+      expire(it)
     }
   }
 
+  private fun expire(fsHandle: FSHandle) {
+    fsHandle.close()
+    fsCache.remove(fsHandle.uri)
+    LOG.debug("Expiring filesystem handler for <{}>", fsHandle.uri)
+  }
+
+  @Synchronized
   override fun close(jarPath: Path) {
     val jarUri = jarPath.toJarFileUri()
-    fsCache[jarUri]?.let { fs ->
-      fs.close()
-      fsCache.remove(jarUri)
+    val fsHandle = fsCache[jarUri] ?: return
+    with(fsHandle) {
+      users--
+      if (shouldExpire) {
+        System.err.println("No useres and expired. Closing FS for $jarUri. Users: $users")
+        expire(this)
+      } else {
+        System.err.println("Users: $users. Retention: $retentionTimeInSeconds.")
+      }
     }
   }
 
+  private val FSHandle.shouldExpire: Boolean
+    get() = users == 0 && hasTimedOut
+
+  private val FSHandle.hasTimedOut: Boolean
+    get() {
+      if (retentionTimeInSeconds == 0L) return true
+      val now = clock.instant()
+      return lastAccessTime.plusSeconds(retentionTimeInSeconds).isBefore(now)
+    }
+
+  private data class FSHandle(
+    val fs: FileSystem,
+    val uri: URI,
+    var lastAccessTime: Instant,
+    var users: Int = 0
+  ): Closeable {
+    override fun close() {
+      try {
+        fs.close()
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        LOG.info("Cannot close due to an interruption for [{}]", fs)
+      } catch (_: NoSuchFileException) {
+        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
+      } catch (_: java.nio.file.NoSuchFileException) {
+        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
+      } catch (e: Exception) {
+        LOG.error("Unable to close [{}]", fs, e)
+      }
+    }
+  }
+
+  @Synchronized
   override fun close() {
-    fsCache.clear()
+    fsCache.values.forEach { fsHandle ->
+      expire(fsHandle)
+    }
+  }
+
+  private fun logHandles(handles: Collection<FSHandle>) {
+    if(handles.isEmpty()) return
+    LOG.debug("Will expire {} cached FS entries", handles.size)
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
@@ -30,7 +30,7 @@ private val LOG: Logger = LoggerFactory.getLogger(PluginJar::class.java)
 class PluginJar(private val jarPath: Path, private val jarFileSystemProvider: JarFileSystemProvider): AutoCloseable {
 
   private val jarFileSystem: FileSystem = jarFileSystemProvider.getFileSystem(jarPath).also {
-    LOG.debug("Provider '{}' created file system for [{}]", jarFileSystemProvider.javaClass.name, jarPath)
+    LOG.debug("File system for [{}] was provided by '{}'", jarPath, jarFileSystemProvider.javaClass.name)
   }
 
   fun resolveDescriptorPath(descriptorPath: String = PLUGIN_XML_RESOURCE_PATH): Path? {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
@@ -106,7 +106,18 @@ object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoClosea
     var users: Int = 0
   ): Closeable {
     override fun close() {
-      fs.closeLogged()
+      try {
+        fs.close()
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        LOG.info("Cannot close due to an interruption for [{}]", fs)
+      } catch (_: NoSuchFileException) {
+        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
+      } catch (_: java.nio.file.NoSuchFileException) {
+        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
+      } catch (e: Exception) {
+        LOG.error("Unable to close [{}]", fs, e)
+      }
     }
   }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
@@ -1,134 +1,18 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.jar
 
-import com.jetbrains.plugin.structure.base.utils.withSuperScheme
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import java.io.Closeable
-import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.Path
-import java.time.Clock
-import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
 
-/**
- * A singleton file system provider that maintains open file systems in an internal cache.
- *
- * This cache is limited in size. Entries expire by the LRU philosophy.
- *
- * @see [com.jetbrains.plugin.structure.classes.resolvers.JarFileSystemsPool]
- */
 object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoCloseable {
-  private val LOG: Logger = LoggerFactory.getLogger(javaClass)
+  private val delegate = CachingJarFileSystemProvider()
 
-  private const val MAX_OPEN_JAR_FILE_SYSTEMS = 256
+  override fun getFileSystem(jarPath: Path): FileSystem = delegate.getFileSystem(jarPath)
 
-  private const val UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE = 64
+  override fun close(jarPath: Path): Unit = delegate.close(jarPath)
 
-  private val retentionTimeInSeconds =
-    System.getProperty("com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime")
-      ?.toLongOrNull() ?: 10L
-
-  private val fsCache = ConcurrentHashMap<URI, FSHandle>()
-
-  private val clock = Clock.systemUTC()
-
-  private val delegateJarFileSystemProvider = UriJarFileSystemProvider { it.toUri().withSuperScheme(JAR_SCHEME) }
-
-  override fun getFileSystem(jarPath: Path): FileSystem {
-    return getOrOpenFsHandler(jarPath).fs
-  }
-
-  @Synchronized
-  private fun getOrOpenFsHandler(jarPath: Path): FSHandle {
-    val jarUri = jarPath.toJarFileUri()
-
-    val fsHandle = fsCache.getOrPut(jarUri) {
-      val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
-        LOG.debug("Opening a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.size)
-      }
-      FSHandle(jarFs, jarUri, clock.instant(), 0)
-    }
-
-    fsHandle.users++
-    fsHandle.lastAccessTime = clock.instant()
-    cleanup()
-    return fsHandle
-  }
-
-  @Synchronized
-  private fun cleanup() {
-    if (fsCache.size <= MAX_OPEN_JAR_FILE_SYSTEMS) return
-
-    val handlesToExpire = fsCache.values
-      .filter { it.shouldExpire }
-      .sortedBy { it.lastAccessTime }
-      .take(UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE)
-      .also(::logHandles)
-
-    handlesToExpire.forEach {
-      expire(it)
-    }
-  }
-
-  private fun expire(fsHandle: FSHandle) {
-    fsHandle.close()
-    fsCache.remove(fsHandle.uri)
-    LOG.debug("Expiring filesystem handler for <{}>", fsHandle.uri)
-  }
-
-  @Synchronized
-  override fun close(jarPath: Path) {
-    val jarUri = jarPath.toJarFileUri()
-    val fsHandle = fsCache[jarUri] ?: return
-    with(fsHandle) {
-      users--
-      if (shouldExpire) {
-        expire(this)
-      }
-    }
-  }
-
-  private val FSHandle.shouldExpire: Boolean
-    get() = users == 0 && hasTimedOut
-
-  private val FSHandle.hasTimedOut: Boolean
-    get() {
-      val now = clock.instant()
-      return lastAccessTime.plusSeconds(retentionTimeInSeconds).isBefore(now)
-    }
-
-  private data class FSHandle(
-    val fs: FileSystem,
-    val uri: URI,
-    var lastAccessTime: Instant,
-    var users: Int = 0
-  ): Closeable {
-    override fun close() {
-      try {
-        fs.close()
-      } catch (_: InterruptedException) {
-        Thread.currentThread().interrupt()
-        LOG.info("Cannot close due to an interruption for [{}]", fs)
-      } catch (_: NoSuchFileException) {
-        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
-      } catch (_: java.nio.file.NoSuchFileException) {
-        LOG.debug("Cannot close as the file no longer exists for [{}]", fs)
-      } catch (e: Exception) {
-        LOG.error("Unable to close [{}]", fs, e)
-      }
-    }
-  }
-
-  @Synchronized
-  override fun close() {
-    fsCache.values.forEach { fsHandle ->
-      expire(fsHandle)
-    }
-  }
-
-  private fun logHandles(handles: Collection<FSHandle>) {
-    if(handles.isEmpty()) return
-    LOG.debug("Will expire {} cached FS entries", handles.size)
-  }
+  override fun close(): Unit = delegate.close()
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
@@ -65,7 +65,7 @@ object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoClosea
       .filter { it.shouldExpire }
       .sortedBy { it.lastAccessTime }
       .take(UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE)
-      .also { LOG.debug("Will expire {} cached FS entries", it.size) }
+      .also(::logHandles)
 
     handlesToExpire.forEach {
       expire(it)
@@ -93,7 +93,6 @@ object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoClosea
   private val FSHandle.shouldExpire: Boolean
     get() = users == 0 && hasTimedOut
 
-
   private val FSHandle.hasTimedOut: Boolean
     get() {
       val now = clock.instant()
@@ -116,5 +115,10 @@ object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoClosea
     fsCache.values.forEach { fsHandle ->
       expire(fsHandle)
     }
+  }
+
+  private fun logHandles(handles: Collection<FSHandle>) {
+    if(handles.isEmpty()) return
+    LOG.debug("Will expire {} cached FS entries", handles.size)
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProvider.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.plugin.structure.jar
 
-import com.jetbrains.plugin.structure.base.utils.closeLogged
 import com.jetbrains.plugin.structure.base.utils.withSuperScheme
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -27,7 +26,7 @@ object SingletonCachingJarFileSystemProvider : JarFileSystemProvider, AutoClosea
   private const val UNUSED_JAR_FILE_SYSTEMS_TO_CLOSE = 64
 
   private val retentionTimeInSeconds =
-    System.getenv("com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime")
+    System.getProperty("com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime")
       ?.toLongOrNull() ?: 10L
 
   private val fsCache = ConcurrentHashMap<URI, FSHandle>()

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -36,9 +36,9 @@ import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationR
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.plugin.structure.jar.DefaultJarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
+import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -59,7 +59,7 @@ class ProductInfoBasedIdeManager(
   private val layoutComponentProvider =
     LayoutComponentsProvider(missingLayoutFileMode = missingLayoutFileMode)
 
-  private val jarFileSystemProvider: JarFileSystemProvider = DefaultJarFileSystemProvider()
+  private val jarFileSystemProvider: JarFileSystemProvider = SingletonCachingJarFileSystemProvider
 
   /**
    * Problem level remapping used for bundled plugins.

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/JarFilesResourceResolver.kt
@@ -13,7 +13,7 @@ import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
-@Deprecated("Use 'JarsResourceLoader' instead.", replaceWith = ReplaceWith("JarsResourceResolver", "com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver"))
+@Deprecated("Use 'JarsResourceResolver' instead.", replaceWith = ReplaceWith("JarsResourceResolver", "com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver"))
 class JarFilesResourceResolver(private val jarFiles: List<Path>) : ResourceResolver {
 
   override fun resolveResource(relativePath: String, basePath: Path): ResourceResolver.Result {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.plugin.structure.jar
 
 import com.jetbrains.plugin.structure.base.utils.writeText
-import org.junit.Assert
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -9,14 +9,14 @@ import java.net.URI
 import java.nio.file.FileSystems
 import java.nio.file.Path
 
-class SingletonCachingJarFileSystemProviderTest {
+class CachingJarFileSystemProviderTest {
 
   @Rule
   @JvmField
   val tempFolder = TemporaryFolder()
 
   @Test
-  fun `Jar Uris are normalized`() {
+  fun `JAR URIss are normalized`() {
     val jarPath = tempFolder.root.toPath().resolve("test.jar")
     FileSystems.newFileSystem(URI.create("jar:${jarPath.toUri()}"), mapOf<String, Any>("create" to true)).use {
       it.getPath("hello.txt").writeText("Hello World")
@@ -24,22 +24,22 @@ class SingletonCachingJarFileSystemProviderTest {
 
     val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = 0)
 
-    //Getting two filesystems with different path that point to the same file.
+    // Getting two filesystems with different paths that point to the same file.
     val fs1 = fileSystemProvider.getFileSystem(jarPath)
     val fs2 = fileSystemProvider.getFileSystem(
       Path.of("${tempFolder.root.absolutePath}/../${tempFolder.root.name}/test.jar")
     )
 
-    Assert.assertSame(fs1, fs2)
+    assertSame(fs1, fs2)
 
-    //After jar is closed for the first time, filesystem remains open
+    // After the JAR is closed for the first time, the filesystem remains open, as there is still one user active.
     fileSystemProvider.close(jarPath)
-    Assert.assertTrue(fs1.isOpen)
-    Assert.assertTrue(fs2.isOpen)
+    assertTrue(fs1.isOpen)
+    assertTrue(fs2.isOpen)
 
-    //After closed for second time, the filesystem has no users and is closed
+    // After the JAR is closed for the second time, the filesystem has no users and is closed
     fileSystemProvider.close(jarPath)
-    Assert.assertFalse(fs1.isOpen)
-    Assert.assertFalse(fs2.isOpen)
+    assertFalse(fs1.isOpen)
+    assertFalse(fs2.isOpen)
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.plugin.structure.jar
 
 import com.jetbrains.plugin.structure.base.utils.writeText
-import com.jetbrains.plugin.structure.xinclude.withSystemProperty
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -17,27 +16,29 @@ class SingletonCachingJarFileSystemProviderTest {
   val tempFolder = TemporaryFolder()
 
   @Test
-  fun `Jar Uris are normalized`() = withSystemProperty("com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime",0) {
+  fun `Jar Uris are normalized`() {
     val jarPath = tempFolder.root.toPath().resolve("test.jar")
     FileSystems.newFileSystem(URI.create("jar:${jarPath.toUri()}"), mapOf<String, Any>("create" to true)).use {
       it.getPath("hello.txt").writeText("Hello World")
     }
 
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = 0)
+
     //Getting two filesystems with different path that point to the same file.
-    val fs1 = SingletonCachingJarFileSystemProvider.getFileSystem(jarPath)
-    val fs2 = SingletonCachingJarFileSystemProvider.getFileSystem(
+    val fs1 = fileSystemProvider.getFileSystem(jarPath)
+    val fs2 = fileSystemProvider.getFileSystem(
       Path.of("${tempFolder.root.absolutePath}/../${tempFolder.root.name}/test.jar")
     )
 
     Assert.assertSame(fs1, fs2)
 
     //After jar is closed for the first time, filesystem remains open
-    SingletonCachingJarFileSystemProvider.close(jarPath)
+    fileSystemProvider.close(jarPath)
     Assert.assertTrue(fs1.isOpen)
     Assert.assertTrue(fs2.isOpen)
 
     //After closed for second time, the filesystem has no users and is closed
-    SingletonCachingJarFileSystemProvider.close(jarPath)
+    fileSystemProvider.close(jarPath)
     Assert.assertFalse(fs1.isOpen)
     Assert.assertFalse(fs2.isOpen)
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/SingletonCachingJarFileSystemProviderTest.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.plugin.structure.jar
 
 import com.jetbrains.plugin.structure.base.utils.writeText
+import com.jetbrains.plugin.structure.xinclude.withSystemProperty
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -16,7 +17,7 @@ class SingletonCachingJarFileSystemProviderTest {
   val tempFolder = TemporaryFolder()
 
   @Test
-  fun `Jar Uris are normalized`() {
+  fun `Jar Uris are normalized`() = withSystemProperty("com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime",0) {
     val jarPath = tempFolder.root.toPath().resolve("test.jar")
     FileSystems.newFileSystem(URI.create("jar:${jarPath.toUri()}"), mapOf<String, Any>("create" to true)).use {
       it.getPath("hello.txt").writeText("Hello World")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/xinclude/XIncludes.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/xinclude/XIncludes.kt
@@ -2,7 +2,7 @@ package com.jetbrains.plugin.structure.xinclude
 
 import com.jetbrains.plugin.structure.intellij.xinclude.IS_RESOLVING_CONDITIONAL_INCLUDES_PROPERTY
 
-internal fun withSystemProperty(property: String, value: Boolean, block: () -> Unit) {
+internal fun withSystemProperty(property: String, value: Any, block: () -> Unit) {
   try {
     System.setProperty(property, value.toString())
     block()


### PR DESCRIPTION
- Extract away the caching functionality to a separate class `CachingJarFileSystemProvider`. Remove the original implementation as it is used nowhere and has a better implementation now.
- Establish a 10 second retention time for cached entries. This prevents multiple consequent open-close operations that lead to unnecessary constructions and immediate closings of a specific filesystem.
- Do not log when no expirations will take place.
- Migrate all remaining production code to the `SingletonCachingJarFileSystemProvider` implementation.