### PR TITLE
Introduce reopenable filesystems

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/fs/FileSystems.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/fs/FileSystems.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base.fs
+
+import java.nio.file.FileSystem
+
+val FileSystem.isClosed: Boolean
+  get() = !isOpen

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -96,6 +96,8 @@ class FsHandlerFileSystemProvider(val delegateProvider: FileSystemProvider) : Fi
   override fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Unit =
     delegateProvider.setAttribute(path.unwrapped, attribute, value, *options)
 
+  private fun FsHandlerPath.reopen() = fileSystem.getPath(delegatePath.toString())
+
   private val Path.unwrapped: Path
     get() = if (this is FsHandlerPath) {
       if (delegatePath.fileSystem.isClosed) {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.fs
 
 import com.jetbrains.plugin.structure.base.fs.isClosed
 import com.jetbrains.plugin.structure.jar.FsHandleFileSystem
+import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import java.net.URI
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.AccessMode
@@ -21,14 +22,19 @@ import java.nio.file.attribute.FileAttribute
 import java.nio.file.attribute.FileAttributeView
 import java.nio.file.spi.FileSystemProvider
 
-class FsHandlerFileSystemProvider(val delegateProvider: FileSystemProvider) : FileSystemProvider() {
+class FsHandlerFileSystemProvider(
+  val delegateProvider: FileSystemProvider,
+  private val delegateJarFileSystemProvider: JarFileSystemProvider
+) : FileSystemProvider() {
   override fun getScheme(): String? = delegateProvider.scheme
 
   override fun newFileSystem(uri: URI, env: Map<String, *>): FileSystem =
-    FsHandleFileSystem(delegateProvider.newFileSystem(uri, env))
+    FsHandleFileSystem(delegateProvider.newFileSystem(uri, env), delegateJarFileSystemProvider)
 
   override fun getFileSystem(uri: URI): FsHandleFileSystem = FsHandleFileSystem(
-    delegateProvider.getFileSystem(uri))
+    delegateProvider.getFileSystem(uri),
+    delegateJarFileSystemProvider
+  )
 
   override fun getPath(uri: URI): Path {
     val fs = getFileSystem(uri)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -63,9 +63,9 @@ class FsHandlerFileSystemProvider(val delegateProvider: FileSystemProvider) : Fi
 
   override fun isSameFile(path: Path, path2: Path): Boolean {
     return if (path is FsHandlerPath && path2 is FsHandlerPath) {
-      path.delegatePath.fileSystem.provider().isSameFile(path, path2)
+      path.delegatePath.fileSystem.provider().isSameFile(path.delegatePath, path2.delegatePath)
     } else {
-      delegateProvider.isSameFile(path, path2)
+      delegateProvider.isSameFile(path.unwrapped, path2.unwrapped)
     }
   }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -29,18 +29,19 @@ class FsHandlerFileSystemProvider(
   override fun getScheme(): String? = delegateProvider.scheme
 
   override fun newFileSystem(uri: URI, env: Map<String, *>): FileSystem =
-    FsHandleFileSystem(delegateProvider.newFileSystem(uri, env), delegateJarFileSystemProvider)
+    FsHandleFileSystem(
+      delegateProvider.newFileSystem(uri, env),
+      delegateJarFileSystemProvider,
+      uri.toPath()
+    )
 
   override fun getFileSystem(uri: URI): FsHandleFileSystem = FsHandleFileSystem(
     delegateProvider.getFileSystem(uri),
-    delegateJarFileSystemProvider
+    delegateJarFileSystemProvider,
+    uri.toPath()
   )
 
-  override fun getPath(uri: URI): Path {
-    val fs = getFileSystem(uri)
-    val path = delegateProvider.getPath(uri)
-    return FsHandlerPath(fs, path)
-  }
+  override fun getPath(uri: URI): Path = FsHandlerPath(getFileSystem(uri), uri.toPath())
 
   override fun newByteChannel(
     path: Path,
@@ -101,6 +102,10 @@ class FsHandlerFileSystemProvider(
 
   override fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Unit =
     delegateProvider.setAttribute(path.unwrapped, attribute, value, *options)
+
+  private fun URI.toPath(): Path {
+    return delegateProvider.getPath(this)
+  }
 
   private fun FsHandlerPath.reopen() = fileSystem.getPath(delegatePath.toString())
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.fs
+
+import com.jetbrains.plugin.structure.base.fs.isClosed
+import com.jetbrains.plugin.structure.jar.FsHandleFileSystem
+import java.net.URI
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.AccessMode
+import java.nio.file.CopyOption
+import java.nio.file.DirectoryStream
+import java.nio.file.FileStore
+import java.nio.file.FileSystem
+import java.nio.file.LinkOption
+import java.nio.file.OpenOption
+import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileAttribute
+import java.nio.file.attribute.FileAttributeView
+import java.nio.file.spi.FileSystemProvider
+
+class FsHandlerFileSystemProvider(val delegateProvider: FileSystemProvider) : FileSystemProvider() {
+  override fun getScheme(): String? = delegateProvider.scheme
+
+  override fun newFileSystem(uri: URI, env: Map<String, *>): FileSystem =
+    FsHandleFileSystem(delegateProvider.newFileSystem(uri, env))
+
+  override fun getFileSystem(uri: URI): FsHandleFileSystem = FsHandleFileSystem(
+    delegateProvider.getFileSystem(uri))
+
+  override fun getPath(uri: URI): Path {
+    val fs = getFileSystem(uri)
+    val path = delegateProvider.getPath(uri)
+    return FsHandlerPath(fs, path)
+  }
+
+  override fun newByteChannel(
+    path: Path,
+    options: Set<OpenOption>,
+    vararg attrs: FileAttribute<*>
+  ): SeekableByteChannel = delegateProvider.newByteChannel(path.unwrapped, options, *attrs)
+
+  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> =
+    delegateProvider.newDirectoryStream(dir.unwrapped, filter)
+
+  override fun createDirectory(dir: Path, vararg attrs: FileAttribute<*>?) {
+    delegateProvider.createDirectory(dir.unwrapped, *attrs)
+  }
+
+  override fun delete(path: Path) {
+    delegateProvider.delete(path.unwrapped)
+  }
+
+  override fun copy(source: Path, target: Path, vararg options: CopyOption) {
+    delegateProvider.copy(source.unwrapped, target.unwrapped, *options)
+  }
+
+  override fun move(source: Path, target: Path, vararg options: CopyOption) {
+    delegateProvider.move(source.unwrapped, target.unwrapped, *options)
+  }
+
+  override fun isSameFile(path: Path, path2: Path): Boolean {
+    return if (path is FsHandlerPath && path2 is FsHandlerPath) {
+      path.delegatePath.fileSystem.provider().isSameFile(path, path2)
+    } else {
+      delegateProvider.isSameFile(path, path2)
+    }
+  }
+
+  override fun isHidden(path: Path) = delegateProvider.isHidden(path.unwrapped)
+
+  override fun getFileStore(path: Path): FileStore = delegateProvider.getFileStore(path.unwrapped)
+
+  override fun checkAccess(path: Path, vararg modes: AccessMode) = delegateProvider.checkAccess(path.unwrapped, *modes)
+
+  override fun <V : FileAttributeView?> getFileAttributeView(
+    path: Path,
+    type: Class<V>,
+    vararg options: LinkOption
+  ): V? = delegateProvider.getFileAttributeView(path.unwrapped, type, *options)
+
+  override fun <A : BasicFileAttributes> readAttributes(
+    path: Path,
+    type: Class<A>,
+    vararg options: LinkOption
+  ): A = delegateProvider.readAttributes(path.unwrapped, type, *options)
+
+  override fun readAttributes(
+    path: Path,
+    attributes: String,
+    vararg options: LinkOption
+  ): Map<String, Any> = delegateProvider.readAttributes(path.unwrapped, attributes, *options)
+
+  override fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Unit =
+    delegateProvider.setAttribute(path.unwrapped, attribute, value, *options)
+
+  private val Path.unwrapped: Path
+    get() = if (this is FsHandlerPath) {
+      if (delegatePath.fileSystem.isClosed) {
+        reopen().unwrapped
+      } else {
+        delegatePath
+      }
+    } else {
+      this
+    }
+}

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.fs
+
+import com.jetbrains.plugin.structure.jar.FsHandleFileSystem
+import java.net.URI
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+
+class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) : Path {
+  override fun getFileSystem() = fs
+
+  override fun isAbsolute() = delegatePath.isAbsolute
+
+  override fun getRoot() = delegatePath.root.wrap()
+
+  override fun getFileName() = delegatePath.fileName.wrap()
+
+  override fun getParent() = delegatePath.parent.wrap()
+
+  override fun getNameCount() = delegatePath.nameCount
+
+  override fun getName(index: Int) = delegatePath.getName(index).wrapNotNull()
+
+  override fun subpath(beginIndex: Int, endIndex: Int) = delegatePath.subpath(beginIndex, endIndex).wrapNotNull()
+
+  override fun startsWith(other: Path) = delegatePath.startsWith(other.unwrap())
+
+  override fun endsWith(other: Path) = delegatePath.endsWith(other.unwrap())
+
+  override fun normalize() = delegatePath.normalize().wrapNotNull()
+
+  override fun resolve(other: Path) = delegatePath.resolve(other.unwrap()).wrapNotNull()
+
+  override fun relativize(other: Path) = delegatePath.relativize(other.unwrap()).wrapNotNull()
+
+  override fun toUri(): URI = delegatePath.toUri()
+
+  override fun toAbsolutePath() = delegatePath.toAbsolutePath().wrapNotNull()
+
+  override fun toRealPath(vararg options: LinkOption): FsHandlerPath = delegatePath.toRealPath(*options).wrapNotNull()
+
+  override fun register(watcher: WatchService,
+    events: Array<out WatchEvent.Kind<*>>?,
+    vararg modifiers: WatchEvent.Modifier?
+  ): WatchKey = delegatePath.register(watcher, events, *modifiers)
+
+  override fun compareTo(other: Path) = delegatePath.compareTo(other)
+
+  private fun Path.wrapNotNull(): FsHandlerPath = FsHandlerPath(fs, this)
+
+  private fun Path?.wrap(): FsHandlerPath? = this?.let {
+    FsHandlerPath(fs, this)
+  }
+
+  private fun Path.unwrap() = (this as? FsHandlerPath)?.delegatePath ?: this
+
+  fun reopen(): Path {
+    return fileSystem.getPath(delegatePath.toString())
+  }
+
+  override fun toString() = delegatePath.toString()
+}

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
@@ -50,16 +50,26 @@ class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) 
     vararg modifiers: WatchEvent.Modifier?
   ): WatchKey = delegatePath.register(watcher, events, *modifiers)
 
-  override fun compareTo(other: Path) = delegatePath.compareTo(other)
+  override fun compareTo(other: Path) = delegatePath.compareTo(other.unwrapped)
 
   private fun Path.wrapNotNull(): FsHandlerPath = FsHandlerPath(fs, this)
 
   private fun Path?.wrap(): FsHandlerPath? = this?.let {
-    FsHandlerPath(fs, this)
+    FsHandlerPath(fs, it)
   }
 
   private val Path.unwrapped: Path
     get() = (this as? FsHandlerPath)?.delegatePath ?: this
 
   override fun toString() = delegatePath.toString()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is Path) return false
+
+    val unwrappedOther = other.unwrapped
+    return delegatePath == unwrappedOther
+  }
+
+  override fun hashCode(): Int = delegatePath.hashCode()
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
@@ -4,16 +4,16 @@
 
 package com.jetbrains.plugin.structure.fs
 
-import com.jetbrains.plugin.structure.jar.FsHandleFileSystem
 import java.net.URI
+import java.nio.file.FileSystem
 import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.WatchEvent
 import java.nio.file.WatchKey
 import java.nio.file.WatchService
 
-class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) : Path {
-  override fun getFileSystem() = fs
+class FsHandlerPath(private val fileSystem: FileSystem, val delegatePath: Path) : Path {
+  override fun getFileSystem(): FileSystem = fileSystem
 
   override fun isAbsolute() = delegatePath.isAbsolute
 
@@ -52,10 +52,10 @@ class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) 
 
   override fun compareTo(other: Path) = delegatePath.compareTo(other.unwrapped)
 
-  private fun Path.wrapNotNull(): FsHandlerPath = FsHandlerPath(fs, this)
+  private fun Path.wrapNotNull(): FsHandlerPath = FsHandlerPath(this@FsHandlerPath.fileSystem, this)
 
   private fun Path?.wrap(): FsHandlerPath? = this?.let {
-    FsHandlerPath(fs, it)
+    FsHandlerPath(this@FsHandlerPath.fileSystem, it)
   }
 
   private val Path.unwrapped: Path

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
@@ -61,9 +61,5 @@ class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) 
   private val Path.unwrapped: Path
     get() = (this as? FsHandlerPath)?.delegatePath ?: this
 
-  fun reopen(): Path {
-    return fileSystem.getPath(delegatePath.toString())
-  }
-
   override fun toString() = delegatePath.toString()
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerPath.kt
@@ -29,15 +29,15 @@ class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) 
 
   override fun subpath(beginIndex: Int, endIndex: Int) = delegatePath.subpath(beginIndex, endIndex).wrapNotNull()
 
-  override fun startsWith(other: Path) = delegatePath.startsWith(other.unwrap())
+  override fun startsWith(other: Path) = delegatePath.startsWith(other.unwrapped)
 
-  override fun endsWith(other: Path) = delegatePath.endsWith(other.unwrap())
+  override fun endsWith(other: Path) = delegatePath.endsWith(other.unwrapped)
 
   override fun normalize() = delegatePath.normalize().wrapNotNull()
 
-  override fun resolve(other: Path) = delegatePath.resolve(other.unwrap()).wrapNotNull()
+  override fun resolve(other: Path) = delegatePath.resolve(other.unwrapped).wrapNotNull()
 
-  override fun relativize(other: Path) = delegatePath.relativize(other.unwrap()).wrapNotNull()
+  override fun relativize(other: Path) = delegatePath.relativize(other.unwrapped).wrapNotNull()
 
   override fun toUri(): URI = delegatePath.toUri()
 
@@ -58,7 +58,8 @@ class FsHandlerPath(private val fs: FsHandleFileSystem, val delegatePath: Path) 
     FsHandlerPath(fs, this)
   }
 
-  private fun Path.unwrap() = (this as? FsHandlerPath)?.delegatePath ?: this
+  private val Path.unwrapped: Path
+    get() = (this as? FsHandlerPath)?.delegatePath ?: this
 
   fun reopen(): Path {
     return fileSystem.getPath(delegatePath.toString())

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -42,7 +42,7 @@ class CachingJarFileSystemProvider(
     val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
       LOG.debug("Creating a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.estimatedSize())
     }
-    return FsHandleFileSystem(jarFs, jarPath)
+    return FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath)
   }
 
   @Synchronized
@@ -69,7 +69,7 @@ class CachingJarFileSystemProvider(
         val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
           LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
         }
-        fs = FsHandleFileSystem(jarFs, jarPath)
+        fs = FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath)
         fsCache.put(key, fs)
         logRecreatedFs(key)
       }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -38,11 +38,11 @@ class CachingJarFileSystemProvider(
 
   val eventLog = EventLog()
 
-  private fun createFsHandle(jarPath: Path, jarUri: URI): FsHandleFileSystem {
+  private fun createFileSystem(jarPath: Path, jarUri: URI): FsHandleFileSystem {
     val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
       LOG.debug("Creating a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.estimatedSize())
     }
-    return FsHandleFileSystem(jarFs)
+    return FsHandleFileSystem(jarFs, jarPath)
   }
 
   @Synchronized
@@ -69,12 +69,12 @@ class CachingJarFileSystemProvider(
         val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
           LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
         }
-        fs = FsHandleFileSystem(jarFs)
+        fs = FsHandleFileSystem(jarFs, jarPath)
         fsCache.put(key, fs)
         logRecreatedFs(key)
       }
     } else {
-      fs = createFsHandle(jarPath, jarUri)
+      fs = createFileSystem(jarPath, jarUri)
       fsCache.put(key, fs)
       logCreatedFs(key)
     }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -63,10 +63,8 @@ class FsHandleFileSystem(
   @Synchronized
   private fun getOrReopenDelegateFileSystem(): FileSystem {
     if (_delegateFileSystem.isClosed) {
-      val reopenedFS = provider.getFileSystem(path)
       LOG.debug("Reopening filesystem delegate for <{}>", path)
-      _delegateFileSystem = reopenedFS
-      return _delegateFileSystem
+      _delegateFileSystem = provider.getFileSystem(path)
     }
     return _delegateFileSystem
   }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -1,5 +1,8 @@
 package com.jetbrains.plugin.structure.jar
 
+import com.jetbrains.plugin.structure.base.fs.isClosed
+import com.jetbrains.plugin.structure.fs.FsHandlerFileSystemProvider
+import com.jetbrains.plugin.structure.fs.FsHandlerPath
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.file.ClosedFileSystemException
@@ -13,11 +16,27 @@ import java.nio.file.spi.FileSystemProvider
 import java.util.concurrent.atomic.AtomicInteger
 
 private val LOG: Logger = LoggerFactory.getLogger(FsHandleFileSystem::class.java)
-class FsHandleFileSystem(val delegate: FileSystem) : FileSystem() {
+class FsHandleFileSystem(val initialDelegateFileSystem: FileSystem, private val path: Path? = null) : FileSystem() {
 
   private var isOpen = true
 
   private val referenceCount = AtomicInteger(1)
+
+  private var _delegateFileSystem = initialDelegateFileSystem
+  val delegateFileSystem: FileSystem
+    get() {
+      if (_delegateFileSystem.isClosed && path != null) {
+        val reopenedFsWrapper = SingletonCachingJarFileSystemProvider.getFileSystem(path)
+        if (reopenedFsWrapper is FsHandleFileSystem) {
+          LOG.debug("Reopening filesystem delegate for <{}>", path)
+          _delegateFileSystem = reopenedFsWrapper.initialDelegateFileSystem
+          return _delegateFileSystem
+        } else {
+          LOG.debug("Filesystem delegate cannot be reopened for <{}>: unsupported type '{}'", path, reopenedFsWrapper.javaClass.simpleName)
+        }
+      }
+      return _delegateFileSystem
+    }
 
   fun increment() {
     referenceCount.incrementAndGet()
@@ -41,42 +60,42 @@ class FsHandleFileSystem(val delegate: FileSystem) : FileSystem() {
 
   fun closeDelegate() {
     try {
-      if (delegate.isOpen) delegate.close()
+      if (delegateFileSystem.isOpen) delegateFileSystem.close()
     } catch (_: InterruptedException) {
       Thread.currentThread().interrupt()
-      LOG.info("Cannot close due to an interruption for [{}]", delegate)
+      LOG.info("Cannot close due to an interruption for [{}]", delegateFileSystem)
     } catch (_: NoSuchFileException) {
-      LOG.debug("Cannot close as the file no longer exists for [{}]", delegate)
+      LOG.debug("Cannot close as the file no longer exists for [{}]", delegateFileSystem)
     } catch (_: java.nio.file.NoSuchFileException) {
-      LOG.debug("Cannot close as the file no longer exists for [{}]", delegate)
+      LOG.debug("Cannot close as the file no longer exists for [{}]", delegateFileSystem)
     } catch (e: Exception) {
-      LOG.error("Unable to close [{}]", delegate, e)
+      LOG.error("Unable to close [{}]", delegateFileSystem, e)
     }
   }
 
-  override fun isOpen(): Boolean = isOpen && delegate.isOpen
+  override fun isOpen(): Boolean = isOpen && delegateFileSystem.isOpen
 
-  override fun isReadOnly(): Boolean = delegate.isReadOnly
+  override fun isReadOnly(): Boolean = delegateFileSystem.isReadOnly
 
-  override fun getSeparator(): String = delegate.separator
+  override fun getSeparator(): String = delegateFileSystem.separator
 
-  override fun getRootDirectories(): Iterable<Path> = delegate.rootDirectories
+  override fun getRootDirectories(): Iterable<Path> = delegateFileSystem.rootDirectories.map { FsHandlerPath(this, it) }
 
-  override fun getFileStores(): Iterable<FileStore> = delegate.fileStores
+  override fun getFileStores(): Iterable<FileStore> = delegateFileSystem.fileStores
 
-  override fun supportedFileAttributeViews(): Set<String> = delegate.supportedFileAttributeViews()
+  override fun supportedFileAttributeViews(): Set<String> = delegateFileSystem.supportedFileAttributeViews()
 
-  override fun getPath(first: String, vararg more: String?): Path = delegate.getPath(first, *more)
+  override fun getPath(first: String, vararg more: String?): Path = FsHandlerPath(this, delegateFileSystem.getPath(first, *more))
 
-  override fun getPathMatcher(syntaxAndPattern: String): PathMatcher = delegate.getPathMatcher(syntaxAndPattern)
+  override fun getPathMatcher(syntaxAndPattern: String): PathMatcher = delegateFileSystem.getPathMatcher(syntaxAndPattern)
 
-  override fun getUserPrincipalLookupService(): UserPrincipalLookupService = delegate.userPrincipalLookupService
+  override fun getUserPrincipalLookupService(): UserPrincipalLookupService = delegateFileSystem.userPrincipalLookupService
 
-  override fun newWatchService(): WatchService = delegate.newWatchService()
+  override fun newWatchService(): WatchService = delegateFileSystem.newWatchService()
 
-  override fun provider(): FileSystemProvider = delegate.provider()
+  override fun provider(): FileSystemProvider = FsHandlerFileSystemProvider(delegateFileSystem.provider())
 
   fun hasSameDelegate(fs: FileSystem): Boolean {
-    return if (fs is FsHandleFileSystem) this.delegate == fs.delegate else false
+    return if (fs is FsHandleFileSystem) this.delegateFileSystem == fs.delegateFileSystem else false
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
 package com.jetbrains.plugin.structure.jar
 
 import com.jetbrains.plugin.structure.base.fs.isClosed
@@ -18,6 +22,23 @@ import java.util.concurrent.atomic.AtomicInteger
 
 private val LOG: Logger = LoggerFactory.getLogger(FsHandleFileSystem::class.java)
 
+/**
+ * Reference counting [FileSystem] wrapper that can reopen closed filesystem.
+ *
+ * When the reference counter reaches zero, the [FsHandleFileSystem.closeDelegate] is called.
+ *
+ * The instance is first initialized with an `initialDelegateFileSystem` as an underlying delegate
+ * for Java NIO [FileSystem] operations.
+ * However, when the underlying [FileSystem] is closed, the [FsHandleFileSystem] will
+ * reopen the instance via `provider` and replace its delegate.
+ *
+ * @param initialDelegateFileSystem an initial low-level Java NIO [FileSystem] to wrap
+ * @param provider a [JarFileSystemProvider] that created this filesystem.
+ * @param path an optional [Path] to the JAR or ZIP managed by this filesystem.
+ *
+ * @see [FsHandlerFileSystemProvider]
+ * @see [FsHandlerPath]
+ */
 class FsHandleFileSystem(
   val initialDelegateFileSystem: FileSystem,
   private val provider: JarFileSystemProvider,

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -34,7 +34,7 @@ private val LOG: Logger = LoggerFactory.getLogger(FsHandleFileSystem::class.java
  *
  * @param initialDelegateFileSystem an initial low-level Java NIO [FileSystem] to wrap
  * @param provider a [JarFileSystemProvider] that created this filesystem.
- * @param path an optional [Path] to the JAR or ZIP managed by this filesystem.
+ * @param path a [Path] to the JAR or ZIP managed by this filesystem.
  *
  * @see [FsHandlerFileSystemProvider]
  * @see [FsHandlerPath]
@@ -42,7 +42,7 @@ private val LOG: Logger = LoggerFactory.getLogger(FsHandleFileSystem::class.java
 class FsHandleFileSystem(
   val initialDelegateFileSystem: FileSystem,
   private val provider: JarFileSystemProvider,
-  private val path: Path? = null
+  private val path: Path
 ) : FileSystem() {
 
   private val isOpen = AtomicBoolean(true)
@@ -62,7 +62,7 @@ class FsHandleFileSystem(
 
   @Synchronized
   private fun getOrReopenDelegateFileSystem(): FileSystem {
-    if (_delegateFileSystem.isClosed && path != null) {
+    if (_delegateFileSystem.isClosed) {
       val reopenedFS = provider.getFileSystem(path)
       LOG.debug("Reopening filesystem delegate for <{}>", path)
       _delegateFileSystem = reopenedFS

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/UriJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/UriJarFileSystemProvider.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.plugin.structure.jar
 
-import com.jetbrains.plugin.structure.base.utils.isJar
-import com.jetbrains.plugin.structure.base.utils.isZip
+import com.jetbrains.plugin.structure.base.utils.extension
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -17,7 +16,7 @@ class UriJarFileSystemProvider(private val pathToUri: (Path) -> URI = { it.toUri
   override fun getFileSystem(jarPath: Path): FileSystem {
     val jarUri = pathToUri(jarPath)
     return try {
-      if (!jarPath.isZip() && !jarPath.isJar()) {
+      if (!jarPath.isZipOrJar()) {
         throw JarArchiveCannotBeOpenException(jarPath, "must end with '.zip' or '.jar'")
       }
       try {
@@ -35,4 +34,6 @@ class UriJarFileSystemProvider(private val pathToUri: (Path) -> URI = { it.toUri
       throw JarArchiveCannotBeOpenException(jarUri, e)
     }
   }
+
+  private fun Path.isZipOrJar() = extension in listOf("zip", "jar")
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/ResourceBundleNameSet.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/ResourceBundleNameSet.kt
@@ -18,4 +18,8 @@ data class ResourceBundleNameSet(internal val bundleNames: Map<String, Set<Strin
   val isEmpty: Boolean get() = bundleNames.isEmpty()
 
   operator fun get(baseName: String): Set<String> = bundleNames.getOrElse(baseName) { emptySet() }
+
+  companion object {
+    val EMPTY = ResourceBundleNameSet(emptyMap())
+  }
 }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/resolvers/SimpleCompositeResolver.kt
@@ -27,9 +27,14 @@ open class SimpleCompositeResolver(
     get() = resolvers.flatMapTo(hashSetOf()) { it.packages }
 
   override val allBundleNameSet: ResourceBundleNameSet
-    get() = resolvers.map {
-      it.allBundleNameSet
-    }.reduce { acc, bundleNames -> acc.merge(bundleNames) }
+    get() {
+      val bundleSets = resolvers.map { it.allBundleNameSet }
+      return if (bundleSets.isEmpty()) {
+        ResourceBundleNameSet.EMPTY
+      } else {
+        bundleSets.reduce { acc, bundleNames -> acc.merge(bundleNames) }
+      }
+    }
 
   @Deprecated("Use 'resolveClass(BinaryClassName)' instead")
   override fun resolveClass(className: String): ResolutionResult<ClassNode> {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/PluginJarTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
 import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
 import com.jetbrains.plugin.structure.jar.PluginJar
 import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.*
@@ -75,7 +76,12 @@ class PluginJarTest(private val fileSystemProvider: JarFileSystemProvider) {
     val jarArchiveException = assertThrows(JarArchiveException::class.java) {
       PluginJar(nonexistentPath, fileSystemProvider)
     }
-    assertThat(jarArchiveException.message, containsString("JAR file cannot be open at [!n0n3xist3nt.jar]"))
+    assertThat(
+      jarArchiveException.message, allOf(
+        containsString("JAR file cannot be open at"),
+        containsString("!n0n3xist3nt.jar")
+      )
+    )
   }
 
   @Test


### PR DESCRIPTION
With `FsHandleFileSystem`, sometimes an underlying filesystem can be closed. This might happen when an low-level implementation, such as `jdk.nio.zipfs.ZipFileSystem` becomes closed.

Introduce `FileSystem`-based implementation that is able to handle this situation. In this case, automatically reopen underlying filesystem without any changes on the client side.

- Introduce `FsHandlerPath` that wraps an arbitrary `Path` and associates it with `FsHandlerFileSystem`. Make this implementation able to reopen itself with a new underlying filesystem.
- Introduce `FsHandlerFileSystemProvider`, an implementation of `java.nio.file.spi.FileSystemProvider` that provides `FsHandlerFileSystem`s and `FsHandlerPath`s.
- Allow the `FsHandleFileSystem` to reopen closed delegated filesystems.

See [MP-7468](https://youtrack.jetbrains.com/issue/MP-7468) 