### PR TITLE
Reuse XML factory instances when parsing plugin identifiers and content modules

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamEventFilter.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamEventFilter.kt
@@ -8,7 +8,6 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import javax.xml.stream.EventFilter
-import javax.xml.stream.XMLInputFactory
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamException
 import javax.xml.stream.events.XMLEvent
@@ -17,16 +16,13 @@ private val LOG: Logger = LoggerFactory.getLogger(XmlStreamEventFilter::class.ja
 
 class XmlStreamEventFilter {
   @Throws(IOException::class)
-  fun filter(eventFilter: EventFilter, pluginXmlInputStream: InputStream, pluginXmlOutputStream: OutputStream) {
+  fun filter(eventFilter: EventFilter, pluginXmlInputStream: InputStream, pluginXmlOutputStream: OutputStream, xmlTransformationContext: XmlTransformationContext) {
     val closeables = mutableListOf<Closeable>()
     try {
-      val inputFactory: XMLInputFactory = newXmlInputFactory()
-      val outputFactory: XMLOutputFactory = XMLOutputFactory.newInstance()
-
-      val eventReader = inputFactory
+      val eventReader = xmlTransformationContext.xmlInputFactory
         .newFilteredEventReader(pluginXmlInputStream, eventFilter)
         .also { closeables += it }
-      val eventWriter = newEventWriter(outputFactory, pluginXmlOutputStream).also { closeables += it }
+      val eventWriter = newEventWriter(xmlTransformationContext.xmlOutputFactory, pluginXmlOutputStream).also { closeables += it }
 
       while (eventReader.hasNextEvent()) {
         val event: XMLEvent = eventReader.nextEvent()

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamings.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlStreamings.kt
@@ -47,13 +47,12 @@ sealed class XmlOutputFactoryResult {
 
 fun createXmlOutputFactory(): XmlOutputFactoryResult {
   try {
-    val inputFactory = XMLOutputFactory.newInstance()
-    return XmlOutputFactoryResult.Created(inputFactory)
+    val outputFactory = XMLOutputFactory.newInstance()
+    return XmlOutputFactoryResult.Created(outputFactory)
   } catch (e: FactoryConfigurationError) {
     return XmlOutputFactoryResult.ConfigurationError(e)
   }
 }
-
 
 fun XMLInputFactory.newEventReader(inputStream: InputStream): CloseableXmlEventReader =
   CloseableXmlEventReader(createXMLEventReader(inputStream))

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlTransformationContext.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/xml/XmlTransformationContext.kt
@@ -1,0 +1,12 @@
+package com.jetbrains.plugin.structure.xml
+
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLOutputFactory
+
+class XmlTransformationContext private constructor(val xmlInputFactory: XMLInputFactory, val xmlOutputFactory: XMLOutputFactory) {
+  companion object {
+    fun create(): XmlTransformationContext {
+      return XmlTransformationContext(XMLInputFactory.newInstance(), XMLOutputFactory.newInstance())
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/dependencies/PluginXmlDependencyFilter.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/dependencies/PluginXmlDependencyFilter.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.xml.ElementNamesFilter
 import com.jetbrains.plugin.structure.xml.EventTypeExcludingEventFilter
 import com.jetbrains.plugin.structure.xml.LogicalAndXmlEventFilter
 import com.jetbrains.plugin.structure.xml.XmlStreamEventFilter
+import com.jetbrains.plugin.structure.xml.XmlTransformationContext
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -25,6 +26,8 @@ class PluginXmlDependencyFilter(private val ignoreComments: Boolean = true, priv
 
   private val xmlStreamEventFilter = XmlStreamEventFilter()
 
+  private val xmlTransformationContext = XmlTransformationContext.create()
+
   @Throws(IOException::class)
   fun filter(pluginXmlInputStream: InputStream, pluginXmlOutputStream: OutputStream) {
     val eventFilter = mutableListOf<EventFilter>().apply {
@@ -35,7 +38,7 @@ class PluginXmlDependencyFilter(private val ignoreComments: Boolean = true, priv
       .let { LogicalAndXmlEventFilter(it) }
       .let { DocumentTypeFilter(passThruElements, it) }
 
-    return xmlStreamEventFilter.filter(eventFilter, pluginXmlInputStream, pluginXmlOutputStream)
+    return xmlStreamEventFilter.filter(eventFilter, pluginXmlInputStream, pluginXmlOutputStream, xmlTransformationContext)
   }
 
   companion object {

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/plugin/DefaultPluginIdProvider.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.xml.ElementTextContentFilter
 import com.jetbrains.plugin.structure.xml.EventTypeExcludingEventFilter
 import com.jetbrains.plugin.structure.xml.LogicalAndXmlEventFilter
 import com.jetbrains.plugin.structure.xml.XmlStreamEventFilter
+import com.jetbrains.plugin.structure.xml.XmlTransformationContext
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -19,8 +20,10 @@ import javax.xml.stream.XMLStreamConstants.START_DOCUMENT
 private const val pluginIdXPath = "/idea-plugin/id"
 private const val pluginNameXPath = "/idea-plugin/name"
 
-class DefaultPluginIdProvider : PluginIdProvider {
+class DefaultPluginIdProvider() : PluginIdProvider {
   private val xmlStreamEventFilter = XmlStreamEventFilter()
+
+  private val xmlTransformationContext = XmlTransformationContext.create()
 
   @Throws(IOException::class, MissingPluginIdException::class)
   override fun getPluginId(pluginDescriptorStream: InputStream): String {
@@ -32,7 +35,7 @@ class DefaultPluginIdProvider : PluginIdProvider {
     }
       .let { LogicalAndXmlEventFilter(it) }
 
-    xmlStreamEventFilter.filter(eventFilter, pluginDescriptorStream, NullOutputStream)
+    xmlStreamEventFilter.filter(eventFilter, pluginDescriptorStream, NullOutputStream, xmlTransformationContext)
 
     return getPluginId(elementTextContentFilter)
   }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/xml/DocumentTypeEventFilterTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/xml/DocumentTypeEventFilterTest.kt
@@ -35,10 +35,11 @@ class DocumentTypeEventFilterTest : BaseEventFilterTest() {
 
     val eventLog = EventLogFilter()
     val xmlStreamEventFilter = XmlStreamEventFilter()
+    val transformationContext = XmlTransformationContext.create()
 
     val documentTypeFilter = DocumentTypeFilter(setOf("module"), eventLog)
     val filteredXml = captureToString {
-      xmlStreamEventFilter.filter(documentTypeFilter, xml.toInputStream(), this)
+      xmlStreamEventFilter.filter(documentTypeFilter, xml.toInputStream(), this, transformationContext)
     }
 
     assertEquals(expectedXml, filteredXml)
@@ -54,10 +55,11 @@ class DocumentTypeEventFilterTest : BaseEventFilterTest() {
 
     val eventLog = EventLogFilter(isDeduplicating = true)
     val xmlStreamEventFilter = XmlStreamEventFilter()
+    val transformationContext = XmlTransformationContext.create()
 
     val documentTypeFilter = DocumentTypeFilter(setOf("module"), eventLog)
     val filteredXml = captureToString {
-      xmlStreamEventFilter.filter(documentTypeFilter, xml.toInputStream(), this)
+      xmlStreamEventFilter.filter(documentTypeFilter, xml.toInputStream(), this, transformationContext)
     }
 
     assertEquals(5, eventLog.events.size)
@@ -67,10 +69,11 @@ class DocumentTypeEventFilterTest : BaseEventFilterTest() {
   fun `XML with supported element that is not a root is handled`() {
     val eventLog = EventLogFilter(isDeduplicating = true)
     val xmlStreamEventFilter = XmlStreamEventFilter()
+    val transformationContext = XmlTransformationContext.create()
 
     val documentTypeFilter = DocumentTypeFilter(setOf("module"), eventLog)
     val filteredXml = captureToString {
-      xmlStreamEventFilter.filter(documentTypeFilter, projectXml.toInputStream(), this)
+      xmlStreamEventFilter.filter(documentTypeFilter, projectXml.toInputStream(), this, transformationContext)
     }
 
     @Language("XML")

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/IdeaPluginXmlDetector.kt
@@ -1,51 +1,20 @@
 package com.jetbrains.plugin.structure.intellij.plugin.descriptors
 
-import com.jetbrains.plugin.structure.base.utils.closeAll
-import com.jetbrains.plugin.structure.base.utils.inputStream
-import com.jetbrains.plugin.structure.xml.CloseableXmlEventReader
-import com.jetbrains.plugin.structure.xml.newXmlInputFactory
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import java.io.Closeable
+import com.jetbrains.plugin.structure.xml.XmlInputFactoryResult
+import com.jetbrains.plugin.structure.xml.createXmlInputFactory
 import java.nio.file.Path
-import javax.xml.stream.XMLInputFactory
-import javax.xml.stream.XMLStreamException
-import javax.xml.stream.events.StartElement
-import javax.xml.stream.events.XMLEvent
 
-private val LOG: Logger = LoggerFactory.getLogger(IdeaPluginXmlDetector::class.java)
+fun interface IdeaPluginXmlDetector {
+  fun isPluginDescriptor(descriptorPath: Path): Boolean
+}
 
-private const val IDEA_PLUGIN_ROOT_ELEMENT = "idea-plugin"
+object NegativeIdeaPluginXmlDetector : IdeaPluginXmlDetector {
+  override fun isPluginDescriptor(descriptorPath: Path) = false
+}
 
-class IdeaPluginXmlDetector {
-  fun isPluginDescriptor(descriptorPath: Path): Boolean {
-    val closeables = mutableListOf<Closeable>()
-    try {
-      val inputFactory: XMLInputFactory = newXmlInputFactory()
-      val eventReader = inputFactory.newEventReader(descriptorPath).also { closeables += it }
-
-      while (eventReader.hasNextEvent()) {
-        val event: XMLEvent = eventReader.nextEvent()
-        if (event.isIdeaPluginElement()) {
-          return true
-        }
-      }
-      return false
-    } catch (e: XMLStreamException) {
-      LOG.debug("Unable to read plugin descriptor '{}': {}", descriptorPath, e.message)
-      return false
-    } catch (e: Exception) {
-      LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
-      return false
-    } finally {
-      closeables.closeAll()
-    }
-  }
-
-  private fun XMLEvent.isIdeaPluginElement(): Boolean =
-    this is StartElement && name.localPart == IDEA_PLUGIN_ROOT_ELEMENT
-
-  private fun XMLInputFactory.newEventReader(descriptorPath: Path): CloseableXmlEventReader {
-    return CloseableXmlEventReader(createXMLEventReader(descriptorPath.inputStream()))
+fun createIdeaPluginXmlDetector(): IdeaPluginXmlDetector {
+  return when (val result = createXmlInputFactory()) {
+    is XmlInputFactoryResult.Created -> StaxIdeaPluginXmlDetector(result.xmlInputFactory)
+    else -> NegativeIdeaPluginXmlDetector
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/StaxIdeaPluginXmlDetector.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/descriptors/StaxIdeaPluginXmlDetector.kt
@@ -1,0 +1,49 @@
+package com.jetbrains.plugin.structure.intellij.plugin.descriptors
+
+import com.jetbrains.plugin.structure.base.utils.closeAll
+import com.jetbrains.plugin.structure.base.utils.inputStream
+import com.jetbrains.plugin.structure.xml.CloseableXmlEventReader
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.nio.file.Path
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamException
+import javax.xml.stream.events.StartElement
+import javax.xml.stream.events.XMLEvent
+
+private val LOG: Logger = LoggerFactory.getLogger(StaxIdeaPluginXmlDetector::class.java)
+
+private const val IDEA_PLUGIN_ROOT_ELEMENT = "idea-plugin"
+
+class StaxIdeaPluginXmlDetector(private val xmlInputFactory: XMLInputFactory): IdeaPluginXmlDetector {
+  override fun isPluginDescriptor(descriptorPath: Path): Boolean {
+    val closeables = mutableListOf<Closeable>()
+    try {
+      val eventReader = xmlInputFactory.newEventReader(descriptorPath).also { closeables += it }
+
+      while (eventReader.hasNextEvent()) {
+        val event: XMLEvent = eventReader.nextEvent()
+        if (event.isIdeaPluginElement()) {
+          return true
+        }
+      }
+      return false
+    } catch (e: XMLStreamException) {
+      LOG.debug("Unable to read plugin descriptor '{}': {}", descriptorPath, e.message)
+      return false
+    } catch (e: Exception) {
+      LOG.warn("Unable to read plugin descriptor '$descriptorPath'", e)
+      return false
+    } finally {
+      closeables.closeAll()
+    }
+  }
+
+  private fun XMLEvent.isIdeaPluginElement(): Boolean =
+    this is StartElement && name.localPart == IDEA_PLUGIN_ROOT_ELEMENT
+
+  private fun XMLInputFactory.newEventReader(descriptorPath: Path): CloseableXmlEventReader {
+    return CloseableXmlEventReader(createXMLEventReader(descriptorPath.inputStream()))
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -4,7 +4,7 @@ import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.hasExtension
 import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.intellij.plugin.LIB_DIRECTORY
-import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.createIdeaPluginXmlDetector
 import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.META_INF
@@ -24,7 +24,7 @@ private val META_INF_PLUGIN_XML_PATH_COMPONENTS = listOf(META_INF, PLUGIN_XML)
 private val LOG: Logger = LoggerFactory.getLogger(ContentModuleScanner::class.java)
 
 class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider) {
-  private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
+  private val ideaPluginXmlDetector = createIdeaPluginXmlDetector()
 
   fun getContentModules(pluginArtifact: Path) : ContentModules {
     val libDir = pluginArtifact.resolve(LIB_DIRECTORY)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarDescriptorTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarDescriptorTest.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.plugin.structure.base.utils
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.intellij.plugin.descriptors.IdeaPluginXmlDetector
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.createIdeaPluginXmlDetector
 import com.jetbrains.plugin.structure.jar.PluginJar
 import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
 import org.junit.Assert.assertEquals
@@ -19,7 +19,7 @@ class PluginJarDescriptorTest {
 
   private lateinit var pluginJarPath: Path
 
-  private val ideaPluginXmlDetector = IdeaPluginXmlDetector()
+  private val ideaPluginXmlDetector = createIdeaPluginXmlDetector()
 
   private val jarFileSystemProvider = SingletonCachingJarFileSystemProvider
 


### PR DESCRIPTION
StAX [`XMLInputFactory`](https://docs.oracle.com/en/java/javase/17/docs/api/java.xml/javax/xml/stream/XMLInputFactory.html) and [`XMLOutputFactory`](https://docs.oracle.com/javase/8/docs/api/javax/xml/stream/XMLOutputFactory.html) are generally not thread-safe. However, it is unnecessary to create an instance with each call when parsing an XML document.

- Introduce `XmlInputFactoryResult` to hold hold a type-safe result for construction of `XMLInputFactory`.
- Introduce `XmlOutFactoryResult` as a parallel mechanism for output factories.
- Introduce `XmlTransformationContext` that holds both the XML input and output factory for transformations or fast XML parsing.
- Use these constructs
* When parsing plugin IDs from the plugin descriptors.
* When parsing plugin content modules

This prevents unnecessary construction of objects that are used only in a single thread.
