### PR TITLE
[verifier] shorten the error message printed by 'IntelliJ API Compatibility Check' configurations

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
@@ -284,21 +284,14 @@ class TwoTargetsResultPrinter : TaskResultPrinter {
 
   private val documentationNote: String
     get() = """
-      Please fix the compatibility problem by keeping the old API as deprecated.
-      Only if it is hard to do this, document the change on 'Incompatible Changes in IntelliJ Platform and Plugins API Page' (see the 'API Evolution Guide' available at https://youtrack.jetbrains.com/articles/IJPL-A-123 for more details).      
+      Please try fixing the compatibility problem by keeping the old API as deprecated.
+      The article https://youtrack.jetbrains.com/articles/IJPL-A-307 describes how to keep API compatible for the most
+      common kinds of changes.
+      Only if it's really hard to keep compatibility, document the incompatible change as described in 
+      the 'API Evolution Guide' available at https://youtrack.jetbrains.com/articles/IJPL-A-123.      
       
-      If this incompatible change cannot be reverted, it must be documented on 'Incompatible Changes in IntelliJ Platform and Plugins API Page'.
       If the problem is documented, it will be ignored by Plugin Verifier on the next verification run. Note that TeamCity investigation may not disappear immediately.
       If an investigation is not closed automatically, mark the investigation as "Fixed" manually. 
-      
-      To document the change, do the following:
-      1) Open https://plugins.jetbrains.com/docs/intellij/api-changes-list.html
-      2) Open a page corresponding to the affected release(s), for example 'Changes in 2023.*'
-      3) Click 'Edit Page' (just below page title) to navigate to GitHub.
-      4) Fork the 'intellij-sdk-docs' repository to propose changes. 
-      5) Read the tutorial on how to document breaking changes at the top, which starts with <!-- Before documenting a breaking API change ... --> 
-      6) Add a documenting pattern (the first line) and the change reason (the second line starting with ':'). The pattern must be syntactically correct, see supported patterns at the top.
-      7) Provide a commit message and optionally an extended description. Then, propose changes and subsequently create a pull request with documented changes. 
     """.trimIndent()
 
   private fun createCompatibilityNote(


### PR DESCRIPTION
Documenting the incompatible change should be used as the last resort, and the process is already described in the 'API Evolution Guide', so it's better not to write a detailed instruction in each error message. Also, a link to 'Compatible API Changes Guide' is added.