### PR TITLE
Introduce `BinaryClassName` as a type-safe variant to String

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/Names.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/Names.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base
+
+/**
+ * Binary Class or Interface name.
+ *
+ * Examples:
+ *
+ * * `java/lang/String` is a binary name for `java.lang.String
+ * * `java/util/Map$Entry` is a binary name for nested class `java.util.Map.Entry`
+ *
+ * See [Java Virtual Machine Specification §4.2.1](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.2.1)
+ */
+typealias BinaryClassName = CharSequence

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/BinaryClasses.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/BinaryClasses.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base.utils
+
+import com.jetbrains.plugin.structure.base.BinaryClassName
+import java.util.*
+
+fun binaryClassNames(): MutableSet<BinaryClassName> = TreeSet(CharSequenceComparator)
+
+fun binaryClassNames(vararg classNames: CharSequence): MutableSet<BinaryClassName> {
+  return classNames.mapTo(binaryClassNames()) { it }
+}

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/CharSequenceComparator.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/CharSequenceComparator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base.utils
+
+import java.nio.CharBuffer
+import kotlin.math.min
+
+object CharSequenceComparator : Comparator<CharSequence> {
+  override fun compare(cs1: CharSequence, cs2: CharSequence): Int {
+    if (cs1 === cs2) return 0
+
+    if (cs1 is CharBuffer && cs2 is CharBuffer) {
+      return cs1.compareTo(cs2)
+    }
+
+    if (cs1 is String && cs2 is String) {
+      return cs1.compareTo(cs2)
+    }
+
+    val len1 = cs1.length
+    val len2 = cs2.length
+    val shorterLen = min(len1, len2)
+
+    for (i in 0 until shorterLen) {
+      val comparison = cs1[i].compareTo(cs2[i])
+      if (comparison != 0) {
+        return comparison
+      }
+    }
+    return len1 - len2
+  }
+}

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
@@ -28,6 +28,7 @@ class CacheResolver(
       .maximumSize(cacheSize.toLong())
       .build { key -> delegate.resolveExactPropertyResourceBundle(key.baseName, key.locale) }
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = delegate.allClasses
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
@@ -67,8 +67,11 @@ class CacheResolver(
 
   override fun toString() = "Caching resolver for $delegate"
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) =
     delegate.containsClass(className)
+
+  override fun containsClass(className: BinaryClassName) = delegate.containsClass(className)
 
   override fun containsPackage(packageName: String) =
     delegate.containsPackage(packageName)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
@@ -48,10 +48,15 @@ class CacheResolver(
   override val readMode
     get() = delegate.readMode
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> = try {
     classCache.get(className)
   } catch (e: ExecutionException) {
     throw e.cause ?: e
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale): ResolutionResult<PropertyResourceBundle> = try {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CacheResolver.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.classes.resolvers
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
 import java.util.concurrent.ExecutionException
@@ -29,6 +30,9 @@ class CacheResolver(
 
   override val allClasses
     get() = delegate.allClasses
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = delegate.allClassNames
 
   override val allBundleNameSet
     get() = delegate.allBundleNameSet

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
@@ -71,11 +71,14 @@ class CompositeResolver private constructor(
 
   private fun getPackageName(className: String) = className.substringBeforeLast('/', "")
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String): Boolean {
     val packageName = getPackageName(className)
     val resolvers = packageToResolvers[packageName] ?: emptyList()
     return resolvers.any { it.containsClass(className) }
   }
+
+  override fun containsClass(className: BinaryClassName) = containsClass(className.toString())
 
   override fun containsPackage(packageName: String) = packageName in packageToResolvers
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
@@ -49,6 +49,7 @@ class CompositeResolver private constructor(
     }
   }
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = resolvers.flatMapTo(hashSetOf()) { it.allClasses }
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
@@ -4,6 +4,8 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.base.utils.closeAll
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
@@ -49,6 +51,9 @@ class CompositeResolver private constructor(
 
   override val allClasses
     get() = resolvers.flatMapTo(hashSetOf()) { it.allClasses }
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = resolvers.flatMapTo(binaryClassNames()) { it.allClassNames }
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(fullBundleNames)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/CompositeResolver.kt
@@ -79,6 +79,7 @@ class CompositeResolver private constructor(
 
   override fun containsPackage(packageName: String) = packageName in packageToResolvers
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     val packageName = getPackageName(className)
     val resolvers = packageToResolvers[packageName] ?: emptyList()
@@ -89,6 +90,10 @@ class CompositeResolver private constructor(
       }
     }
     return ResolutionResult.NotFound
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale): ResolutionResult<PropertyResourceBundle> {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -62,9 +62,14 @@ class DirectoryResolver(
     return root
   }
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     val classFile = classNameToFile[className] ?: return ResolutionResult.NotFound
     return readClass(className, classFile)
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   private fun readClass(className: String, classFile: Path): ResolutionResult<ClassNode> =

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -106,6 +106,7 @@ class DirectoryResolver(
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(bundleNames)
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = classNameToFile.keys
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -118,7 +118,10 @@ class DirectoryResolver(
   override val allClassNames: Set<BinaryClassName>
     get() = allClasses
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = className in classNameToFile
+
+  override fun containsClass(className: BinaryClassName) = containsClass(className.toString())
 
   override fun containsPackage(packageName: String) = packageName in packageSet
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/DirectoryResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.utils.closeOnException
 import com.jetbrains.plugin.structure.base.utils.extension
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
@@ -107,6 +108,9 @@ class DirectoryResolver(
 
   override val allClasses
     get() = classNameToFile.keys
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = allClasses
 
   override fun containsClass(className: String) = className in classNameToFile
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
@@ -14,7 +14,10 @@ class EmptyResolver(override val name: String) : NamedResolver(name) {
 
   override fun processAllClasses(processor: (ResolutionResult<ClassNode>) -> Boolean) = true
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String) = ResolutionResult.NotFound
+
+  override fun resolveClass(className: BinaryClassName) = ResolutionResult.NotFound
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale) = ResolutionResult.NotFound
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
@@ -21,7 +21,10 @@ class EmptyResolver(override val name: String) : NamedResolver(name) {
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale) = ResolutionResult.NotFound
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = false
+
+  override fun containsClass(className: BinaryClassName) = false
 
   override fun containsPackage(packageName: String) = false
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
@@ -22,6 +22,7 @@ class EmptyResolver(override val name: String) : NamedResolver(name) {
 
   override fun containsPackage(packageName: String) = false
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses = emptySet<String>()
 
   override val allClassNames: Set<BinaryClassName> = emptySet()

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/EmptyResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
 
@@ -22,6 +23,8 @@ class EmptyResolver(override val name: String) : NamedResolver(name) {
   override fun containsPackage(packageName: String) = false
 
   override val allClasses = emptySet<String>()
+
+  override val allClassNames: Set<BinaryClassName> = emptySet()
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages = emptySet<String>()

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -57,6 +57,7 @@ class FixedClassesResolver private constructor(
     return ResolutionResult.Found(propertyResourceBundle, fileOrigin)
   }
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = classes.keys
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -83,7 +83,10 @@ class FixedClassesResolver private constructor(
   override val packages: Set<String>
     get() = packageSet.entries
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = className in classes
+
+  override fun containsClass(className: BinaryClassName) = containsClass(className.toString())
 
   override fun containsPackage(packageName: String) = packageName in packageSet
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -45,9 +45,14 @@ class FixedClassesResolver private constructor(
       .map { ResolutionResult.Found(it, fileOrigin) }
       .all(processor)
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     val classNode = classes[className] ?: return ResolutionResult.NotFound
     return ResolutionResult.Found(classNode, fileOrigin)
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale): ResolutionResult<PropertyResourceBundle> {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/FixedClassesResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.classes.utils.getBundleBaseName
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
@@ -58,6 +59,9 @@ class FixedClassesResolver private constructor(
 
   override val allClasses
     get() = classes.keys
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = allClasses
 
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
@@ -137,7 +137,10 @@ class JarFileResolver(
     }
   }
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = className in classes
+
+  override fun containsClass(className: BinaryClassName) = containsClass(className.toString())
 
   override fun containsPackage(packageName: String) = packageName in packageSet
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
@@ -113,6 +113,7 @@ class JarFileResolver(
   override val allBundleNameSet: ResourceBundleNameSet
     get() = ResourceBundleNameSet(bundleNames)
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = classes
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
@@ -116,6 +116,9 @@ class JarFileResolver(
   override val allClasses
     get() = classes
 
+  override val allClassNames
+    get() = classes
+
   override fun processAllClasses(processor: (ResolutionResult<ClassNode>) -> Boolean): Boolean {
     checkIsOpen()
     return JarFileSystemsPool.perform(jarPath) { jarFs ->

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/JarFileResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.utils.closeOnException
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.inputStream
@@ -140,6 +141,7 @@ class JarFileResolver(
 
   override fun containsPackage(packageName: String) = packageName in packageSet
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     checkIsOpen()
     if (className !in classes) {
@@ -153,6 +155,10 @@ class JarFileResolver(
         ResolutionResult.NotFound
       }
     }
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale): ResolutionResult<PropertyResourceBundle> {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
 
@@ -15,6 +16,9 @@ class LazyCompositeResolver private constructor(
 
   override val allClasses: Set<String>
     get() = delegateResolver.allClasses
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = delegateResolver.allClassNames
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
@@ -14,6 +14,7 @@ class LazyCompositeResolver private constructor(
     CompositeResolver.create(resolvers, name)
   }
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses: Set<String>
     get() = delegateResolver.allClasses
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
@@ -31,7 +31,10 @@ class LazyCompositeResolver private constructor(
   override val allBundleNameSet: ResourceBundleNameSet
     get() = delegateResolver.allBundleNameSet
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> = delegateResolver.resolveClass(className)
+
+  override fun resolveClass(className: BinaryClassName) = delegateResolver.resolveClass(className)
 
   override fun resolveExactPropertyResourceBundle(
     baseName: String,

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyCompositeResolver.kt
@@ -41,7 +41,10 @@ class LazyCompositeResolver private constructor(
     locale: Locale
   ): ResolutionResult<PropertyResourceBundle> = delegateResolver.resolveExactPropertyResourceBundle(baseName, locale)
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String): Boolean = delegateResolver.containsClass(className)
+
+  override fun containsClass(className: BinaryClassName): Boolean = delegateResolver.containsClass(className)
 
   override fun containsPackage(packageName: String): Boolean = delegateResolver.containsPackage(packageName)
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -52,10 +52,15 @@ class LazyJarResolver(
     jar.serviceProviders
   }
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     return jar.withClass(className) { className, classFilePath ->
       readClass(className, classFilePath)
     } ?: NotFound
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   override fun processAllClasses(processor: (ResolutionResult<ClassNode>) -> Boolean): Boolean {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -68,7 +68,10 @@ class LazyJarResolver(
       processor(readClass(className, classFilePath)) }
   }
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String): Boolean = jar.containsClass(className)
+
+  override fun containsClass(className: BinaryClassName) = containsClass(className.toString())
 
   override fun containsPackage(packageName: String): Boolean = jar.containsPackage(packageName)
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -30,6 +30,7 @@ class LazyJarResolver(
   override val bundleNames: MutableMap<String, MutableSet<String>>
     get() = jar.bundleNames.mapValues { it.value.toMutableSet() }.toMutableMap()
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses: Set<String> by lazy  {
     jar.classes.mapTo(hashSetOf()) { it.toString() }
   }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.inputStream
 import com.jetbrains.plugin.structure.classes.resolvers.ResolutionResult.NotFound
@@ -31,6 +32,10 @@ class LazyJarResolver(
 
   override val allClasses: Set<String> by lazy  {
     jar.classes.mapTo(hashSetOf()) { it.toString() }
+  }
+
+  override val allClassNames: Set<BinaryClassName> by lazy {
+    jar.classes
   }
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
@@ -31,6 +31,7 @@ abstract class Resolver : Closeable {
   /**
    * Returns the *binary* names of all the contained classes.
    */
+  @Deprecated(message = "Use 'allClassNames' property instead which is more efficient")
   abstract val allClasses: Set<String>
 
   /**

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import org.objectweb.asm.tree.ClassNode
 import java.io.Closeable
 import java.io.IOException
@@ -31,6 +32,11 @@ abstract class Resolver : Closeable {
    * Returns the *binary* names of all the contained classes.
    */
   abstract val allClasses: Set<String>
+
+  /**
+   * Returns the *binary* names of all the contained classes.
+   */
+  abstract val allClassNames: Set<BinaryClassName>
 
   /**
    * Returns binary names of all contained packages and their super-packages.

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
@@ -82,7 +82,14 @@ abstract class Resolver : Closeable {
    * Returns true if `this` Resolver contains the given class. It may be faster
    * than checking [.findClass] is not null.
    */
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   abstract fun containsClass(className: String): Boolean
+
+  /**
+   * Returns true if `this` Resolver contains the given class. It may be faster
+   * than checking [.findClass] is not null.
+   */
+  abstract fun containsClass(className: BinaryClassName): Boolean
 
   /**
    * Returns true if `this` Resolver contains the given package,
@@ -90,6 +97,7 @@ abstract class Resolver : Closeable {
    * than fetching [allPackages] and checking for presence in it.
    */
   abstract fun containsPackage(packageName: String): Boolean
+
 
   /**
    * Runs the given [processor] on every class contained in _this_ [Resolver].

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/Resolver.kt
@@ -64,7 +64,13 @@ abstract class Resolver : Closeable {
   /**
    * Resolves class with specified binary name.
    */
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   abstract fun resolveClass(className: String): ResolutionResult<ClassNode>
+
+  /**
+   * Resolves class with specified binary name.
+   */
+  abstract fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode>
 
   /**
    * Resolves property resource bundle with specified **exact** base name and locale.

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -31,7 +31,18 @@ class SimpleCompositeResolver internal constructor(
       it.allBundleNameSet
     }.reduce { acc, bundleNames -> acc.merge(bundleNames) }
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
+    for (resolver in resolvers) {
+      val resolutionResult = resolver.resolveClass(className)
+      if (resolutionResult !is ResolutionResult.NotFound) {
+        return resolutionResult
+      }
+    }
+    return ResolutionResult.NotFound
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
     for (resolver in resolvers) {
       val resolutionResult = resolver.resolveClass(className)
       if (resolutionResult !is ResolutionResult.NotFound) {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.plugin.structure.classes.resolvers
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.base.utils.closeAll
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
@@ -12,6 +14,9 @@ class SimpleCompositeResolver internal constructor(
 
   override val allClasses: Set<String>
     get() = resolvers.flatMapTo(hashSetOf()) { it.allClasses }
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = resolvers.flatMapTo(binaryClassNames()) { it.allClassNames }
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages: Set<String>

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -12,6 +12,7 @@ class SimpleCompositeResolver internal constructor(
   val name: String
 ) : Resolver() {
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses: Set<String>
     get() = resolvers.flatMapTo(hashSetOf()) { it.allClasses }
 

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -65,7 +65,12 @@ class SimpleCompositeResolver internal constructor(
     return ResolutionResult.NotFound
   }
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String): Boolean {
+    return resolvers.any { it.containsClass(className) }
+  }
+
+  override fun containsClass(className: BinaryClassName): Boolean {
     return resolvers.any { it.containsClass(className) }
   }
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -130,7 +130,10 @@ class CachingPluginDependencyResolverProvider(pluginProvider: PluginProvider) : 
     override val allBundleNameSet: ResourceBundleNameSet
       get() = delegateResolver.allBundleNameSet
 
+    @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
     override fun resolveClass(className: String) = delegateResolver.resolveClass(className)
+
+    override fun resolveClass(className: BinaryClassName) = delegateResolver.resolveClass(className)
 
     override fun resolveExactPropertyResourceBundle(
       baseName: String,

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -140,7 +140,10 @@ class CachingPluginDependencyResolverProvider(pluginProvider: PluginProvider) : 
       locale: Locale
     ) = delegateResolver.resolveExactPropertyResourceBundle(baseName, locale)
 
+    @Deprecated("Use 'containsClass(BinaryClassName)' instead")
     override fun containsClass(className: String) = delegateResolver.containsClass(className)
+
+    override fun containsClass(className: BinaryClassName) = delegateResolver.containsClass(className)
 
     override fun containsPackage(packageName: String) = delegateResolver.containsPackage(packageName)
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -117,6 +117,7 @@ class CachingPluginDependencyResolverProvider(pluginProvider: PluginProvider) : 
 
     override val readMode: ReadMode
       get() = delegateResolver.readMode
+    @Deprecated("Use 'allClassNames' property instead which is more efficient")
     override val allClasses: Set<String>
       get() = delegateResolver.allClasses
     override val allClassNames: Set<BinaryClassName>

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.ide.classes.resolver
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.stats.CacheStats
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.classes.resolvers.EMPTY_RESOLVER
 import com.jetbrains.plugin.structure.classes.resolvers.LazyCompositeResolver
 import com.jetbrains.plugin.structure.classes.resolvers.LazyJarResolver
@@ -118,6 +119,8 @@ class CachingPluginDependencyResolverProvider(pluginProvider: PluginProvider) : 
       get() = delegateResolver.readMode
     override val allClasses: Set<String>
       get() = delegateResolver.allClasses
+    override val allClassNames: Set<BinaryClassName>
+      get() = delegateResolver.allClassNames
     @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
     override val allPackages: Set<String>
       get() = delegateResolver.allPackages

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.ide.classes.resolver
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.classes.resolvers.EmptyResolver
 import com.jetbrains.plugin.structure.classes.resolvers.LazyCompositeResolver
@@ -106,6 +107,8 @@ class ProductInfoClassResolver(
   override val readMode: ReadMode get() = resolverConfiguration.readMode
 
   override val allClasses get() = delegateResolver.allClasses
+
+  override val allClassNames: Set<BinaryClassName> get() = delegateResolver.allClassNames
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages get() = delegateResolver.allPackages

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -106,6 +106,7 @@ class ProductInfoClassResolver(
 
   override val readMode: ReadMode get() = resolverConfiguration.readMode
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses get() = delegateResolver.allClasses
 
   override val allClassNames: Set<BinaryClassName> get() = delegateResolver.allClassNames

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -128,7 +128,10 @@ class ProductInfoClassResolver(
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale) =
     delegateResolver.resolveExactPropertyResourceBundle(baseName, locale)
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = delegateResolver.containsClass(className)
+
+  override fun containsClass(className: BinaryClassName) = delegateResolver.containsClass(className)
 
   override fun containsPackage(packageName: String) = delegateResolver.containsPackage(packageName)
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -118,7 +118,12 @@ class ProductInfoClassResolver(
 
   override val allBundleNameSet get() = delegateResolver.allBundleNameSet
 
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String) = delegateResolver.resolveClass(className)
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return delegateResolver.resolveClass(className)
+  }
 
   override fun resolveExactPropertyResourceBundle(baseName: String, locale: Locale) =
     delegateResolver.resolveExactPropertyResourceBundle(baseName, locale)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/LazyJarResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/LazyJarResolverTest.kt
@@ -106,7 +106,7 @@ class LazyJarResolverTest {
     assertEquals(jar.classes, anotherJar.classes)
     assertEquals(2, jar.classes.size)
     LazyJarResolver(jarPath, Resolver.ReadMode.FULL, fileOrigin, fileSystemProvider = SingletonCachingJarFileSystemProvider).use { resolver ->
-      assertEquals(jar.classes, resolver.allClasses)
+      assertEquals(jar.classes, resolver.allClassNames)
       val resourceBundleResolution = resolver.resolveExactPropertyResourceBundle("com.example.MyClass", Locale.US)
       assertTrue(resourceBundleResolution is Found)
       resourceBundleResolution as Found

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/IdeResolverCreatorTest.kt
@@ -22,7 +22,7 @@ class IdeResolverCreatorTest {
   @Test
   fun `layout component with missing file in the filesystem is skipped`() {
     val ideResolver = IdeResolverCreator.createIdeResolver(createIdeWithNonExistentFileOfLayoutComponent())
-    assertEquals("IDE Resolver class count", 0, ideResolver.allClasses.size)
+    assertEquals("IDE Resolver class count", 0, ideResolver.allClassNames.size)
     assertEquals("IDE Resolver package count", 0, ideResolver.packages.size)
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
@@ -149,10 +150,10 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
 
   private fun checkPluginClasses(resolver: Resolver, expectedFileOrigin: FileOrigin) {
     assertEquals(
-      setOf("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
-      resolver.allClasses
+      binaryClassNames("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
+      resolver.allClassNames
     )
-    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.packages)
+    assertEquals(binaryClassNames("somePackage", "somePackage/subPackage"), resolver.packages)
     assertTrue(resolver.containsPackage("somePackage"))
     assertTrue(resolver.containsPackage("somePackage/subPackage"))
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -2,6 +2,7 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.classes.resolvers.AbstractJarResolver
@@ -694,10 +695,10 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
 
   private fun checkPluginClasses(resolver: Resolver, expectedFileOrigin: FileOrigin) {
     assertEquals(
-      setOf("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
-      resolver.allClasses
+      binaryClassNames("somePackage/ClassOne", "somePackage/subPackage/ClassTwo"),
+      resolver.allClassNames
     )
-    assertEquals(setOf("somePackage", "somePackage/subPackage"), resolver.packages)
+    assertEquals(binaryClassNames("somePackage", "somePackage/subPackage"), resolver.packages)
     assertTrue(resolver.containsPackage("somePackage"))
     assertTrue(resolver.containsPackage("somePackage/subPackage"))
 
@@ -857,10 +858,10 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
     }
     val singleResolver = resolvers.single() as AbstractJarResolver
 
-    val libDirectoryClasses = singleResolver.allClasses
+    val libDirectoryClasses = singleResolver.allClassNames
 
     val compileLibraryClass = "com/some/compile/library/CompileLibraryClass"
-    assertEquals(setOf(compileLibraryClass), libDirectoryClasses)
+    assertEquals(binaryClassNames(compileLibraryClass), libDirectoryClasses)
 
     val fileOrigin = (singleResolver.resolveClass(compileLibraryClass) as ResolutionResult.Found).fileOrigin
     assertEquals(JarOrZipFileOrigin("compile-library.jar", PluginFileOrigin.CompileServer(plugin)), fileOrigin)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/resolvers/ResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/resolvers/ResolverTest.kt
@@ -17,7 +17,7 @@ class ResolverTest {
   fun `empty cache doesnt contain classes`() {
     val cacheResolver = CacheResolver(EMPTY_RESOLVER)
     assertEquals(ResolutionResult.NotFound, cacheResolver.resolveClass("a"))
-    assertTrue(cacheResolver.allClasses.isEmpty())
+    assertTrue(cacheResolver.allClassNames.isEmpty())
     assertEquals(emptySet<String>(), cacheResolver.packages)
 
     assertEquals(ResolutionResult.NotFound, cacheResolver.resolveExactPropertyResourceBundle("a", Locale.ROOT))
@@ -35,7 +35,7 @@ class ResolverTest {
     val cacheResolver = CacheResolver(
       FixedClassesResolver.create(listOf(classNode), fileOrigin, readMode = Resolver.ReadMode.FULL)
     )
-    assertEquals(1, cacheResolver.allClasses.size)
+    assertEquals(1, cacheResolver.allClassNames.size)
     val found = cacheResolver.resolveClass(className) as ResolutionResult.Found
     assertEquals(classNode, found.value)
     assertEquals(fileOrigin, found.fileOrigin)
@@ -70,7 +70,7 @@ class ResolverTest {
     val resolver = CompositeResolver.create(resolver1, resolver2)
 
     assertEquals(setOf("some/package"), resolver.packages)
-    assertEquals(setOf(sameClass, class1, class2), resolver.allClasses)
+    assertEquals(setOf(sameClass, class1, class2), resolver.allClassNames)
 
     assertSame(origin1, (resolver.resolveClass(class1) as ResolutionResult.Found).fileOrigin)
     assertSame(origin2, (resolver.resolveClass(class2) as ResolutionResult.Found).fileOrigin)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -4,9 +4,11 @@
 
 package com.jetbrains.pluginverifier
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.telemetry.MutablePluginTelemetry
 import com.jetbrains.plugin.structure.base.telemetry.PLUGIN_VERIFIED_CLASSES_COUNT
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.classes.resolvers.BinaryPackageName
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
 import com.jetbrains.plugin.structure.classes.resolvers.Packages
@@ -124,7 +126,7 @@ class PluginVerifier(
             )
           )
         )
-      ).verify(classesToCheck, context) {}
+      ).verifyClasses(classesToCheck, context) {}
 
       context.runAnalyzers()
 
@@ -347,10 +349,10 @@ class PluginVerifier(
     }
   }
 
-  private fun selectClassesForCheck(pluginDetails: PluginDetails): Set<String> {
-    val classesForCheck = hashSetOf<String>()
+  private fun selectClassesForCheck(pluginDetails: PluginDetails): Set<BinaryClassName> {
     val selectorsToUse =
       if (excludeExternalBuildClassesSelector) classesSelectors.filterNot { it is ExternalBuildClassesSelector } else classesSelectors
+    val classesForCheck = binaryClassNames()
     for (classesSelector in selectorsToUse) {
       classesForCheck += classesSelector.getClassesForCheck(pluginDetails.pluginClassesLocations)
     }
@@ -363,7 +365,7 @@ class PluginVerifier(
     return allPackages.all
   }
 
-  private fun Set<String>.reportTelemetry(pluginDetails: PluginDetails, context: PluginVerificationContext) {
+  private fun Set<BinaryClassName>.reportTelemetry(pluginDetails: PluginDetails, context: PluginVerificationContext) {
     context.reportTelemetry(pluginDetails.pluginInfo, MutablePluginTelemetry().apply {
       set(PLUGIN_VERIFIED_CLASSES_COUNT, this@reportTelemetry.size)
     })

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ClassesSelector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ClassesSelector.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.pluginverifier.filtering
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 
@@ -14,5 +15,5 @@ interface ClassesSelector {
 
   fun getClassLoader(classesLocations: IdePluginClassesLocations): List<Resolver>
 
-  fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<String>
+  fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<BinaryClassName>
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ExternalBuildClassesSelector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/ExternalBuildClassesSelector.kt
@@ -4,6 +4,8 @@
 
 package com.jetbrains.pluginverifier.filtering
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.classes.resolvers.AbstractJarResolver
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.CompileServerExtensionKey
@@ -17,7 +19,7 @@ class ExternalBuildClassesSelector : ClassesSelector {
   override fun getClassLoader(classesLocations: IdePluginClassesLocations): List<Resolver> =
     classesLocations.getResolvers(CompileServerExtensionKey)
 
-  override fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<String> {
+  override fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<BinaryClassName> {
     val compileServerResolvers = classesLocations.getResolvers(CompileServerExtensionKey)
     val jarFileResolvers = compileServerResolvers.filterIsInstance<AbstractJarResolver>()
 
@@ -32,7 +34,7 @@ class ExternalBuildClassesSelector : ClassesSelector {
       .filter { resolver ->
         allServiceImplementations.any { serviceImplementation -> resolver.containsClass(serviceImplementation.replace('.', '/')) }
       }
-      .flatMapTo(hashSetOf()) { it.allClasses }
+      .flatMapTo(binaryClassNames()) { it.allClassNames }
   }
 
   private fun isJetbrainsServiceProvider(serviceProvider: String): Boolean =

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/MainClassesSelector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/MainClassesSelector.kt
@@ -4,6 +4,8 @@
 
 package com.jetbrains.pluginverifier.filtering
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
+import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.intellij.classes.locator.LocationKey
 import com.jetbrains.plugin.structure.intellij.classes.plugin.BundledPluginClassesFinder
@@ -50,7 +52,7 @@ class MainClassesSelector private constructor(private val locationKeys: List<Loc
    * Instead, our approach is to look at classes referenced in the `plugin.xml`. Given these classes
    * we predict the .jar-files that correspond to the plugin itself (not the secondary bundled libraries).
    */
-  override fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<String> {
+  override fun getClassesForCheck(classesLocations: IdePluginClassesLocations): Set<BinaryClassName> {
     val resolvers = locationKeys.flatMap { classesLocations.getResolvers(it) }
 
     val allClassesReferencedFromXml = getAllClassesReferencedFromXml(classesLocations.idePlugin)
@@ -65,7 +67,7 @@ class MainClassesSelector private constructor(private val locationKeys: List<Loc
       referencedResolvers
     }
 
-    return checkResolvers.flatMapTo(hashSetOf()) { it.allClasses }
+    return checkResolvers.flatMapTo(binaryClassNames()) { it.allClassNames }
   }
 
   private fun getAllClassesReferencedFromXml(plugin: IdePlugin): Set<String> {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -108,6 +108,7 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
    *
    * The class name must be slash separated, e.g. `java/lang/String`.
    */
+  @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {
     val moduleName = classNameToModuleName[className]
     if (moduleName != null) {
@@ -115,6 +116,10 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
       return readClass(className, classPath)
     }
     return ResolutionResult.NotFound
+  }
+
+  override fun resolveClass(className: BinaryClassName): ResolutionResult<ClassNode> {
+    return resolveClass(className.toString())
   }
 
   private fun readClass(className: String, classPath: Path): ResolutionResult<ClassNode> =

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -86,6 +86,7 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
       .substringBeforeLast(".class").replace(nameSeparator, "/")
   }
 
+  @Deprecated("Use 'allClassNames' property instead which is more efficient")
   override val allClasses
     get() = classNameToModuleName.keys
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -140,7 +140,10 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
       AsmUtil.readClassNode(className, inputStream, readMode == ReadMode.FULL)
     }
 
+  @Deprecated("Use 'containsClass(BinaryClassName)' instead")
   override fun containsClass(className: String) = className in classNameToModuleName
+
+  override fun containsClass(className: BinaryClassName) = className.toString() in classNameToModuleName
 
   override fun containsPackage(packageName: String) = packageName in packageSet
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/jdk/JdkJImageResolver.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.pluginverifier.jdk
 
+import com.jetbrains.plugin.structure.base.BinaryClassName
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
 import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
 import com.jetbrains.plugin.structure.classes.resolvers.InvalidClassFileException
@@ -87,6 +88,9 @@ class JdkJImageResolver(jdkPath: Path, override val readMode: ReadMode) : Resolv
 
   override val allClasses
     get() = classNameToModuleName.keys
+
+  override val allClassNames: Set<BinaryClassName>
+    get() = allClassNames
 
   @Deprecated("Use 'packages' property instead. This property may be slow on some file systems.")
   override val allPackages


### PR DESCRIPTION
- Introduce `BinaryClassName` that explicitly indicates a class name separated by '/' as per [Java Virtual Machine Specification §4.2.1](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.2.1).
- Enable `Resolver` to 
  * resolve class by `BinaryClassName`: `resolveClass`
  * detect if a class is present: `containsClass`
  * list all available classes: `allClasses`
- Update production code and tests to use the new methods
- Deprecate `String`-based methods in `Resolver`.

This enables more effective JAR-based resolvers that base class names on byte arrays instead of Strings. Such resolvers might be more efficient and prevent unnecessary construction of Strings that require more heap.