### PR TITLE
Ensure filesystem remains open during class batch processing in an `Resolver`

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -23,6 +23,10 @@ class FsHandleFileSystem(val delegate: FileSystem) : FileSystem() {
     referenceCount.incrementAndGet()
   }
 
+  fun increment(amount: Int) {
+    referenceCount.addAndGet(amount)
+  }
+
   @Synchronized
   override fun close() {
     if (!isOpen) {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.IOException
 import java.nio.CharBuffer
+import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -92,7 +93,7 @@ class Jar(
   }
 
   fun processAllClasses(processor: (String, Path) -> Boolean): Boolean {
-    return fileSystemProvider.getFileSystem(jarPath).use { fs ->
+    return getFileSystem(jarPath, classesInJar.size).use { fs ->
       classesInJar.all { (className, classFilePath) ->
         fs.getPath(classFilePath.toString())
           .takeIf { it.isFile }
@@ -106,6 +107,10 @@ class Jar(
   fun containsClass(className: String) = className in classes
 
   private fun getPath(className: String): PathInJar? = classesInJar[className]
+
+  private fun getFileSystem(jarPath: Path, expectedClients: Int): FileSystem {
+    return fileSystemProvider.getFileSystem(jarPath, JarFileSystemProvider.Configuration(expectedClients))
+  }
 
   fun <T> withClass(className: String, handler: (String, Path) -> T): T? {
     return getPath(className)?.let { pathInJar ->

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/JarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/JarFileSystemProvider.kt
@@ -6,4 +6,13 @@ import java.nio.file.Path
 interface JarFileSystemProvider {
   @Throws(JarArchiveException::class)
   fun getFileSystem(jarPath: Path): FileSystem
+
+  @Throws(JarArchiveException::class)
+  fun getFileSystem(jarPath: Path, configuration: Configuration): FileSystem = getFileSystem(jarPath)
+
+  data class Configuration(val expectedClients: Int = DEFAULT_EXPECTED_CLIENTS)
+
+  companion object {
+    const val DEFAULT_EXPECTED_CLIENTS = 1
+  }
 }


### PR DESCRIPTION
When batch-processing classes in a `Resolver`, the underlying filesystem can be closed. Prevent such situations.

- Advice a total number of potential references to the caching JAR filesystem provider. For example, when a resolver has 3 classes, advice 3 usages which contribute to the reference count. This decreases the chance that the filesystem will be closed.
- Create a separate method in the `JarFileSystemProvider` with type-safe configuration. This is similar to the [FileSystems#newFileSystem(URI, Map)](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystems.html#newFileSystem-java.net.URI-java.util.Map-) method in the Java SDK. Provide the number of expected clients in this configuration.