### PR TITLE
fix false-positive 'No dependencies' error and deprecate confusing 'IdePlugin::isV2'

### DIFF
--- a/intellij-feature-extractor/src/test/java/com/intellij/featureExtractor/MockIdePlugin.kt
+++ b/intellij-feature-extractor/src/test/java/com/intellij/featureExtractor/MockIdePlugin.kt
@@ -46,7 +46,9 @@ data class MockIdePlugin(
   override val useIdeClassLoader = false
   override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail = false
+  @Deprecated("See IdePlugin::isV2")
   override val isV2: Boolean = false
+  override val hasPackagePrefix: Boolean = false
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit
   override val hasDotNetPart: Boolean = false
   override val declaredThemes = emptyList<IdeTheme>()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
@@ -67,7 +67,25 @@ interface IdePlugin : Plugin {
 
   val isImplementationDetail: Boolean
 
+  /**
+   * There are different features from the v2 plugin model that can be used or not in a plugin:
+   *  * content modules ([modulesDescriptors]),
+   *  * dependencies on specific modules ([ModuleV2Dependency], [PluginV2Dependency]),
+   *  * package attribute ([hasPackagePrefix]).
+   * 
+   * So a single flag cannot have a proper meaning here. 
+   * Use other properties instead of this one.
+   * 
+   * The current implementation returns `true` for [com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule]
+   * instances or if [hasPackagePrefix] is true.
+   */
+  @Deprecated("Use other properties")
   val isV2: Boolean
+  
+  /** 
+   * Specifies whether a `package` attribute is set in the root tag of `plugin.xml` file.
+   */
+  val hasPackagePrefix: Boolean
 
   val kotlinPluginMode: KotlinPluginMode
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -46,8 +46,12 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
 
   override var isImplementationDetail: Boolean = false
 
-  override var isV2: Boolean = false
+  @Deprecated("See IdePlugin::isV2")
+  override val isV2: Boolean
+    get() = hasPackagePrefix
 
+  override var hasPackagePrefix: Boolean = false
+    
   override var kotlinPluginMode: KotlinPluginMode = Implicit
 
   override var hasDotNetPart: Boolean = false
@@ -120,7 +124,7 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
         useIdeClassLoader = old.useIdeClassLoader
         classpath = old.classpath
         isImplementationDetail = old.isImplementationDetail
-        isV2 = old.isV2
+        hasPackagePrefix = old.hasPackagePrefix
         kotlinPluginMode = old.kotlinPluginMode
         hasDotNetPart = old.hasDotNetPart
         underlyingDocument = old.underlyingDocument

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
@@ -46,7 +46,9 @@ class InvalidPlugin(override val underlyingDocument: Document) : IdePlugin, Stru
   override val useIdeClassLoader: Boolean = false
   override val classpath: Classpath = Classpath.EMPTY
   override val isImplementationDetail: Boolean = false
+  @Deprecated("See IdePlugin::isV2")
   override val isV2: Boolean = false
+  override val hasPackagePrefix: Boolean = false
   override val kotlinPluginMode: KotlinPluginMode = Implicit
   override fun isCompatibleWithIde(ideVersion: IdeVersion): Boolean = false
   override val hasDotNetPart: Boolean = false

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -597,7 +597,7 @@ internal class PluginCreator private constructor(
       if (dependencies.isEmpty()) {
         registerProblem(NoDependencies(descriptorPath))
       }
-      if (dependencies.count { it.isModule } == 0) {
+      if (dependencies.none { it.isModule || it is PluginV2Dependency }) {
         registerProblem(NoModuleDependencies(descriptorPath))
       }
     }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -321,7 +321,7 @@ internal class PluginCreator private constructor(
       }
     }
 
-    isV2 = bean.packageName != null
+    hasPackagePrefix = bean.packageName != null
 
     val modulePrefix = "com.intellij.modules."
 
@@ -593,7 +593,7 @@ internal class PluginCreator private constructor(
 
   private fun validatePlugin(plugin: IdePluginImpl) {
     val dependencies = plugin.dependencies
-    if (!plugin.isV2 && contentModules.isEmpty()) {
+    if (!plugin.hasPackagePrefix && contentModules.isEmpty()) {
       if (dependencies.isEmpty()) {
         registerProblem(NoDependencies(descriptorPath))
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -593,7 +593,7 @@ internal class PluginCreator private constructor(
 
   private fun validatePlugin(plugin: IdePluginImpl) {
     val dependencies = plugin.dependencies
-    if (!plugin.isV2) {
+    if (!plugin.isV2 && contentModules.isEmpty()) {
       if (dependencies.isEmpty()) {
         registerProblem(NoDependencies(descriptorPath))
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
@@ -20,7 +20,8 @@ import org.jdom2.Element
 typealias Dependency = ModuleBean.ModuleDependency
 typealias Resource = ModuleBean.ResourceRoot
 
-class IdeModule(override val pluginId: String, override val classpath: Classpath = EMPTY) : IdePlugin {
+class IdeModule(override val pluginId: String, override val classpath: Classpath = EMPTY,
+                override val hasPackagePrefix: Boolean) : IdePlugin {
   val moduleDependencies = mutableListOf<Dependency>()
   val resources = mutableListOf<Resource>()
   override var underlyingDocument = Document()
@@ -39,6 +40,7 @@ class IdeModule(override val pluginId: String, override val classpath: Classpath
   override val originalFile = null
   override val productDescriptor = null
   override val useIdeClassLoader = false
+  @Deprecated("See IdePlugin::isV2")
   override val isV2 = true
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit
   override val url = null
@@ -62,7 +64,7 @@ class IdeModule(override val pluginId: String, override val classpath: Classpath
   companion object {
     @Throws(IllegalArgumentException::class)
     fun clone(plugin: IdePlugin, pluginId: String, classpath: Classpath): IdeModule {
-      return IdeModule(pluginId,classpath).apply {
+      return IdeModule(pluginId,classpath, hasPackagePrefix = plugin.hasPackagePrefix).apply {
         underlyingDocument = plugin.underlyingDocument.clone()
 
         extensions.putAll(plugin.extensions)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -315,6 +315,9 @@ class PluginXmlValidationTest {
         file("plugin.xml", classpath("/descriptors/ml-llm/plugin-single-module-in-cdata.xml"))
       }
     }
+
+    assertEquals(emptyList<PluginProblem>(), pluginCreationSuccess.unacceptableWarnings)
+    
     pluginCreationSuccess.warnings.filterIsInstance<ModuleDescriptorResolutionProblem>().let {
       assertEquals(0, it.size)
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/PluginXmlValidationTest.kt
@@ -14,6 +14,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginV2Dependency
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
 import com.jetbrains.plugin.structure.intellij.problems.NoDependencies
+import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileIsEmpty
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyConfigFileNotSpecified
 import com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionAndPluginVersionMismatch
@@ -152,6 +153,27 @@ class PluginXmlValidationTest {
     val unacceptableWarning = unacceptableWarnings.filterIsInstance<NoDependencies>()
       .singleOrNull()
     assertNotNull("Plugin descriptor plugin.xml does not include any module dependency tags. The plugin is assumed to be a legacy plugin and is loaded only in IntelliJ IDEA. See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html", unacceptableWarning)
+  }
+  
+  @Test
+  fun `plugin with v2 dependency on plugin`() {
+    val pluginCreationSuccess = buildCorrectPlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              $HEADER
+              <dependencies>
+                <plugin id="org.jetbrains.kotlin"/>
+              </dependencies>
+            </idea-plugin>
+          """
+        }
+      }
+    }
+
+    assertEquals(emptyList<PluginProblem>(), pluginCreationSuccess.unacceptableWarnings)
+    assertEquals(emptyList<PluginProblem>(), pluginCreationSuccess.warnings.filterIsInstance<NoModuleDependencies>())
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
@@ -43,7 +43,9 @@ data class MockIdePlugin(
   override val moduleContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor(),
   override val thirdPartyDependencies: List<ThirdPartyDependency> = emptyList(),
   override val modulesDescriptors: List<ModuleDescriptor> = emptyList(),
+  @Deprecated("See IdePlugin::isV2")
   override val isV2: Boolean = false,
+  override val hasPackagePrefix: Boolean = false,
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit,
   override val classpath: Classpath = Classpath.EMPTY
 ) : IdePlugin {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -109,7 +109,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
     assertNull(plugin.changeNotes)
     assertFalse(plugin.useIdeClassLoader)
     assertFalse(plugin.isImplementationDetail)
-    assertTrue(plugin.isV2)
+    assertTrue(plugin.hasPackagePrefix)
   }
 
   private fun checkIdeCompatibility(plugin: IdePlugin) {

--- a/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-single-module-in-cdata.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/descriptors/ml-llm/plugin-single-module-in-cdata.xml
@@ -12,7 +12,4 @@
   </dependencies>
 </idea-plugin>]]></module>
     </content>
-    <dependencies>
-        <plugin id="com.intellij.modules.platform" />
-    </dependencies>
 </idea-plugin>

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/LegacyPluginAnalysis.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/LegacyPluginAnalysis.kt
@@ -5,11 +5,12 @@
 package com.jetbrains.pluginverifier.analysis
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
 
 class LegacyPluginAnalysis {
   // https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#declaring-plugin-dependencies
   fun isLegacyPlugin(plugin: IdePlugin): Boolean = with(plugin) {
-    !isV2 && (hasNoDependencies() || hasNoModuleDependencies())
+    plugin !is IdeModule && !hasPackagePrefix && (hasNoDependencies() || hasNoModuleDependencies())
   }
 
   private fun IdePlugin.hasNoDependencies() = dependencies.isEmpty()

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/LegacyPluginAnalysis.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/LegacyPluginAnalysis.kt
@@ -5,15 +5,24 @@
 package com.jetbrains.pluginverifier.analysis
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import com.jetbrains.plugin.structure.intellij.plugin.PluginV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
 
 class LegacyPluginAnalysis {
   // https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#declaring-plugin-dependencies
   fun isLegacyPlugin(plugin: IdePlugin): Boolean = with(plugin) {
-    plugin !is IdeModule && !hasPackagePrefix && (hasNoDependencies() || hasNoModuleDependencies())
+    plugin !is IdeModule 
+      && !hasPackagePrefix
+      && modulesDescriptors.isEmpty()
+      && dependencies.all { it.canBeLegacy }
   }
 
-  private fun IdePlugin.hasNoDependencies() = dependencies.isEmpty()
-
-  private fun IdePlugin.hasNoModuleDependencies() = dependencies.none { it.isModule }
+  private val PluginDependency.canBeLegacy: Boolean
+    get() = when (this) {
+      is PluginV2Dependency -> false
+      is ModuleV2Dependency -> false
+      else -> !isModule && id != "com.intellij.java"
+    }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
@@ -42,7 +42,7 @@ class IdeDependencyFinderTest {
   @Before
   fun setUp() {
     lock = IdleFileLock(tempFolder.newFile().toPath())
-    ideModule = IdeModule(MOCK_IDE_MODULE_ID).apply {
+    ideModule = IdeModule(MOCK_IDE_MODULE_ID, hasPackagePrefix = false).apply {
       definedModules += MOCK_IDE_MODULE_ID
     }
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockIdePlugin.kt
@@ -43,7 +43,9 @@ data class MockIdePlugin(
   override val moduleContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor(),
   override val thirdPartyDependencies: List<ThirdPartyDependency> = emptyList(),
   override val modulesDescriptors: List<ModuleDescriptor> = emptyList(),
+  @Deprecated("See IdePlugin::isV2")
   override val isV2: Boolean = false,
+  override val hasPackagePrefix: Boolean = false,
   override val kotlinPluginMode: KotlinPluginMode = KotlinPluginMode.Implicit
 ) : IdePlugin {
 


### PR DESCRIPTION
This pull request fixes [MP-7413](https://youtrack.jetbrains.com/issue/MP-7413) and [MP-7414](https://youtrack.jetbrains.com/issue/MP-7414),  and also deprecates 'IdePlugin::isV2' property which may be confusing.