### PR TITLE
Fix classpath duplicates

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -18,6 +18,14 @@ class Classpath private constructor(val entries: List<ClasspathEntry> = emptyLis
 
   val paths: Set<Path> = entries.map { it.path }.toSet()
 
+  fun getUnique(): Classpath {
+    return if (size == 1) {
+      this
+    } else {
+      Classpath(entries.distinctBy { it.path.toString() })
+    }
+  }
+
   override fun toString(): String = entries.joinToString(separator = ":", prefix = "[", postfix = "]")
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -529,7 +529,7 @@ class IdePluginManager private constructor(
   private fun CreationResult.withResolvedClasspath(): CreationResult = apply {
     val contentModules = contentModuleScanner.getContentModules(artifact)
     val classpath = contentModules.asClasspath()
-    creator.setClasspath(classpath)
+    creator.setClasspath(classpath.getUnique())
   }
 
   private data class CreationResult(val artifact: Path, val creator: PluginCreator)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -165,12 +165,15 @@ class CachingPluginDependencyResolverProviderTest {
 
     val resolverProvider = CachingPluginDependencyResolverProvider(ide)
     val resolver = resolverProvider.getResolver(plugin)
+    val corePluginCacheHit = 0L
     with(resolverProvider.getStats()) {
       assertNotNull(this); this!!
       /*
-        "com.intellij.modules.platform" and "com.intellij.modules.lang" belong to the same module
+        "com.intellij.modules.platform" and "com.intellij.modules.lang" belong to the same module.
+        Cache was not even hit, since the resolver for the second invocation is already in the list
+        of modules since the first invocation
        */
-      assertEquals(1, hitCount())
+      assertEquals(corePluginCacheHit, hitCount())
       /*
         "com.example.somePlugin" (plugin itself), "com.intellij" and "com.intellij.modules.json" need to be created without cache
        */
@@ -189,7 +192,7 @@ class CachingPluginDependencyResolverProviderTest {
       /*
         One previous value. On top: 'Java' depends on 'Lang' that is already in cache, making a 2nd cache hit.
        */
-      assertEquals(2, hitCount())
+      assertEquals(corePluginCacheHit + 1, hitCount())
       /*
         Three previous values. On top, two values need to be created without the cache
         1) 'Java'

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -155,7 +155,7 @@ class PluginClasspathTest : BasePluginTest() {
   }
 
   @Test
-  fun name() {
+  fun `lib-module and a main JAR are discovered`() {
     val result = buildPluginInDirectory {
       dir("lib") {
         dir("modules") {
@@ -171,7 +171,7 @@ class PluginClasspathTest : BasePluginTest() {
     }
     assertSuccess(result) {
       with(plugin.classpath) {
-        assertEquals(3, size)
+        assertEquals(2, size)
         assertTrue(containsFileName("json.jar"))
         assertTrue(containsFileName("intellij.json.split.jar"))
       }


### PR DESCRIPTION
When creating a `classpath` for any plugin or module by content module scanning, remove duplicate classpath entries.

Every such duplicate entry produces a separate JarResolver, possibly consuming duplicate memory.