### PR TITLE
Caching JAR filesystem provider tracks filesystem provision events

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.jar
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.jetbrains.plugin.structure.base.utils.withSuperScheme
+import com.jetbrains.plugin.structure.jar.CachingJarFileSystemProvider.EventLog.Event.*
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider.Companion.DEFAULT_EXPECTED_CLIENTS
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider.Configuration
 import org.slf4j.Logger
@@ -24,7 +25,8 @@ const val RETENTION_TIME_PROPERTY_NAME = "com.jetbrains.plugin.structure.jar.Sin
 
 class CachingJarFileSystemProvider(
   val retentionTimeInSeconds: Long = System.getProperty(RETENTION_TIME_PROPERTY_NAME)
-    ?.toLongOrNull() ?: 10L
+    ?.toLongOrNull() ?: 10L,
+  private val enableEventLogging: Boolean = false
 ) : JarFileSystemProvider, AutoCloseable {
 
   private val delegateJarFileSystemProvider = UriJarFileSystemProvider { it.toUri().withSuperScheme(JAR_SCHEME) }
@@ -33,6 +35,8 @@ class CachingJarFileSystemProvider(
     .maximumSize(MAX_OPEN_JAR_FILE_SYSTEMS)
     .expireAfterAccess(retentionTimeInSeconds, TimeUnit.SECONDS)
     .build<String, FsHandleFileSystem>()
+
+  val eventLog = EventLog()
 
   private fun createFsHandle(jarPath: Path, jarUri: URI): FsHandleFileSystem {
     val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
@@ -60,23 +64,64 @@ class CachingJarFileSystemProvider(
     if (fs != null)  {
       if (fs.isOpen) {
         fs.increment(expectedClients)
-        LOG.debug("Reusing filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
+        logReusedFs(key)
       } else {
         val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
           LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
         }
         fs = FsHandleFileSystem(jarFs)
         fsCache.put(key, fs)
+        logRecreatedFs(key)
       }
     } else {
       fs = createFsHandle(jarPath, jarUri)
       fsCache.put(key, fs)
+      logCreatedFs(key)
     }
     return fs
   }
 
-
   override fun close() {
     fsCache.invalidateAll()
+  }
+
+  private fun logCreatedFs(uriString: String) {
+    if (enableEventLogging) eventLog.logCreated(uriString)
+  }
+
+  private fun logReusedFs(uriString: String) {
+    LOG.debug("Reusing filesystem handler for <{}> (Cache size: {})", uriString, fsCache.estimatedSize())
+    if (enableEventLogging) eventLog.logReused(uriString)
+  }
+
+  private fun logRecreatedFs(uriString: String) {
+    if (enableEventLogging) eventLog.logRecreated(uriString)
+  }
+
+  class EventLog : AbstractList<EventLog.Event>() {
+    private val events = mutableListOf<Event>()
+
+    fun logCreated(key: String) {
+      events += Created(key)
+    }
+
+    fun logReused(key: String) {
+      events += Reused(key)
+    }
+
+    fun logRecreated(key: String) {
+      events += Recreated(key)
+    }
+
+    override val size: Int
+      get() = events.size
+
+    override fun get(index: Int): Event = events[index]
+
+    sealed class Event {
+      data class Created(val key: String) : Event()
+      data class Reused(val key: String) : Event()
+      data class Recreated(val key: String) : Event()
+    }
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
@@ -112,18 +112,6 @@ class Jar(
     return fileSystemProvider.getFileSystem(jarPath, JarFileSystemProvider.Configuration(expectedClients))
   }
 
-  fun <T> withClass(className: String, handler: (String, Path) -> T): T? {
-    return getPath(className)?.let { pathInJar ->
-      fileSystemProvider.getFileSystem(jarPath).use { fs ->
-        fs.getPath(pathInJar.toString())
-          .takeIf { it.isFile }
-          ?.let {
-            handler(className, it)
-          }
-      }
-    }
-  }
-
   fun <T> processClassPathInJar(className: String, handler: (String, PathInJar) -> T): T? {
     return getPath(className)?.let { pathInJar ->
       handler(className, pathInJar)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
@@ -95,9 +95,11 @@ class Jar(
   fun processAllClasses(processor: (String, Path) -> Boolean): Boolean {
     return getFileSystem(jarPath, classesInJar.size).use { fs ->
       classesInJar.all { (className, classFilePath) ->
-        fs.getPath(classFilePath.toString())
-          .takeIf { it.isFile }
-          ?.let { processor(className.toString(), it) } == true
+        getFileSystem(jarPath, expectedClients = 1).use { classFs ->
+          classFs.getPath(classFilePath.toString())
+            .takeIf { it.isFile }
+            ?.let { processor(className.toString(), it) } == true
+        }
       }
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/JarTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/JarTest.kt
@@ -231,7 +231,7 @@ class JarTest {
       }
     }
     assertEquals(1, reopenBecauseNull)
-    assertEquals(1, reopenBecauseClosed)
+    assertEquals(2, reopenBecauseClosed)
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/JarTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/classes/resolvers/jar/JarTest.kt
@@ -236,7 +236,7 @@ class JarTest {
 
   @Test
   fun `all classes are processed when underlying filesystem is closed with caching filesystem provider`() {
-    val fsProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+    val fsProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE, enableEventLogging = true)
     val jarPath = temporaryFolder.newFile("plugin-class-processing.jar").toPath()
     createJar(jarPath, fsProvider).use { jar ->
       val uniqueFileSystems = IdentityHashMap<FileSystem, Unit>()
@@ -257,6 +257,15 @@ class JarTest {
       }
       // Provider should have closed 1 filesystem (in the 1st iteration)
       assertEquals(1, uniqueFileSystems.size)
+    }
+    with(fsProvider.eventLog) {
+      assertEquals(5, size)
+      // initially, create a filesystem
+      assertEquals(1, filterIsInstance<CachingJarFileSystemProvider.EventLog.Event.Created>().size)
+      // after closing, recreate filesystem once
+      assertEquals(1, filterIsInstance<CachingJarFileSystemProvider.EventLog.Event.Recreated>().size)
+      // reuse filesystem for 3 classes
+      assertEquals(3, filterIsInstance<CachingJarFileSystemProvider.EventLog.Event.Reused>().size)
     }
   }
 }


### PR DESCRIPTION
The Caching JAR filesystem provider tracks filesystem provisioning events, including:

- Creating a filesystem
- Reusing an existing filesystem
- Recreating a filesystem if it was previously closed