### PR TITLE
Broken ZIP does not fail verification when scanning for content modules

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/PluginJar.kt
@@ -27,7 +27,10 @@ private val THIRD_PARTY_LIBRARIES_FILE_NAME = "dependencies.json"
 
 private val LOG: Logger = LoggerFactory.getLogger(PluginJar::class.java)
 
-class PluginJar(private val jarPath: Path, private val jarFileSystemProvider: JarFileSystemProvider): AutoCloseable {
+class PluginJar @Throws(JarArchiveCannotBeOpenException::class) constructor(
+    private val jarPath: Path,
+    private val jarFileSystemProvider: JarFileSystemProvider
+) : AutoCloseable {
 
   private val jarFileSystem: FileSystem = jarFileSystemProvider.getFileSystem(jarPath).also {
     LOG.debug("File system for [{}] was provided by '{}'", jarPath, jarFileSystemProvider.javaClass.name)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -5,10 +5,13 @@ import com.jetbrains.plugin.structure.base.utils.hasExtension
 import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.intellij.plugin.LIB_DIRECTORY
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.META_INF
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.plugin.structure.jar.PluginJar
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
 
@@ -17,6 +20,8 @@ private const val MODULES_DIR = "modules"
 private const val XML_EXTENSION = "xml"
 
 private val META_INF_PLUGIN_XML_PATH_COMPONENTS = listOf(META_INF, PLUGIN_XML)
+
+private val LOG: Logger = LoggerFactory.getLogger(ContentModuleScanner::class.java)
 
 class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider) {
   private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
@@ -29,20 +34,35 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
     val jarPaths = libDir.listJars()
     val moduleJarPaths = libDir.resolve(MODULES_DIR).listJars()
     val contentModules = (jarPaths + moduleJarPaths).flatMap { jarPath ->
-      PluginJar(jarPath, fileSystemProvider).use { jar ->
-        val descriptorPaths = jar.resolveDescriptors { it.isDescriptor() }
-        descriptorPaths.map {
-          val moduleName = if (it.isMetaInfPluginXml()) {
-            "ROOT"
-          } else {
-            it.getModuleName()
-          }
-          ContentModule(moduleName, jarPath, it)
-        }
-      }
+      getJarContentModules(jarPath)
     }
 
     return ContentModules(pluginArtifact, contentModules)
+  }
+
+  private fun getJarContentModules(jarPath: Path): List<ContentModule> = withPluginJar(jarPath) { jar ->
+    jar.resolveDescriptors { it.isDescriptor() }
+      .map { resolveContentModule(jarPath, it) }
+  } ?: emptyList()
+
+  private fun resolveContentModule(jarPath: Path, descriptorPath: Path): ContentModule {
+    val moduleName = if (descriptorPath.isMetaInfPluginXml()) {
+      "ROOT"
+    } else {
+      descriptorPath.getModuleName()
+    }
+    return ContentModule(moduleName, jarPath, descriptorPath)
+  }
+
+  private fun <T> withPluginJar(jarPath: Path, action: (PluginJar) -> T): T? {
+    return try {
+      PluginJar(jarPath, fileSystemProvider).use { jar ->
+        action(jar)
+      }
+    } catch (e: JarArchiveCannotBeOpenException) {
+      LOG.warn("Unable to open $jarPath: " + e.cause?.message)
+      null
+    }
   }
 
   /**

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/Zips.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/Zips.kt
@@ -1,0 +1,16 @@
+package com.jetbrains.plugin.structure.base.utils
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+internal fun createZipBufferWithSingleEmptyFile(): ByteArray {
+  val byteOut = ByteArrayOutputStream()
+  ZipOutputStream(byteOut).use { zipOut ->
+    val entry = ZipEntry("empty.bin")
+    zipOut.putNextEntry(entry)
+    // No data written to the file
+    zipOut.closeEntry()
+  }
+  return byteOut.toByteArray()
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
@@ -2,6 +2,7 @@ package com.jetbrains.plugin.structure.intellij.plugin.module
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
+import com.jetbrains.plugin.structure.zipBombs.getZipWithoutEocd
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -54,5 +55,20 @@ class ContentModuleScannerTest {
     val resolvedClassPath = contentModules.resolvedClassPath.map { root.relativize(it).toString() }.sorted()
 
     assertEquals(expectedClassPath, resolvedClassPath)
+  }
+
+  @Test
+  fun `no content modules are found in a corrupted artifact`() {
+    val pluginPath = buildDirectory(temporaryFolder.newFolder("corrupted").toPath()) {
+      dir("lib") {
+        getZipWithoutEocd()?.let {
+          file("corrupted.jar", it)
+        }
+      }
+    }
+
+    val contentModuleScanner = ContentModuleScanner(jarFileSystemProvider)
+    val contentModules = contentModuleScanner.getContentModules(pluginPath)
+    assertTrue(contentModules.modules.isEmpty())
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/zipBombs/CorruptedZips.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/zipBombs/CorruptedZips.kt
@@ -1,0 +1,25 @@
+package com.jetbrains.plugin.structure.zipBombs
+
+import com.jetbrains.plugin.structure.base.utils.createZipBufferWithSingleEmptyFile
+
+internal fun getZipWithoutEocd(): ByteArray? {
+  val zipBytes = createZipBufferWithSingleEmptyFile()
+  // EOCD signature: 0x06054b50 -> bytes: 50 4B 05 06
+  val eocdSignature = byteArrayOf(0x50.toByte(), 0x4B.toByte(), 0x05.toByte(), 0x06.toByte())
+  val lastEOCDIndex = zipBytes.lastIndexOf(eocdSignature)
+  if (lastEOCDIndex == -1) {
+    return null
+  }
+  val corruptedBytes = zipBytes.copyOfRange(0, lastEOCDIndex)
+  return corruptedBytes
+}
+
+private fun ByteArray.lastIndexOf(pattern: ByteArray): Int {
+  outer@ for (i in size - pattern.size downTo 0) {
+    for (j in pattern.indices) {
+      if (this[i + j] != pattern[j]) continue@outer
+    }
+    return i
+  }
+  return -1
+}


### PR DESCRIPTION
A broken ZIP can fail the plugin verification. This is due to the unhandled exception when scanning for content modules via `PluginJar`.

- Rework `ContentModuleScanner` to handle such exceptions.
- Prepare test fixtures for broken ZIPs.