### PR TITLE
Product Info `bootClassPathJarNames` share resolvers with core plugin layout components

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/LazyJarResolver.kt
@@ -17,7 +17,7 @@ import java.util.*
 private val LOG: Logger = LoggerFactory.getLogger(LazyJarResolver::class.java)
 
 class LazyJarResolver(
-  override val jarPath: Path,
+  public override val jarPath: Path,
   override val readMode: ReadMode,
   override val fileOrigin: FileOrigin,
   override val name: String = jarPath.fileName.toString(),

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -6,8 +6,8 @@ import com.jetbrains.plugin.structure.base.utils.closeAll
 import org.objectweb.asm.tree.ClassNode
 import java.util.*
 
-class SimpleCompositeResolver internal constructor(
-  private val resolvers: List<Resolver>,
+open class SimpleCompositeResolver(
+  open val resolvers: List<Resolver>,
   override val readMode: ReadMode,
   override val name: String
 ) : NamedResolver(name) {

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverConfiguration.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/IdeResolverConfiguration.kt
@@ -3,5 +3,9 @@ package com.jetbrains.plugin.structure.ide.classes
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
 
-data class IdeResolverConfiguration(val readMode: Resolver.ReadMode, val missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN)
+data class IdeResolverConfiguration(
+  val readMode: Resolver.ReadMode,
+  val missingLayoutFileMode: MissingLayoutFileMode = MissingLayoutFileMode.SKIP_AND_WARN,
+  val isCollectingStats: Boolean = false
+)
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -188,7 +188,7 @@ class ProductInfoClassResolver(
   private fun getBootJarResolver(relativeJarPath: String): NamedResolver {
     val fullyQualifiedJarFile = ide.idePath.resolve("lib/$relativeJarPath")
     return corePluginClasspathCache[fullyQualifiedJarFile]?.also {
-      statisticizeReuse(fullyQualifiedJarFile)
+      recordResolverReuse(fullyQualifiedJarFile)
     } ?: LazyJarResolver(fullyQualifiedJarFile, readMode, IdeLibDirectory(ide), name = relativeJarPath)
   }
 
@@ -198,7 +198,7 @@ class ProductInfoClassResolver(
     }
   }
 
-  private fun statisticizeReuse(fullyQualifiedJarFile: Path) {
+  private fun recordResolverReuse(fullyQualifiedJarFile: Path) {
     _stats?.add("Reusing $fullyQualifiedJarFile")
   }
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -57,8 +57,6 @@ class ProductInfoClassResolver(
     }
   }
 
-  internal val namedResolvers: Collection<NamedResolver> = resolvers.values
-
   override fun getResolver(plugin: IdePlugin): Resolver {
     val id = plugin.pluginId?: plugin.pluginName
     return id?.let { resolvers[id] } ?: EMPTY_RESOLVER

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
@@ -44,7 +44,7 @@ class ProductInfoClassResolverTest {
 
       ideRoot.resolve("build.txt").writeText(IDEA_ULTIMATE_2024_2)
 
-      createEmptyIdeFiles()
+      ideRoot.createEmptyIdeFiles()
       createEmptyJarClassFiles()
     }
   }
@@ -154,10 +154,10 @@ class ProductInfoClassResolverTest {
     }
   }
 
-  private fun createEmptyIdeFiles() {
+  private fun Path.createEmptyIdeFiles() {
     ideFiles.flatMap { (_, files) -> files }
       .map { file ->
-        ideRoot.resolve(file).apply {
+        resolve(file).apply {
           createParentDirs()
         }
       }.forEach {
@@ -210,6 +210,7 @@ class ProductInfoClassResolverTest {
       "lib/protobuf.jar",
       "lib/intellij-test-discovery.jar",
       "lib/forms_rt.jar",
+      "lib/kotlinx-coroutines-slf4j-1.8.0-intellij.jar",
       "lib/lib.jar",
       "lib/externalProcess-rt.jar",
       "lib/groovy.jar",
@@ -241,6 +242,7 @@ class ProductInfoClassResolverTest {
       "lib/protobuf.jar",
       "lib/intellij-test-discovery.jar",
       "lib/forms_rt.jar",
+      "lib/kotlinx-coroutines-slf4j-1.8.0-intellij.jar",
       "lib/lib.jar",
       "lib/externalProcess-rt.jar",
       "lib/groovy.jar",
@@ -304,6 +306,96 @@ class ProductInfoClassResolverTest {
         }
       ]        
     } 
+  """.trimIndent()
+
+  @Language("JSON")
+  private val productInfoJsonWithBootClassPathAndASingleLayoutComponent = """
+    {
+      "name": "IntelliJ IDEA",
+      "version": "2025.1",
+      "buildNumber": "251.23774.435",
+      "productCode": "IU",
+      "envVarBaseName": "IDEA",
+      "dataDirectoryName": "IntelliJIdea2025.1",
+      "svgIconPath": "bin/idea.svg",
+      "productVendor": "JetBrains",
+      "launch": [
+        {
+          "os": "Linux",
+          "arch": "amd64",
+          "launcherPath": "bin/idea",
+          "javaExecutablePath": "jbr/bin/java",
+          "vmOptionsFilePath": "bin/idea64.vmoptions",
+          "startupWmClass": "jetbrains-idea",
+          "bootClassPathJarNames": [
+            "platform-loader.jar",
+            "util-8.jar",
+            "util.jar",
+            "app-client.jar",
+            "util_rt.jar",
+            "product.jar",
+            "lib-client.jar",
+            "trove.jar",
+            "app.jar",
+            "opentelemetry.jar",
+            "jps-model.jar",
+            "stats.jar",
+            "rd.jar",
+            "external-system-rt.jar",
+            "protobuf.jar",
+            "bouncy-castle.jar",
+            "intellij-test-discovery.jar",
+            "forms_rt.jar",
+            "lib.jar",
+            "externalProcess-rt.jar",
+            "groovy.jar",
+            "annotations.jar",
+            "idea_rt.jar",
+            "jsch-agent.jar",
+            "kotlinx-coroutines-slf4j-1.8.0-intellij.jar",
+            "product-client.jar"
+          ]
+        }
+      ],
+      "bundledPlugins": [],
+      "modules": [],
+      "layout": [
+        {
+          "name": "com.intellij",
+          "kind": "plugin",
+          "classPath": [
+            "lib/platform-loader.jar",
+            "lib/util-8.jar",
+            "lib/util.jar",
+            "lib/app-client.jar",
+            "lib/util_rt.jar",
+            "lib/product.jar",
+            "lib/lib-client.jar",
+            "lib/trove.jar",
+            "lib/app.jar",
+            "lib/opentelemetry.jar",
+            "lib/jps-model.jar",
+            "lib/stats.jar",
+            "lib/rd.jar",
+            "lib/external-system-rt.jar",
+            "lib/protobuf.jar",
+            "lib/bouncy-castle.jar",
+            "lib/nio-fs.jar",
+            "lib/intellij-test-discovery.jar",
+            "lib/forms_rt.jar",
+            "lib/lib.jar",
+            "lib/externalProcess-rt.jar",
+            "lib/groovy.jar",
+            "lib/annotations.jar",
+            "lib/idea_rt.jar",
+            "lib/jsch-agent.jar",
+            "lib/kotlinx-coroutines-slf4j-1.8.0-intellij.jar",
+            "lib/product-client.jar",
+            "lib/testFramework.jar"
+          ]
+        }
+      ]
+    }    
   """.trimIndent()
 }
 


### PR DESCRIPTION
Product Info `bootClassPathJarNames` often share entries with `com.intellij` plugin layout component. 

When creating `Resolver`s, try to reuse an existing resolver for a particular JAR, if that already exists.

For example:

```json
"bootClassPathJarNames" : [
  "platform-loader.jar",
  "util-8.jar",
]
```

Some entries are shared with:

```json
{
  "name": "com.intellij",
  "kind": "plugin",
  "classPath": [
    "lib/platform-loader.jar",
    "lib/util-8.jar"
  ]
}
```