### PR TITLE
Allow to decompress tar.gz IDE distributions

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/decompress/Decompressor.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/decompress/Decompressor.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.base.decompress
 
+import com.jetbrains.plugin.structure.base.utils.bufferedInputStream
 import com.jetbrains.plugin.structure.base.utils.createDir
 import com.jetbrains.plugin.structure.base.utils.createParentDirs
 import com.jetbrains.plugin.structure.base.utils.inputStream
@@ -122,7 +123,7 @@ internal class TarDecompressor(private val tarFile: Path, sizeLimit: Long?) : De
 
   override fun openStream() {
     stream = try {
-      val compressorStream = CompressorStreamFactory().createCompressorInputStream(tarFile.inputStream())
+      val compressorStream = CompressorStreamFactory().createCompressorInputStream(tarFile.bufferedInputStream())
       TarArchiveInputStream(compressorStream)
     } catch (e: CompressorException) {
       val cause = e.cause

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -51,6 +51,8 @@ fun String.replaceInvalidFileNameCharacters(): String = replace(Regex("[^a-zA-Z0
 
 fun Path.inputStream(): InputStream = Files.newInputStream(this)
 
+fun Path.bufferedInputStream() = Files.newInputStream(this).buffered()
+
 fun Path.outputStream(): OutputStream = Files.newOutputStream(this)
 
 fun Path.writeText(text: String, charset: Charset = Charsets.UTF_8) = this.writeBytes(text.toByteArray(charset))

--- a/intellij-plugin-structure/tests/build.gradle.kts
+++ b/intellij-plugin-structure/tests/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   testImplementation(project(":structure-teamcity-recipes"))
   testImplementation(sharedLibs.junit)
   testImplementation(sharedLibs.jackson.module.kotlin)
+  testImplementation(libs.commons.compress)
   testImplementation(libs.jimfs)
   testImplementation(libs.jackson.yaml)
   testImplementation(libs.semver4j)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/DecompressTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/DecompressTest.kt
@@ -1,0 +1,21 @@
+import com.jetbrains.plugin.structure.base.utils.createMinimalisticTarGz
+import com.jetbrains.plugin.structure.base.utils.extractTo
+import com.jetbrains.plugin.structure.base.utils.newTemporaryFile
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DecompressTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `TAR_GZ is decompressed into a directory`() {
+    val tarGzPath = temporaryFolder.newTemporaryFile("archives/ide.tar.gz")
+    createMinimalisticTarGz(tarGzPath)
+
+    val decompressedIdeFolder = temporaryFolder.newFolder("ide").toPath()
+    tarGzPath.extractTo(decompressedIdeFolder)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/Zips.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/Zips.kt
@@ -1,8 +1,15 @@
 package com.jetbrains.plugin.structure.base.utils
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import java.io.ByteArrayOutputStream
+import java.nio.file.Path
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+
+private const val TAR_GZ_CONTENT_FILE_NAME = "a"
+private const val TAR_GZ_CONTENT_FILE_SIZE = 0
 
 internal fun createZipBufferWithSingleEmptyFile(): ByteArray {
   val byteOut = ByteArrayOutputStream()
@@ -13,4 +20,25 @@ internal fun createZipBufferWithSingleEmptyFile(): ByteArray {
     zipOut.closeEntry()
   }
   return byteOut.toByteArray()
+}
+
+/**
+ * Creates a single-file TAR.GZ.
+ *
+ * The file inside this archive will have a single-character name and no content (0 bytes).
+ */
+internal fun createMinimalisticTarGz(tarGzPath: Path) {
+  val fileContent = ByteArray(TAR_GZ_CONTENT_FILE_SIZE)
+  tarGzPath.outputStream().use { tarGzPathStream ->
+    GzipCompressorOutputStream(tarGzPathStream).use { gzipOut ->
+      TarArchiveOutputStream(gzipOut).use { tarOut ->
+        val entry = TarArchiveEntry(TAR_GZ_CONTENT_FILE_NAME)
+        entry.size = TAR_GZ_CONTENT_FILE_SIZE.toLong()
+
+        tarOut.putArchiveEntry(entry)
+        tarOut.write(fileContent)
+        tarOut.closeArchiveEntry()
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fix [MP-7489](https://youtrack.jetbrains.com/issue/MP-7489) Plugin Verifier: Unable to decompress tar.gz IDE distributions.

`commons-compress` is now an explicit dependency instead being pulled transitively via JPS.
However, decompressing `.tar.gz` now requires buffered `mark()`-able stream.