### PR TITLE
Update coordinates of Gradle Wrapper Validation Action

### DIFF
--- a/.github/workflows/ide-diff-builder.yml
+++ b/.github/workflows/ide-diff-builder.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v4.2.2
 
   # Run tests
   test:

--- a/.github/workflows/intellij-feature-extractor.yml
+++ b/.github/workflows/intellij-feature-extractor.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v4.2.2
 
   # Run tests
   test:

--- a/.github/workflows/intellij-plugin-structure.yml
+++ b/.github/workflows/intellij-plugin-structure.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v4.2.2
 
   # Run tests
   test:

--- a/.github/workflows/intellij-plugin-verifier.yml
+++ b/.github/workflows/intellij-plugin-verifier.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v4.2.2
 
   # Run tests
   test:

--- a/.github/workflows/plugins-verifier-service.yml
+++ b/.github/workflows/plugins-verifier-service.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/actions/wrapper-validation@v4.2.2
 
   # Run tests
   test:


### PR DESCRIPTION
_Gradle Wrapper Validation_ has updated its coordinates. Change the coordinates to the new location and use the most recent version.

This eliminates the frequent connectivity issues, such as:

```
Run gradle/actions/wrapper-validation@v3.5.0
Error: Multiple errors returned
Error: Error 0: connect ETIMEDOUT 104.16.73.101:443
Error: connect ETIMEDOUT 104.16.73.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:17[11](https://github.com/JetBrains/intellij-plugin-verifier/actions/runs/14774280767/job/41479662518?pr=1262#step:3:13):38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 1: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
    at internalConnectMultiple (node:net:1186:[16](https://github.com/JetBrains/intellij-plugin-verifier/actions/runs/14774280767/job/41479662518?pr=1262#step:3:18))
    at Timeout.internalConnectMultipleTimeout (node:net:[17](https://github.com/JetBrains/intellij-plugin-verifier/actions/runs/14774280767/job/41479662518?pr=1262#step:3:19)16:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
```