### PR TITLE
Deprecate 'allPackages' property on Resolver

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
@@ -33,8 +33,12 @@ class CacheResolver(
   override val allBundleNameSet
     get() = delegate.allBundleNameSet
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
     get() = delegate.allPackages
+
+  override val packages: Set<String>
+    get() = delegate.packages
 
   override val readMode
     get() = delegate.readMode

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
@@ -53,8 +53,12 @@ class CompositeResolver private constructor(
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(fullBundleNames)
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
     get() = packageToResolvers.keys
+
+  override val packages: Set<String>
+    get() = resolvers.flatMapTo(hashSetOf()) { it.packages }
 
   override fun processAllClasses(processor: (ResolutionResult<ClassNode>) -> Boolean) =
     resolvers.all { it.processAllClasses(processor) }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -4,7 +4,11 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
-import com.jetbrains.plugin.structure.base.utils.*
+import com.jetbrains.plugin.structure.base.utils.closeOnException
+import com.jetbrains.plugin.structure.base.utils.extension
+import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
 import com.jetbrains.plugin.structure.classes.utils.AsmUtil
 import com.jetbrains.plugin.structure.classes.utils.getBundleBaseName
 import com.jetbrains.plugin.structure.classes.utils.getBundleNameByBundlePath
@@ -91,8 +95,12 @@ class DirectoryResolver(
     return ResolutionResult.NotFound
   }
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
     get() = packageSet.getAllPackages()
+
+  override val packages: Set<String>
+    get() = TODO("Not yet implemented")
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(bundleNames)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -29,7 +29,7 @@ class DirectoryResolver(
 
   private val bundleNames = hashMapOf<String, MutableSet<String>>()
 
-  private val packageSet = PackageSet()
+  private val packageSet = Packages()
 
   init {
     Files.walk(root).use { fileStream ->
@@ -39,7 +39,7 @@ class DirectoryResolver(
           val classRoot = getClassRoot(file, className)
           if (classRoot != null) {
             classNameToFile[className] = file
-            packageSet.addPackagesOfClass(className)
+            packageSet.addClass(className)
           }
         }
         if (file.extension == "properties") {
@@ -97,10 +97,10 @@ class DirectoryResolver(
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
-    get() = packageSet.getAllPackages()
+    get() = packageSet.all
 
   override val packages: Set<String>
-    get() = TODO("Not yet implemented")
+    get() = packageSet.entries
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(bundleNames)
@@ -110,7 +110,7 @@ class DirectoryResolver(
 
   override fun containsClass(className: String) = className in classNameToFile
 
-  override fun containsPackage(packageName: String) = packageSet.containsPackage(packageName)
+  override fun containsPackage(packageName: String) = packageName in packageSet
 
   override fun close() = Unit
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
@@ -23,7 +23,10 @@ class EmptyResolver(override val name: String) : NamedResolver(name) {
 
   override val allClasses = emptySet<String>()
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages = emptySet<String>()
+
+  override val packages = emptySet<String>()
 
   override val allBundleNameSet = ResourceBundleNameSet(emptyMap())
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -66,8 +66,12 @@ class FixedClassesResolver private constructor(
         .mapValues { it.value.toSet() }
     )
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>
     get() = packageSet.getAllPackages()
+
+  override val packages: Set<String>
+    get() = TODO("Not yet implemented")
 
   override fun containsClass(className: String) = className in classes
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -30,11 +30,11 @@ class FixedClassesResolver private constructor(
     )
   }
 
-  private val packageSet = PackageSet()
+  private val packageSet = Packages()
 
   init {
     for (className in classes.keys) {
-      packageSet.addPackagesOfClass(className)
+      packageSet.addClass(className)
     }
   }
 
@@ -68,14 +68,14 @@ class FixedClassesResolver private constructor(
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>
-    get() = packageSet.getAllPackages()
+    get() = packageSet.all
 
   override val packages: Set<String>
-    get() = TODO("Not yet implemented")
+    get() = packageSet.entries
 
   override fun containsClass(className: String) = className in classes
 
-  override fun containsPackage(packageName: String) = packageSet.containsPackage(packageName)
+  override fun containsPackage(packageName: String) = packageName in packageSet
 
   override fun close() = Unit
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
@@ -103,8 +103,12 @@ class JarFileResolver(
   override val implementedServiceProviders: Map<String, Set<String>>
     get() = serviceProviders
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
     get() = packageSet.getAllPackages()
+
+  override val packages: Set<String>
+    get() = TODO("Not yet implemented")
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(bundleNames)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
@@ -16,8 +16,12 @@ class LazyCompositeResolver private constructor(
   override val allClasses: Set<String>
     get() = delegateResolver.allClasses
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>
     get() = delegateResolver.allPackages
+
+  override val packages: Set<String>
+    get() = delegateResolver.packages
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = delegateResolver.allBundleNameSet

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -29,8 +29,12 @@ class LazyJarResolver(
   override val allClasses: Set<String>
     get() = jar.classes
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>
     get() = jar.packages
+
+  override val packages: Set<String>
+    get() = jar.packageSet
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(jar.bundleNames)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/PackageSet.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/PackageSet.kt
@@ -42,4 +42,5 @@ class PackageSet {
 
   fun getAllPackages(): Set<String> = packages
 
+
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
@@ -38,6 +38,11 @@ class Packages {
     get() {
       val visitor = TrieTraversals.All<Boolean>()
       trie.visit(wordSeparator = '/', visitor)
-      return visitor.result - ROOT_PACKAGE_NAME
+      val packages = visitor.result
+      return if (trie.length == 1 && packages.size == 1 && packages.first() == ROOT_PACKAGE_NAME) {
+        packages
+      } else {
+        packages - ROOT_PACKAGE_NAME
+      }
     }
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
@@ -1,0 +1,29 @@
+package com.jetbrains.plugin.structure.classes.resolvers
+
+import com.jetbrains.plugin.structure.classes.utils.Trie
+
+typealias BinaryPackageName = String
+
+class Packages {
+  private val trie = Trie<Boolean>()
+
+  fun addClass(binaryClassName: CharSequence) {
+    val pkg = binaryClassName.lastIndexOf('/')
+      .takeIf { it != -1 }
+      ?.let { binaryClassName.subSequence(0, it)  }
+      ?: ""
+
+    trie.insert(pkg)
+  }
+
+  operator fun contains(packageName: BinaryPackageName): Boolean = trie.find(packageName)
+
+  val all: Set<BinaryPackageName>
+    get() = mutableSetOf<BinaryPackageName>().also { allPackageNames ->
+      if(!trie.isEmpty) {
+        trie.visitWords('/') { packageName: BinaryPackageName, _, _ ->
+          allPackageNames += packageName
+        }
+      }
+    }
+}

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
@@ -1,10 +1,13 @@
 package com.jetbrains.plugin.structure.classes.resolvers
 
 import com.jetbrains.plugin.structure.classes.utils.Trie
+import com.jetbrains.plugin.structure.classes.utils.TrieTraversals
 
 typealias BinaryPackageName = String
 
 private const val TRACK_MIDDLE_PACKAGES = true
+
+private const val ROOT_PACKAGE_NAME = ""
 
 class Packages {
   private val trie = Trie<Boolean>(false)
@@ -21,14 +24,16 @@ class Packages {
   operator fun contains(packageName: BinaryPackageName): Boolean = trie.find(packageName)
 
   val entries: Set<BinaryPackageName>
-    get() = trie.findAllWords(value = TRACK_MIDDLE_PACKAGES, wordSeparator = '/')
+    get() {
+      val visitor = TrieTraversals.WithValue(TRACK_MIDDLE_PACKAGES)
+      trie.visit(wordSeparator = '/', visitor)
+      return visitor.result
+    }
 
   val all: Set<BinaryPackageName>
-    get() = mutableSetOf<BinaryPackageName>().also { allPackageNames ->
-      if(!trie.isEmpty) {
-        trie.visitWords('/') { packageName: BinaryPackageName, _, _ ->
-          allPackageNames += packageName
-        }
-      }
+    get() {
+      val visitor = TrieTraversals.All<Boolean>()
+      trie.visit(wordSeparator = '/', visitor)
+      return visitor.result - ROOT_PACKAGE_NAME
     }
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
@@ -4,8 +4,10 @@ import com.jetbrains.plugin.structure.classes.utils.Trie
 
 typealias BinaryPackageName = String
 
+private const val TRACK_MIDDLE_PACKAGES = true
+
 class Packages {
-  private val trie = Trie<Boolean>()
+  private val trie = Trie<Boolean>(false)
 
   fun addClass(binaryClassName: CharSequence) {
     val pkg = binaryClassName.lastIndexOf('/')
@@ -13,10 +15,13 @@ class Packages {
       ?.let { binaryClassName.subSequence(0, it)  }
       ?: ""
 
-    trie.insert(pkg)
+    trie.insert(pkg, TRACK_MIDDLE_PACKAGES)
   }
 
   operator fun contains(packageName: BinaryPackageName): Boolean = trie.find(packageName)
+
+  val entries: Set<BinaryPackageName>
+    get() = trie.findAllWords(value = TRACK_MIDDLE_PACKAGES, wordSeparator = '/')
 
   val all: Set<BinaryPackageName>
     get() = mutableSetOf<BinaryPackageName>().also { allPackageNames ->

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Packages.kt
@@ -18,7 +18,11 @@ class Packages {
       ?.let { binaryClassName.subSequence(0, it)  }
       ?: ""
 
-    trie.insert(pkg, TRACK_MIDDLE_PACKAGES)
+    addPackage(pkg)
+  }
+
+  fun addPackage(binaryPackageName: CharSequence) {
+    trie.insert(binaryPackageName, TRACK_MIDDLE_PACKAGES)
   }
 
   operator fun contains(packageName: BinaryPackageName): Boolean = trie.find(packageName)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
@@ -38,7 +38,16 @@ abstract class Resolver : Closeable {
    * For example, if this Resolver contains classes of a package `com/example/utils`
    * then [allPackages] contains `com`, `com/example` and `com/example/utils`.
    */
+  @Deprecated(message = "Use 'packages' property instead. This property may be slow on some file systems.")
   abstract val allPackages: Set<String>
+
+  /**
+   * Returns binary names of all contained packages. Their superpackages are *not* available in this collection.
+   *
+   * For example, if this Resolver contains classes of a package `com/example/utils` and `org.example.impl`.
+   * then [packages] contains these two elements.
+   */
+  abstract val packages: Set<String>
 
   /**
    * Returns data structure used to obtain bundle names contained in this resolver.

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/jar/Jar.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/jar/Jar.kt
@@ -44,6 +44,12 @@ class Jar(
   val packages: Set<String>
     get() = getAllPackages()
 
+  val packageSet: Set<String> by lazy {
+    classesInJar.mapTo(mutableSetOf()) { it.name.substringBeforeLast('/', "")
+      it.name.substringBeforeLast('/', "")
+    }
+  }
+
   private val _bundleNames = mutableMapOf<String, MutableSet<String>>()
   val bundleNames: Map<String, Set<String>> get() = _bundleNames
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -21,6 +21,15 @@ class Trie<V>(val defaultValue: V? = null) {
     return true
   }
 
+  fun findValue(word: CharSequence): V? {
+    var n = root
+    for (c in word) {
+      n = n.children[c] ?: return null
+    }
+    return n.value
+  }
+
+
   fun insert(key: CharSequence, value: V? = defaultValue): Boolean {
     var isInserted = false
     var currentNode = root
@@ -50,6 +59,7 @@ class Trie<V>(val defaultValue: V? = null) {
 
   val length: Int
     get() {
+      if (root.children.isEmpty()) return 0
       val leafCount = TrieTraversals.LeafCount<V>()
       visit('.', leafCount)
       return leafCount.count

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -31,20 +31,6 @@ class Trie<V>(val defaultValue: V? = null) {
     return isInserted
   }
 
-  fun findAllWords(value: V?, wordSeparator: Char = '.'): Set<String> {
-    return mutableSetOf<String>().apply {
-      visit(root, "", wordSeparator) { word, visitedValue, leaf ->
-        if (leaf || value == visitedValue) {
-          add(word)
-        }
-      }
-    }
-  }
-
-  fun visitWords(wordSeparator: Char, visitor: Visitor<V>) {
-    visit(root, "", wordSeparator, visitor)
-  }
-
   fun visit(wordSeparator: Char, visitor: Visitor<V>) {
     visit(root, "", wordSeparator, visitor)
   }
@@ -64,11 +50,9 @@ class Trie<V>(val defaultValue: V? = null) {
 
   val length: Int
     get() {
-      var size = 0
-      visitWords('.') { _, _, leaf ->
-        if (leaf) size++
-      }
-      return size
+      val leafCount = TrieTraversals.LeafCount<V>()
+      visit('.', leafCount)
+      return leafCount.count
     }
 
   fun interface Visitor<V> {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -41,7 +41,7 @@ class Trie<V>(val defaultValue: V? = null) {
   }
 
   fun visit(wordSeparator: Char, visitor: Visitor<V>) {
-    if (root.children.isEmpty()) return
+    if (isEmpty) return
     visit(root, "", wordSeparator, visitor)
   }
 
@@ -60,7 +60,7 @@ class Trie<V>(val defaultValue: V? = null) {
 
   val length: Int
     get() {
-      if (root.children.isEmpty()) return 0
+      if (root.children.isEmpty() && root.value == defaultValue) return 0
       val leafCount = TrieTraversals.LeafCount<V>()
       visit('.', leafCount)
       return leafCount.count

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -31,10 +31,6 @@ class Trie<V>(val defaultValue: V? = null) {
     return isInserted
   }
 
-  fun getAllWords(): Set<String> {
-    return findAllWords(value = null)
-  }
-
   fun findAllWords(value: V?, wordSeparator: Char = '.'): Set<String> {
     return mutableSetOf<String>().apply {
       visit(root, "", wordSeparator) { word, visitedValue, leaf ->
@@ -46,6 +42,10 @@ class Trie<V>(val defaultValue: V? = null) {
   }
 
   fun visitWords(wordSeparator: Char, visitor: Visitor<V>) {
+    visit(root, "", wordSeparator, visitor)
+  }
+
+  fun visit(wordSeparator: Char, visitor: Visitor<V>) {
     visit(root, "", wordSeparator, visitor)
   }
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -11,7 +11,8 @@ class Trie<V>(val defaultValue: V? = null) {
 
   private val root = empty(defaultValue)
 
-  val isEmpty: Boolean get() = root.children.isEmpty() && root.value == defaultValue
+  val isEmpty: Boolean get() = root.isChildless && root.value == defaultValue
+  private val Node<V>.isChildless: Boolean get() = children.isEmpty()
 
   fun find(word: CharSequence): Boolean {
     var n = root
@@ -46,7 +47,7 @@ class Trie<V>(val defaultValue: V? = null) {
   }
 
   private fun visit(node: Node<V>, prefix: String, wordSeparator: Char, visitor: Visitor<V>) {
-    if (node.children.isEmpty()) {
+    if (node.isChildless) {
       visitor.visit(prefix, node.value, true)
     } else {
       for ((char, child) in node.children) {
@@ -60,7 +61,6 @@ class Trie<V>(val defaultValue: V? = null) {
 
   val length: Int
     get() {
-      if (root.children.isEmpty() && root.value == defaultValue) return 0
       val leafCount = TrieTraversals.LeafCount<V>()
       visit('.', leafCount)
       return leafCount.count

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -1,0 +1,78 @@
+package com.jetbrains.plugin.structure.classes.utils
+
+
+class Trie<V>(val defaultValue: V? = null) {
+  private data class Node<V>(
+    val children: MutableMap<Char, Node<V>> = mutableMapOf(),
+    var value: V? = null
+  )
+
+  private fun empty(value: V?) = Node<V>(mutableMapOf(), value)
+
+  private val root = empty(defaultValue)
+
+  val isEmpty: Boolean get() = root.children.isEmpty()
+
+  fun find(word: CharSequence): Boolean {
+    var n = root
+    for (c in word) {
+      n = n.children[c] ?: return false
+    }
+    return true
+  }
+
+  fun insert(key: CharSequence, value: V? = defaultValue): Boolean {
+    var isInserted = false
+    var currentNode = root
+    for (char in key) {
+      currentNode = currentNode.children.getOrPut(char) { empty(defaultValue).also { isInserted = true } }
+    }
+    currentNode.value = value
+    return isInserted
+  }
+
+  fun getAllWords(): Set<String> {
+    return findAllWords(value = null)
+  }
+
+  fun findAllWords(value: V?, wordSeparator: Char = '.'): Set<String> {
+    return mutableSetOf<String>().apply {
+      visit(root, "", wordSeparator) { word, visitedValue, leaf ->
+        if (leaf || value == visitedValue) {
+          add(word)
+        }
+      }
+    }
+  }
+
+  fun visitWords(wordSeparator: Char, visitor: Visitor<V>) {
+    visit(root, "", wordSeparator, visitor)
+  }
+
+  private fun visit(node: Node<V>, prefix: String, wordSeparator: Char, visitor: Visitor<V>) {
+    if (node.children.isEmpty()) {
+      visitor.visit(prefix, node.value, true)
+    } else {
+      for ((char, child) in node.children) {
+        if (char == wordSeparator) {
+          visitor.visit(prefix, node.value, false)
+        }
+        visit(child, prefix + char, wordSeparator, visitor)
+      }
+    }
+  }
+
+  val length: Int
+    get() {
+      var size = 0
+      visitWords('.') { _, _, leaf ->
+        if (leaf) size++
+      }
+      return size
+    }
+
+  fun interface Visitor<V> {
+    fun visit(word: String, value: V?, isLeaf: Boolean)
+  }
+}
+

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -11,7 +11,7 @@ class Trie<V>(val defaultValue: V? = null) {
 
   private val root = empty(defaultValue)
 
-  val isEmpty: Boolean get() = root.children.isEmpty()
+  val isEmpty: Boolean get() = root.children.isEmpty() && root.value == defaultValue
 
   fun find(word: CharSequence): Boolean {
     var n = root

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/Trie.kt
@@ -41,6 +41,7 @@ class Trie<V>(val defaultValue: V? = null) {
   }
 
   fun visit(wordSeparator: Char, visitor: Visitor<V>) {
+    if (root.children.isEmpty()) return
     visit(root, "", wordSeparator, visitor)
   }
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/TrieTraversals.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/TrieTraversals.kt
@@ -1,0 +1,33 @@
+package com.jetbrains.plugin.structure.classes.utils
+
+import com.jetbrains.plugin.structure.classes.utils.Trie.Visitor
+
+object TrieTraversals {
+  class All<V>: Visitor<V> {
+    private val _result = mutableSetOf<String>()
+    val result: Set<String> get() = _result
+
+    override fun visit(word: String, value: V?, isLeaf: Boolean) {
+      _result += word
+    }
+  }
+
+  class Leaves<V>: Visitor<V> {
+    private val _result = mutableSetOf<String>()
+    val result: Set<String> get() = _result
+
+    override fun visit(word: String, value: V?, isLeaf: Boolean) {
+      if (isLeaf) _result += word
+    }
+  }
+
+  class WithValue<V>(private val expectedValue: V) : Visitor<V> {
+    private val _result = mutableSetOf<String>()
+    val result: Set<String> get() = _result
+
+    override fun visit(word: String, value: V?, isLeaf: Boolean) {
+      if (expectedValue == value) _result += word
+    }
+  }
+
+}

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/TrieTraversals.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/TrieTraversals.kt
@@ -3,28 +3,38 @@ package com.jetbrains.plugin.structure.classes.utils
 import com.jetbrains.plugin.structure.classes.utils.Trie.Visitor
 
 object TrieTraversals {
-  class All<V>: Visitor<V> {
-    private val _result = mutableSetOf<String>()
-    val result: Set<String> get() = _result
+  fun <V> Trie<V>.collect(wordSeparator: Char, wordCollector: SetCollector<V>): Set<String> {
+    visit(wordSeparator, wordCollector)
+    return wordCollector.result
+  }
 
+  abstract class SetCollector<V> : Visitor<V> {
+    protected val _result = mutableSetOf<String>()
+    val result: Set<String> get() = _result
+  }
+
+  class LeafCount<V> : Visitor<V> {
+    private var _count = 0
+    val count get() = _count
+
+    override fun visit(word: String, value: V?, isLeaf: Boolean) {
+      if (isLeaf) _count++
+    }
+  }
+
+  class All<V>: SetCollector<V>() {
     override fun visit(word: String, value: V?, isLeaf: Boolean) {
       _result += word
     }
   }
 
-  class Leaves<V>: Visitor<V> {
-    private val _result = mutableSetOf<String>()
-    val result: Set<String> get() = _result
-
+  class Leaves<V>: SetCollector<V>() {
     override fun visit(word: String, value: V?, isLeaf: Boolean) {
       if (isLeaf) _result += word
     }
   }
 
-  class WithValue<V>(private val expectedValue: V) : Visitor<V> {
-    private val _result = mutableSetOf<String>()
-    val result: Set<String> get() = _result
-
+  class WithValue<V>(private val expectedValue: V) : SetCollector<V>() {
     override fun visit(word: String, value: V?, isLeaf: Boolean) {
       if (expectedValue == value) _result += word
     }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -119,8 +119,11 @@ class CachingPluginDependencyResolverProvider(pluginProvider: PluginProvider) : 
       get() = delegateResolver.readMode
     override val allClasses: Set<String>
       get() = delegateResolver.allClasses
+    @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
     override val allPackages: Set<String>
       get() = delegateResolver.allPackages
+    override val packages: Set<String>
+      get() = delegateResolver.packages
     override val allBundleNameSet: ResourceBundleNameSet
       get() = delegateResolver.allBundleNameSet
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -106,7 +106,10 @@ class ProductInfoClassResolver(
 
   override val allClasses get() = delegateResolver.allClasses
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages get() = delegateResolver.allPackages
+
+  override val packages: Set<String> get() = delegateResolver.packages
 
   override val allBundleNameSet get() = delegateResolver.allBundleNameSet
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/util/KnownIdePackages.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/util/KnownIdePackages.kt
@@ -4,20 +4,26 @@
 
 package com.jetbrains.plugin.structure.ide.util
 
+import com.jetbrains.plugin.structure.classes.resolvers.BinaryPackageName
+
 /**
  * Utility class that contains list of known IntelliJ IDE packages.
  */
 object KnownIdePackages {
 
-  private val idePackages: Set<String> by lazy(::readKnownIdePackages)
+  private val idePackages: Set<BinaryPackageName> by lazy(::readKnownIdePackages)
 
-  fun isKnownPackage(packageName: String): Boolean =
+  fun isKnownPackage(packageName: BinaryPackageName): Boolean =
     idePackages.any { packageName == it || packageName.startsWith("$it.") }
 
-  private fun readKnownIdePackages() =
+  private fun readKnownIdePackages() = mutableSetOf<BinaryPackageName>().apply {
     KnownIdePackages::class.java.classLoader
       .getResourceAsStream("com.jetbrains.plugin.structure.ide/knownIdePackages.txt")!!
-      .bufferedReader()
-      .readLines()
-      .toSet()
+      .reader()
+      .useLines { lines ->
+        lines.forEach { line ->
+          add(line.replace('.', '/'))
+        }
+      }
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
@@ -82,4 +82,16 @@ class PackagesTest {
     assertEquals(setOf("com", "com/example", "com/example/foo", "com/example/bar"), packages.all)
   }
 
+  @Test
+  fun `class with empty package is inserted`() {
+    val packages = Packages()
+    packages.addClass("FooService")
+
+    assertTrue(packages.contains(""))
+
+    assertEquals(setOf(""), packages.entries)
+    assertEquals(setOf(""), packages.all)
+  }
+
+
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
@@ -62,4 +62,24 @@ class PackagesTest {
       assertTrue(isEmpty())
     }
   }
+
+  @Test
+  fun `packages are inserted and retrieved`() {
+    val packages = Packages()
+    packages.addPackage("com/example/foo")
+    // duplicate insertion
+    packages.addPackage("com/example/foo")
+    packages.addPackage("com/example/bar")
+
+    assertTrue(packages.contains("com/example"))
+    assertTrue(packages.contains("com/example/bar"))
+
+    assertTrue(packages.contains("com"))
+
+    assertFalse(packages.contains("org/example"))
+
+    assertEquals(setOf("com/example/foo", "com/example/bar"), packages.entries)
+    assertEquals(setOf("com", "com/example", "com/example/foo", "com/example/bar"), packages.all)
+  }
+
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
@@ -1,0 +1,41 @@
+package com.jetbrains.plugin.structure.classes.resolvers
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class PackagesTest {
+  @Test
+  fun `packages in the package set are found, others are not`() {
+    val packages = Packages()
+    packages.addClass("com/example/foo/FooService")
+    packages.addClass("com/example/bar/BarService")
+
+    assertTrue(packages.contains("com/example"))
+    assertTrue(packages.contains("com/example/bar"))
+
+    assertTrue(packages.contains("com"))
+
+    assertFalse(packages.contains("org/example"))
+  }
+
+  @Test
+  fun `all packages, include recursive, are listed`() {
+    val packages = Packages()
+    packages.addClass("com/example/foo/FooService")
+    packages.addClass("com/example/bar/BarService")
+
+    with(packages.all) {
+      assertEquals(4, size)
+      assertEquals(setOf("com", "com/example", "com/example/bar", "com/example/foo"), this)
+    }
+  }
+
+  @Test
+  fun `empty package collection`() {
+    val packages = Packages()
+    with(packages.all) {
+      assertEquals(0, size)
+      assertTrue(isEmpty())
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/PackagesTest.kt
@@ -19,6 +19,30 @@ class PackagesTest {
   }
 
   @Test
+  fun `all packages are listed`() {
+    val packages = Packages()
+    packages.addClass("com/example/foo/FooService")
+    packages.addClass("com/example/bar/BarService")
+    packages.addClass("com/example/bar/zap/ZapService")
+    packages.addClass("com/jetbrains/foo/JBFooService")
+    packages.addClass("com/jetbrains/cli/JBCliService")
+    packages.addClass("com/jetbrains/cli/impl/JBCliServiceImpl")
+
+    with(packages.entries) {
+      assertEquals(6, size)
+      assertEquals(
+        setOf("com/example/foo",
+          "com/example/bar",
+          "com/example/bar/zap",
+          "com/jetbrains/foo",
+          "com/jetbrains/cli",
+          "com/jetbrains/cli/impl"), this)
+    }
+  }
+
+
+
+  @Test
   fun `all packages, include recursive, are listed`() {
     val packages = Packages()
     packages.addClass("com/example/foo/FooService")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.classes.utils
 
+import com.jetbrains.plugin.structure.classes.utils.TrieTraversals.collect
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -76,8 +77,9 @@ class TrieTest {
       "com.jetbrains.cli",
       "com.jetbrains.cli.impl",
     )
-    val words = packages.findAllWords(true)
-    assertEquals(expected, words)
+    val visitor = TrieTraversals.WithValue<Boolean>(true)
+    packages.visit('.', visitor)
+    assertEquals(expected, visitor.result)
   }
 
   @Test
@@ -95,11 +97,8 @@ class TrieTest {
       "com.jetbrains", "com.jetbrains.foo",
       "com.jetbrains.cli", "com.jetbrains.cli.impl"
     )
-    val visitedWords = mutableSetOf<String>()
-    packages.visitWords('.') { word,_,  _ ->
-      visitedWords += word
-    }
-    assertEquals(expected, visitedWords)
+    val actualWords = packages.collect('.', TrieTraversals.All<Boolean>())
+    assertEquals(expected, actualWords)
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -130,6 +130,21 @@ class TrieTest {
   }
 
   @Test
+  fun `trie with an empty string inserted`() {
+    val emptyTrie = newTrie()
+    emptyTrie.insert("")
+    assertTrue(emptyTrie.isEmpty)
+  }
+
+  @Test
+  fun `trie with an empty string inserted with an explicit value`() {
+    val emptyTrie = newTrie()
+    emptyTrie.insert("", true)
+    assertFalse(emptyTrie.isEmpty)
+  }
+
+
+  @Test
   fun `empty trie is not traversed at all`() {
     val emptyTrie = newTrie()
     var wasVisited = false

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -10,7 +10,7 @@ class TrieTest {
   }
 
   @Test
-  fun `all words are retrieved`() {
+  fun `all words are retrieved, nonrecursively (without middle prefixes)`() {
     val packages = newTrie()
     packages.insert("com.example.foo")
     packages.insert("com.example.bar")
@@ -25,9 +25,37 @@ class TrieTest {
       "com.jetbrains.cli.impl",
       "com.jetbrains.foo"
     )
-    val words = packages.getAllWords()
-    assertEquals(expected, words)
+    val visitor = TrieTraversals.Leaves<Boolean>()
+    packages.visit('.', visitor)
+    assertEquals(expected, visitor.result)
   }
+
+  @Test
+  fun `all words are retrieved, recursively`() {
+    val packages = newTrie()
+    packages.insert("com.example.foo")
+    packages.insert("com.example.bar")
+    packages.insert("com.example.bar.zap")
+    packages.insert("com.jetbrains.foo")
+    packages.insert("com.jetbrains.cli")
+    packages.insert("com.jetbrains.cli.impl")
+
+    val expected = setOf(
+      "com",
+      "com.example",
+      "com.example.foo",
+      "com.example.bar",
+      "com.example.bar.zap",
+      "com.jetbrains",
+      "com.jetbrains.foo",
+      "com.jetbrains.cli",
+      "com.jetbrains.cli.impl",
+    )
+    val visitor = TrieTraversals.All<Boolean>()
+    packages.visit('.', visitor)
+    assertEquals(expected, visitor.result)
+  }
+
 
   @Test
   fun `all words are retrieved with explicit values`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -124,6 +124,12 @@ class TrieTest {
   }
 
   @Test
+  fun `empty trie has zero length`() {
+    val emptyTrie = newTrie()
+    assertEquals(0, emptyTrie.length)
+  }
+
+  @Test
   fun `duplicate insertions are tracked`() {
     val packages = newTrie()
     assertTrue(packages.insert("com.example.foo"))
@@ -150,4 +156,19 @@ class TrieTest {
     packages.insert("com.jetbrains.cli.impl")
     assertEquals(4, packages.length)
   }
+
+  @Test
+  fun `word with specific value is found`() {
+    val packages = Trie<String>(defaultValue = "")
+    packages.insert("com.example.foo", "FOO")
+    packages.insert("com.example.bar", "BAR")
+    packages.insert("com.example.bar.zap", "ZAP")
+
+    assertEquals("FOO", packages.findValue("com.example.foo"))
+    assertEquals("BAR", packages.findValue("com.example.bar"))
+    assertEquals("ZAP", packages.findValue("com.example.bar.zap"))
+
+    assertEquals(null, packages.findValue("com.unavailable"))
+  }
+
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -130,6 +130,16 @@ class TrieTest {
   }
 
   @Test
+  fun `empty trie is not traversed at all`() {
+    val emptyTrie = newTrie()
+    var wasVisited = false
+    emptyTrie.visit('.') { _, _, _ ->
+      wasVisited = true
+    }
+    assertFalse(wasVisited)
+  }
+
+  @Test
   fun `duplicate insertions are tracked`() {
     val packages = newTrie()
     assertTrue(packages.insert("com.example.foo"))

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/utils/TrieTest.kt
@@ -1,0 +1,126 @@
+package com.jetbrains.plugin.structure.classes.utils
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class TrieTest {
+
+  private fun newTrie(): Trie<Boolean> {
+    return Trie<Boolean>(defaultValue = false)
+  }
+
+  @Test
+  fun `all words are retrieved`() {
+    val packages = newTrie()
+    packages.insert("com.example.foo")
+    packages.insert("com.example.bar")
+    packages.insert("com.example.bar.zap")
+    packages.insert("com.jetbrains.foo")
+    packages.insert("com.jetbrains.cli")
+    packages.insert("com.jetbrains.cli.impl")
+
+    val expected = setOf(
+      "com.example.bar.zap",
+      "com.example.foo",
+      "com.jetbrains.cli.impl",
+      "com.jetbrains.foo"
+    )
+    val words = packages.getAllWords()
+    assertEquals(expected, words)
+  }
+
+  @Test
+  fun `all words are retrieved with explicit values`() {
+    val packages = newTrie().apply {
+      insert("com.example.foo", true)
+      insert("com.example.bar", true)
+      insert("com.example.bar.zap", true)
+      insert("com.jetbrains.foo", true)
+      insert("com.jetbrains.cli", true)
+      insert("com.jetbrains.cli.impl", true)
+    }
+
+    val expected = setOf(
+      "com.example.foo",
+      "com.example.bar",
+      "com.example.bar.zap",
+      "com.jetbrains.foo",
+      "com.jetbrains.cli",
+      "com.jetbrains.cli.impl",
+    )
+    val words = packages.findAllWords(true)
+    assertEquals(expected, words)
+  }
+
+  @Test
+  fun `all dot separated words are retrieved`() {
+    val packages = newTrie()
+    packages.insert("com.example.foo")
+    packages.insert("com.example.bar")
+    packages.insert("com.example.bar.zap")
+    packages.insert("com.jetbrains.foo")
+    packages.insert("com.jetbrains.cli")
+    packages.insert("com.jetbrains.cli.impl")
+
+    val expected = setOf(
+      "com", "com.example", "com.example.foo", "com.example.bar", "com.example.bar.zap",
+      "com.jetbrains", "com.jetbrains.foo",
+      "com.jetbrains.cli", "com.jetbrains.cli.impl"
+    )
+    val visitedWords = mutableSetOf<String>()
+    packages.visitWords('.') { word,_,  _ ->
+      visitedWords += word
+    }
+    assertEquals(expected, visitedWords)
+  }
+
+  @Test
+  fun `word in trie is found, others are not`() {
+    val packages = Trie<Boolean>(defaultValue = false)
+    packages.insert("com.example.foo")
+    packages.insert("com.example.bar")
+    packages.insert("com.example.bar.zap")
+    packages.insert("com.jetbrains.foo")
+    packages.insert("com.jetbrains.cli")
+    packages.insert("com.jetbrains.cli.impl")
+
+    assertTrue(packages.find("com.example"))
+    assertTrue(packages.find("com.example.bar.zap"))
+    assertFalse(packages.find("com.unavailable"))
+    assertTrue(packages.find(""))
+  }
+
+  @Test
+  fun `empty trie`() {
+    val emptyTrie = newTrie()
+    assertTrue(emptyTrie.isEmpty)
+  }
+
+  @Test
+  fun `duplicate insertions are tracked`() {
+    val packages = newTrie()
+    assertTrue(packages.insert("com.example.foo"))
+    assertFalse(packages.insert("com.example.foo"))
+    assertTrue(packages.insert("com.example.foo.zap"))
+    assertFalse(packages.insert("com.example.foo.zap"))
+
+    assertFalse(packages.insert("com.example"))
+  }
+
+  @Test
+  fun `trie size is calculated`() {
+    val packages = newTrie()
+    packages.insert("com.example.foo")
+    assertEquals(1, packages.length)
+    packages.insert("com.example.bar")
+    assertEquals(2, packages.length)
+    packages.insert("com.example.bar.zap")
+    assertEquals(2, packages.length)
+    packages.insert("com.jetbrains.foo")
+    assertEquals(3, packages.length)
+    packages.insert("com.jetbrains.cli")
+    assertEquals(4, packages.length)
+    packages.insert("com.jetbrains.cli.impl")
+    assertEquals(4, packages.length)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
@@ -23,7 +23,7 @@ class IdeResolverCreatorTest {
   fun `layout component with missing file in the filesystem is skipped`() {
     val ideResolver = IdeResolverCreator.createIdeResolver(createIdeWithNonExistentFileOfLayoutComponent())
     assertEquals("IDE Resolver class count", 0, ideResolver.allClasses.size)
-    assertEquals("IDE Resolver package count", 0, ideResolver.allPackages.size)
+    assertEquals("IDE Resolver package count", 0, ideResolver.packages.size)
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -263,7 +263,7 @@ class CachingPluginDependencyResolverProviderTest {
       )
       assertEquals(expectedPackages, allPackages)
       // 'Alpha' plugin package should not be in the Alpha's transitive dependencies
-      assertFalse(allPackages.contains("com/example/alpha"))
+      assertFalse(packages.contains("com/example/alpha"))
 
       val expectedClasses = setOf(
         "com/example/beta/BetaAction",

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -43,6 +43,10 @@ class CachingPluginDependencyResolverProviderTest {
     "com/intellij/openapi/graph/builder/actions"
   )
 
+  val expectedIdeaCorePluginExplicitPackages = setOf(
+    "com/intellij/openapi/graph/builder/actions"
+  )
+
   val expectedJavaPluginPackages = setOf(
     "com",
     "com/intellij",
@@ -50,9 +54,17 @@ class CachingPluginDependencyResolverProviderTest {
     "com/intellij/openapi/actionSystem",
   )
 
+  val expectedJavaPluginExplicitPackages = setOf(
+    "com/intellij/openapi/actionSystem",
+  )
+
   private val expectedJsonPluginPackages = setOf(
     "com",
     "com/intellij",
+    "com/intellij/json",
+  )
+
+  private val expectedJsonPluginExplicitPackages = setOf(
     "com/intellij/json",
   )
 
@@ -166,7 +178,7 @@ class CachingPluginDependencyResolverProviderTest {
     }
 
     with(resolver) {
-      assertEquals(expectedIdeaCorePluginPackages + expectedJsonPluginPackages, allPackages)
+      assertEquals(expectedIdeaCorePluginExplicitPackages + expectedJsonPluginExplicitPackages, packages)
       assertEquals(expectedIdeaCoreClasses + expectedJsonPluginClasses, allClasses)
     }
 
@@ -187,7 +199,7 @@ class CachingPluginDependencyResolverProviderTest {
     }
 
     with(pluginDependingOnJavaResolver) {
-      assertEquals(expectedIdeaCorePluginPackages + expectedJavaPluginPackages, allPackages)
+      assertEquals(expectedIdeaCorePluginExplicitPackages + expectedJavaPluginExplicitPackages, packages)
       assertEquals(expectedIdeaCoreClasses + expectedJavaPluginClasses, allClasses)
     }
   }
@@ -240,7 +252,7 @@ class CachingPluginDependencyResolverProviderTest {
 
     val gammaFiles = buildZipFile(temporaryFolder.newTemporaryFile("gamma/gamma.jar")) {
       dirs("com/example/gamma") {
-        file("GammaAction.class", createEmptyClass("com/example/beta/GammaAction"))
+        file("GammaAction.class", createEmptyClass("com/example/gamma/GammaAction"))
       }
     }
     val gammaPlugin = MockIdePlugin(
@@ -255,13 +267,19 @@ class CachingPluginDependencyResolverProviderTest {
     val resolverProvider = CachingPluginDependencyResolverProvider(ide)
 
     with(resolverProvider.getResolver(alphaPlugin)) {
-      val expectedPackages = setOf(
+      val expectedAllPackages = setOf(
         "com",
         "com/example",
         "com/example/beta",
         "com/example/gamma",
       )
-      assertEquals(expectedPackages, allPackages)
+      assertEquals(expectedAllPackages, allPackages)
+
+      val expectedPackages = setOf(
+        "com/example/beta",
+        "com/example/gamma",
+      )
+      assertEquals(expectedPackages, packages)
       // 'Alpha' plugin package should not be in the Alpha's transitive dependencies
       assertFalse(packages.contains("com/example/alpha"))
 
@@ -271,7 +289,7 @@ class CachingPluginDependencyResolverProviderTest {
       )
       assertEquals(expectedClasses, allClasses)
       // 'Alpha' plugin classes should not be resolved in the dependencies
-      assertFalse(allPackages.contains("com/example/alpha/AlphaAction"))
+      assertFalse(packages.contains("com/example/alpha/AlphaAction"))
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
@@ -49,7 +49,7 @@ class ProductInfoClassResolverTest {
     val ide = MockIde(IdeVersion.createIdeVersion(IDEA_ULTIMATE_2024_2), ideRoot, bundledPlugins = listOf(corePlugin()))
     val resolver = ProductInfoClassResolver.of(ide)
 
-    assertTrue(resolver.allPackages.isNotEmpty())
+    assertTrue(resolver.packages.isNotEmpty())
 
     with(resolver.allPackages) {
       assertEquals(5, size)
@@ -58,6 +58,10 @@ class ProductInfoClassResolverTest {
       assertTrue(contains("com/intellij/execution/process/elevation"))
       assertTrue(contains("com/intellij"))
       assertTrue(contains("com/intellij/execution"))
+    }
+
+    with(resolver.packages) {
+      assertEquals(setOf("com/intellij/execution/process/elevation"), this)
     }
 
     with(resolver.layoutComponentNames) {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -152,7 +152,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
       setOf("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
       resolver.allClasses
     )
-    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.allPackages)
+    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.packages)
     assertTrue(resolver.containsPackage("somePackage"))
     assertTrue(resolver.containsPackage("somePackage/subPackage"))
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -697,7 +697,7 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
       setOf("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
       resolver.allClasses
     )
-    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.allPackages)
+    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.packages)
     assertTrue(resolver.containsPackage("somePackage"))
     assertTrue(resolver.containsPackage("somePackage/subPackage"))
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/resolvers/ResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/resolvers/ResolverTest.kt
@@ -18,7 +18,7 @@ class ResolverTest {
     val cacheResolver = CacheResolver(EMPTY_RESOLVER)
     assertEquals(ResolutionResult.NotFound, cacheResolver.resolveClass("a"))
     assertTrue(cacheResolver.allClasses.isEmpty())
-    assertEquals(emptySet<String>(), cacheResolver.allPackages)
+    assertEquals(emptySet<String>(), cacheResolver.packages)
 
     assertEquals(ResolutionResult.NotFound, cacheResolver.resolveExactPropertyResourceBundle("a", Locale.ROOT))
     assertTrue(cacheResolver.allBundleNameSet.isEmpty)
@@ -39,7 +39,7 @@ class ResolverTest {
     val found = cacheResolver.resolveClass(className) as ResolutionResult.Found
     assertEquals(classNode, found.value)
     assertEquals(fileOrigin, found.fileOrigin)
-    assertEquals(setOf(""), cacheResolver.allPackages)
+    assertEquals(setOf(""), cacheResolver.packages)
     assertTrue(cacheResolver.containsPackage(""))
   }
 
@@ -69,7 +69,7 @@ class ResolverTest {
 
     val resolver = CompositeResolver.create(resolver1, resolver2)
 
-    assertEquals(setOf("some", "some/package"), resolver.allPackages)
+    assertEquals(setOf("some/package"), resolver.packages)
     assertEquals(setOf(sameClass, class1, class2), resolver.allClasses)
 
     assertSame(origin1, (resolver.resolveClass(class1) as ResolutionResult.Found).fileOrigin)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -7,7 +7,9 @@ package com.jetbrains.pluginverifier
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.telemetry.MutablePluginTelemetry
 import com.jetbrains.plugin.structure.base.telemetry.PLUGIN_VERIFIED_CLASSES_COUNT
+import com.jetbrains.plugin.structure.classes.resolvers.BinaryPackageName
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
+import com.jetbrains.plugin.structure.classes.resolvers.Packages
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.ide.util.KnownIdePackages
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
@@ -339,7 +341,7 @@ class PluginVerifier(
   }
 
   private fun PluginVerificationContext.findMistakenlyBundledIdeClasses(pluginResolver: Resolver) {
-    val idePackages = pluginResolver.allPackages.filter { KnownIdePackages.isKnownPackage(it.replace('/', '.')) }
+    val idePackages = getAllPackages(pluginResolver).filter { KnownIdePackages.isKnownPackage(it.replace('/', '.')) }
     if (idePackages.isNotEmpty()) {
       registerCompatibilityWarning(MistakenlyBundledIdePackagesWarning(idePackages.map { it.replace('/', '.') }))
     }
@@ -353,6 +355,12 @@ class PluginVerifier(
       classesForCheck += classesSelector.getClassesForCheck(pluginDetails.pluginClassesLocations)
     }
     return classesForCheck
+  }
+
+  private fun getAllPackages(resolver: Resolver): Set<BinaryPackageName> {
+    val allPackages = Packages()
+    resolver.packages.forEach { allPackages.addPackage(it) }
+    return allPackages.all
   }
 
   private fun Set<String>.reportTelemetry(pluginDetails: PluginDetails, context: PluginVerificationContext) {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -341,7 +341,7 @@ class PluginVerifier(
   }
 
   private fun PluginVerificationContext.findMistakenlyBundledIdeClasses(pluginResolver: Resolver) {
-    val idePackages = getAllPackages(pluginResolver).filter { KnownIdePackages.isKnownPackage(it.replace('/', '.')) }
+    val idePackages = getAllPackages(pluginResolver).filter { KnownIdePackages.isKnownPackage(it) }
     if (idePackages.isNotEmpty()) {
       registerCompatibilityWarning(MistakenlyBundledIdePackagesWarning(idePackages.map { it.replace('/', '.') }))
     }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -5,11 +5,21 @@
 package com.jetbrains.pluginverifier.jdk
 
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
-import com.jetbrains.plugin.structure.classes.resolvers.*
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.InvalidClassFileException
+import com.jetbrains.plugin.structure.classes.resolvers.JdkFileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.PackageSet
+import com.jetbrains.plugin.structure.classes.resolvers.ResolutionResult
+import com.jetbrains.plugin.structure.classes.resolvers.Resolver
+import com.jetbrains.plugin.structure.classes.resolvers.ResourceBundleNameSet
 import com.jetbrains.plugin.structure.classes.utils.AsmUtil
 import org.objectweb.asm.tree.ClassNode
 import java.net.URI
-import java.nio.file.*
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.util.*
 import java.util.stream.Collectors
 
@@ -78,8 +88,12 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
   override val allClasses
     get() = classNameToModuleName.keys
 
+  @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages
     get() = packageSet.getAllPackages()
+
+  override val packages: Set<String>
+    get() = TODO("Not yet implemented")
 
   override val allBundleNameSet
     get() = ResourceBundleNameSet(emptyMap())


### PR DESCRIPTION
The `Resolver` class has a `allPackages` property. This is very inefficient: when a `CompositeResolver` is rebuilding its internal cache, it launches a full-recursive resolver-tree traversal.
However, this property is used only in a single place: when tracking usage of known IDE packages in the plugin.

- Introduce a `Trie` property to track packages.
- Introduce a `Packages` class representing a package tree backed by the `Trie`. This is a more efficient counterpart to the `PackageSet`. 
- Deprecate `allPackages` property. Remove its usage in the production code. Replace the single actual usage with the `Packages` tracking.