### PR TITLE
Read ASM class nodes via binary class names

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
@@ -18,7 +18,7 @@ abstract class AbstractJarResolver(
 
   abstract val implementedServiceProviders: Map<String, Set<String>>
 
-  protected open fun readClass(className: String, classPath: Path): ResolutionResult<ClassNode> {
+  protected open fun readClass(className: CharSequence, classPath: Path): ResolutionResult<ClassNode> {
     return try {
       val classNode = classPath.inputStream().use {
         AsmUtil.readClassNode(className, it, readMode == ReadMode.FULL)

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/InvalidClassFileException.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/InvalidClassFileException.kt
@@ -8,7 +8,7 @@ package com.jetbrains.plugin.structure.classes.resolvers
  * An exception thrown to indicate that a class-file cannot be read
  * using the ASM Java Bytecode engineering library.
  */
-class InvalidClassFileException(val className: String, private val asmError: String) : Exception() {
+class InvalidClassFileException(val className: CharSequence, private val asmError: String) : Exception() {
 
   override val message
     get() = "Unable to read class '$className' using the ASM Java Bytecode engineering library. The internal ASM error: $asmError."

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/AsmUtil.java
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/AsmUtil.java
@@ -22,7 +22,7 @@ public class AsmUtil {
   public static final int ASM_API_LEVEL = Opcodes.ASM9;
 
   @NotNull
-  public static ClassNode readClassNode(@NotNull String className,
+  public static ClassNode readClassNode(@NotNull CharSequence className,
                                         @NotNull InputStream inputStream,
                                         boolean fully) throws InvalidClassFileException, IOException {
     try {


### PR DESCRIPTION
Allow to read class nodes from ASM via binary class names. 

The binary class name serves a debugging / tracing purpose only. ASM library is able to deduce the class node name from the bytecode.