### PR TITLE
Remove duplicate 'file' subschema from URIs

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
@@ -17,11 +17,15 @@ fun Path.toJarFileUri(): URI {
   return if (toUri().scheme == FILE_SCHEMA) {
     val absoluteJarPath = if (isAbsolute) this else toAbsolutePath()
     if(absoluteJarPath.exists()) {
-      URI("$JAR_FILE_SCHEMA:${absoluteJarPath.toRealPath().toUri()}")
+      absoluteJarPath.toRealPath().asJarFileUri()
     } else {
-      URI("$JAR_FILE_SCHEMA:${absoluteJarPath.normalize().toUri()}")
+      absoluteJarPath.normalize().asJarFileUri()
     }
   } else {
     toUri()
   }
 }
+
+private fun Path.asJarFileUri(): URI = toUri().replaceSchema(JAR_FILE_SCHEMA)
+
+private fun URI.replaceSchema(newSchema: String) = URI(newSchema, userInfo, host, port, path, query, fragment)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jars.kt
@@ -13,17 +13,12 @@ const val JAR_SCHEME = "jar"
  * This path is resolved to an absolute path before converting to the URI.
  * All other paths are retained as-is.
  */
-fun Path.toJarFileUri(): URI {
-  return if (toUri().scheme == FILE_SCHEMA) {
-    val absoluteJarPath = if (isAbsolute) this else toAbsolutePath()
-    if(absoluteJarPath.exists()) {
-      absoluteJarPath.toRealPath().asJarFileUri()
-    } else {
-      absoluteJarPath.normalize().asJarFileUri()
-    }
-  } else {
-    toUri()
-  }
+fun Path.toJarFileUri(): URI = if (toUri().scheme == FILE_SCHEMA) {
+  toAbsolutePath().run {
+    if (exists()) toRealPath() else normalize()
+  }.asJarFileUri()
+} else {
+  toUri()
 }
 
 private fun Path.asJarFileUri(): URI = toUri().replaceSchema(JAR_FILE_SCHEMA)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/JarsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/JarsTest.kt
@@ -1,0 +1,108 @@
+package com.jetbrains.plugin.structure.jar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+
+private const val JAR_FILE_SCHEMA_PREFIX = "$JAR_FILE_SCHEMA:"
+
+class JarsTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `path with file scheme that is absolute and exists`() {
+    val existingPath = temporaryFolder.newFile("existing.jar").toPath()
+
+    val jarUri = existingPath.toJarFileUri()
+    assertEquals(JAR_SCHEME, jarUri.scheme)
+    assertTrue(jarUri.toString().startsWith(JAR_FILE_SCHEMA_PREFIX))
+    assertTrue(jarUri.toString().contains(existingPath.toRealPath().toSystemIndependentString()))
+  }
+
+  @Test
+  fun `path with 'file' scheme that is absolute but doesn't exist`() {
+    val nonExistingPath = Paths.get(temporaryFolder.root.absolutePath, "non-existing.jar")
+    val jarUri = nonExistingPath.toJarFileUri()
+
+    assertEquals(JAR_SCHEME, jarUri.scheme)
+    assertTrue(jarUri.toString().startsWith(JAR_FILE_SCHEMA_PREFIX))
+    assertTrue(jarUri.toString().contains(nonExistingPath.normalize().toSystemIndependentString()))
+  }
+
+  @Test
+  fun `relative path with 'scheme' file that exists is converted to JAR-protocol URI with real path`() {
+    val existingPath = temporaryFolder.newFile("relative-existing.jar").toPath()
+
+    val currentDir = Paths.get("").toAbsolutePath()
+    val relativePath = currentDir.relativize(existingPath)
+
+    val jarUri = relativePath.toJarFileUri()
+
+    assertEquals(JAR_SCHEME, jarUri.scheme)
+    assertTrue(jarUri.toString().startsWith(JAR_FILE_SCHEMA_PREFIX))
+    assertTrue(jarUri.toString().contains(existingPath.toRealPath().toSystemIndependentString()))
+  }
+
+  @Test
+  fun `relative path with 'file' scheme that does not exist is converted to JAR-protocol URI with normalized absolute path`() {
+    val relativePath = Paths.get("non-existing-relative.jar")
+    val jarUri = relativePath.toJarFileUri()
+
+    assertEquals(JAR_SCHEME, jarUri.scheme)
+    assertTrue(jarUri.toString().startsWith(JAR_FILE_SCHEMA_PREFIX))
+    val absolutePath = relativePath.toAbsolutePath().normalize()
+    assertTrue(jarUri.toString().contains(absolutePath.toSystemIndependentString()))
+  }
+
+  @Test
+  fun `non-file scheme URI is returned as-is`() {
+    val mockUri = URI("https://example.com/file.jar")
+    val mockPath = object : Path {
+      override fun toUri(): URI = mockUri
+
+      // Implement other required methods with minimal functionality
+      override fun getFileSystem() = throw UnsupportedOperationException("Not implemented")
+      override fun isAbsolute() = true
+      override fun getRoot() = null
+      override fun getFileName() = null
+      override fun getParent() = null
+      override fun getNameCount() = 0
+      override fun getName(index: Int) = throw UnsupportedOperationException("Not implemented")
+      override fun subpath(beginIndex: Int, endIndex: Int) = throw UnsupportedOperationException("Not implemented")
+      override fun startsWith(other: Path) = false
+      override fun startsWith(other: String) = false
+      override fun endsWith(other: Path) = false
+      override fun endsWith(other: String) = false
+      override fun normalize() = this
+      override fun resolve(other: Path) = throw UnsupportedOperationException("Not implemented")
+      override fun resolve(other: String) = throw UnsupportedOperationException("Not implemented")
+      override fun resolveSibling(other: Path) = throw UnsupportedOperationException("Not implemented")
+      override fun resolveSibling(other: String) = throw UnsupportedOperationException("Not implemented")
+      override fun relativize(other: Path) = throw UnsupportedOperationException("Not implemented")
+      override fun toAbsolutePath() = this
+      override fun toRealPath(vararg options: java.nio.file.LinkOption) = this
+      override fun toFile() = throw UnsupportedOperationException("Not implemented")
+      override fun register(watcher: java.nio.file.WatchService, events: Array<out java.nio.file.WatchEvent.Kind<*>>, vararg modifiers: java.nio.file.WatchEvent.Modifier) = throw UnsupportedOperationException("Not implemented")
+      override fun register(watcher: java.nio.file.WatchService, vararg events: java.nio.file.WatchEvent.Kind<*>) = throw UnsupportedOperationException("Not implemented")
+      override fun iterator() = throw UnsupportedOperationException("Not implemented")
+      override fun compareTo(other: Path) = 0
+    }
+
+    val jarUri = mockPath.toJarFileUri()
+
+    assertEquals("https", jarUri.scheme)
+    assertEquals(mockUri, jarUri)
+  }
+
+  private fun Path.toSystemIndependentString(): String {
+    return toString().replace(File.separatorChar, '/')
+  }
+}


### PR DESCRIPTION
Remove duplicate `file` subschema from `URI`s.

Before, a path could have been resolved to `jar:file:file:///var/archive.jar`. Now, it is a correct absolute `jar:file:///var/archive.jar`.

This PR fixes the path resolution and adds unit tests.