### PR TITLE
Lazy JAR resolver uses `ZipFile` to resolve resource bundles

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
@@ -38,9 +38,9 @@ abstract class AbstractJarResolver(
     }
 
     val control = ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES)
-    val bundleName = control.toBundleName(baseName, locale)
+    val bundleName: String = control.toBundleName(baseName, locale)
 
-    val resourceName = control.toResourceName(bundleName, "properties")
+    val resourceName: String = control.toResourceName(bundleName, "properties")
     val propertyResourceBundle = try {
       readPropertyResourceBundle(resourceName)
     } catch (e: IllegalArgumentException) {

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/AbstractJarResolver.kt
@@ -4,6 +4,11 @@ import com.jetbrains.plugin.structure.base.utils.inputStream
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
 import com.jetbrains.plugin.structure.classes.utils.AsmUtil
 import org.objectweb.asm.tree.ClassNode
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.nio.charset.MalformedInputException
+import java.nio.charset.UnmappableCharacterException
 import java.nio.file.Path
 import java.util.*
 
@@ -13,6 +18,8 @@ abstract class AbstractJarResolver(
   protected open val fileOrigin: FileOrigin,
   name: String = jarPath.fileName.toString()
 ) : NamedResolver(name) {
+
+  private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
   protected abstract val bundleNames: MutableMap<String, MutableSet<String>>
 
@@ -41,21 +48,30 @@ abstract class AbstractJarResolver(
     val bundleName: String = control.toBundleName(baseName, locale)
 
     val resourceName: String = control.toResourceName(bundleName, "properties")
-    val propertyResourceBundle = try {
-      readPropertyResourceBundle(resourceName)
+
+    return try {
+      val propertyResourceBundle = readPropertyResourceBundle(resourceName) ?: return ResolutionResult.NotFound
+      return ResolutionResult.Found(propertyResourceBundle, fileOrigin)
+    } catch (e: IOException) {
+      failedToRead(resourceName, e, "I/O error")
+    } catch (e: NullPointerException) {
+      failedToRead(resourceName, e, "Stream is null")
     } catch (e: IllegalArgumentException) {
-      return ResolutionResult.Invalid(e.message ?: e.javaClass.name)
+      failedToRead(resourceName, e, "Stream contains malformed Unicode sequences")
+    } catch (e: MalformedInputException) {
+      failedToRead(resourceName, e, "Stream contains an invalid UTF-8 sequence")
+    } catch (e: UnmappableCharacterException) {
+      failedToRead(resourceName, e, "Stream contains an unmappable UTF-8 sequence")
     } catch (e: Exception) {
       e.rethrowIfInterrupted()
-      return ResolutionResult.FailedToRead(e.message ?: e.javaClass.name)
+      ResolutionResult.Invalid(e.message ?: e.javaClass.name)
     }
-
-    if (propertyResourceBundle != null) {
-      return ResolutionResult.Found(propertyResourceBundle, fileOrigin)
-    }
-
-    return ResolutionResult.NotFound
   }
 
   protected abstract fun readPropertyResourceBundle(bundleResourceName: String): PropertyResourceBundle?
+
+  private fun failedToRead(bundleResourceName: String, e: Exception, reason: String): ResolutionResult.FailedToRead {
+    logger.debug("Cannot read resource bundle '{}'. {}: {}", bundleResourceName, reason, e.message, e)
+    return ResolutionResult.FailedToRead(e.message ?: e.javaClass.name)
+  }
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -11,9 +11,6 @@ import com.jetbrains.plugin.structure.jar.newZipHandler
 import org.objectweb.asm.tree.ClassNode
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.IOException
-import java.nio.charset.MalformedInputException
-import java.nio.charset.UnmappableCharacterException
 import java.nio.file.Path
 import java.util.*
 
@@ -99,27 +96,9 @@ class LazyJarResolver(
   }
 
   override fun readPropertyResourceBundle(bundleResourceName: String): PropertyResourceBundle? {
-    try {
-      return zipHandler.handleEntry(bundleResourceName) { bundleResourceName, entry ->
-        val inputStream = bundleResourceName.getInputStream(entry)
-        PropertyResourceBundle(inputStream)
-      }
-    } catch (e: IOException) {
-      bundleResourceName.logException(e, "I/O error")
-    } catch (e: NullPointerException) {
-      bundleResourceName.logException(e, "Stream is null")
-    } catch (e: IllegalArgumentException) {
-      bundleResourceName.logException(e, "Stream contains malformed Unicode sequences")
-    } catch (e: MalformedInputException) {
-      bundleResourceName.logException(e, "Stream contains an invalid UTF-8 sequence")
-    } catch (e: UnmappableCharacterException) {
-      bundleResourceName.logException(e, "Stream contains an unmappable UTF-8 sequence")
+    return zipHandler.handleEntry(bundleResourceName) { bundleResourceName, entry ->
+      val inputStream = bundleResourceName.getInputStream(entry)
+      PropertyResourceBundle(inputStream)
     }
-    return null
   }
-
-  private fun String.logException(e: Exception, reason: String) {
-    LOG.debug("Cannot read resource bundle '{}'. {}: {}", this, reason, e.message, e)
-  }
-
 }


### PR DESCRIPTION
- `LazyJarResolver` uses `ZipFile` to resolve resource bundles. This is in line with the algorithm that is used to resolve classes by name.
- Improve exception handling in malformed UTF-8 resource bundle content.
- Use explicit types in platform types.