### PR TITLE
Cache `DependencyNode` and `DeprecationInfo` instances

### DIFF
--- a/.idea/copyright/Apache_2_0.xml
+++ b/.idea/copyright/Apache_2_0.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file." />
+    <option name="notice" value="Copyright 2000-&amp;#36;today.year JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file." />
     <option name="myName" value="Apache 2.0" />
   </copyright>
 </component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,3 @@
 <component name="CopyrightManager">
-  <settings default="" />
+  <settings default="Apache 2.0" />
 </component>

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphProvider.kt
@@ -4,9 +4,11 @@
 
 package com.jetbrains.pluginverifier.dependencies
 
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.DependencyTreeResolution
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.id
+import java.util.function.Function
 
 private const val UNKNOWN_VERSION = "unknown version"
 
@@ -36,11 +38,19 @@ class DependenciesGraphProvider {
   private fun DependencyTreeResolution.getEdges(): List<DependencyEdge> {
     val edges = mutableListOf<DependencyEdge>()
     forEach { id, dependency ->
-      edges += DependencyEdge(DependencyNode(id,
-        "unknown version"), DependencyNode(dependency.id, UNKNOWN_VERSION), dependency)
+      edges += DependencyEdge(
+        DependencyNode(id, UNKNOWN_VERSION).intern(),
+        DependencyNode(dependency.id, UNKNOWN_VERSION).intern(),
+        dependency.intern()
+      )
     }
     return edges
   }
+
+  private val pluginDependencyCache = hashMapOf<PluginDependency, PluginDependency>()
+  private fun PluginDependency.intern(): PluginDependency = pluginDependencyCache.computeIfAbsent(this, Function.identity())
+  private val dependencyNodeCache = hashMapOf<DependencyNode, DependencyNode>()
+  private fun DependencyNode.intern(): DependencyNode = dependencyNodeCache.computeIfAbsent(this, Function.identity())
 
   private fun DependencyTreeResolution.getMissingDependencies(): Map<DependencyNode, Set<MissingDependency>> {
     return missingDependencies.map { (plugin, dependencies) ->

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationInfo.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.deprecated
@@ -13,4 +13,9 @@ package com.jetbrains.pluginverifier.usages.deprecated
 data class DeprecationInfo(
   val forRemoval: Boolean,
   val untilVersion: String?
-)
+) {
+  companion object {
+    val FOR_REMOVAL_TRUE = DeprecationInfo(true, null)
+    val FOR_REMOVAL_FALSE = DeprecationInfo(false, null)
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationUtil.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecationUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.pluginverifier.usages.deprecated
@@ -28,13 +28,13 @@ val ClassFileMember.deprecationInfo: DeprecationInfo?
     val scheduledForRemoval = annotations.findAnnotation(JETBRAINS_SCHEDULED_FOR_REMOVAL_ANNOTATION_NAME)
     if (scheduledForRemoval != null) {
       val inVersion = scheduledForRemoval.getAnnotationValue("inVersion") as? String
-      return DeprecationInfo(true, inVersion)
+      return if (inVersion == null) DeprecationInfo.FOR_REMOVAL_TRUE else DeprecationInfo(true, inVersion)
     }
 
     val deprecated = annotations.findAnnotation(JAVA_DEPRECATED_ANNOTATION_NAME)
     if (deprecated != null) {
       val forRemoval = deprecated.getAnnotationValue("forRemoval") as? Boolean ?: false
-      return DeprecationInfo(forRemoval, null)
+      return if (forRemoval) DeprecationInfo.FOR_REMOVAL_TRUE else DeprecationInfo.FOR_REMOVAL_FALSE
     }
 
     val kotlinDeprecated = annotations.findAnnotation(KOTLIN_DEPRECATED_ANNOTATION_NAME)
@@ -46,7 +46,7 @@ val ClassFileMember.deprecationInfo: DeprecationInfo?
     }
 
     return if (isDeprecated) {
-      DeprecationInfo(false, null)
+      DeprecationInfo.FOR_REMOVAL_FALSE
     } else {
       null
     }


### PR DESCRIPTION
Based on the profiling information:

- Cache `DependencyNode` instances when converting _Structure_ dependency graph to the Plugin Verifier dependency graph
- Reuse `DeprecationInfo` instances for more common cases