### PR TITLE
Extract content module resolution to separate classes

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePlugin.kt
@@ -46,6 +46,8 @@ interface IdePlugin : Plugin {
 
   val modulesDescriptors: List<ModuleDescriptor>
 
+  val contentModules: List<Module>
+
   /**
    * Underlying plugin descriptor file parsed and resolved as XML Document.
    */

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginImpl.kt
@@ -85,6 +85,8 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
 
   override val modulesDescriptors: MutableList<ModuleDescriptor> = arrayListOf()
 
+  override val contentModules: MutableList<Module> = arrayListOf()
+
   override var thirdPartyDependencies: List<ThirdPartyDependency> = emptyList()
 
   override fun isCompatibleWithIde(ideVersion: IdeVersion) =
@@ -142,6 +144,7 @@ class IdePluginImpl : IdePlugin, StructurallyValidated {
         icons = old.icons.toMutableList()
         optionalDescriptors.addAll(old.optionalDescriptors)
         modulesDescriptors.addAll(old.modulesDescriptors)
+        contentModules.addAll(old.contentModules)
         thirdPartyDependencies = old.thirdPartyDependencies.toMutableList()
         if (old is StructurallyValidated) {
           problems.addAll(overriddenProblems)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -360,7 +360,7 @@ class IdePluginManager private constructor(
 
   private fun resolveContentModules(pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
     if (currentPlugin.isSuccess) {
-      val contentModules = currentPlugin.contentModules
+      val contentModules = currentPlugin.plugin.contentModules
       for (module in contentModules) {
         when (module) {
           is FileBasedModule -> {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/InvalidPlugin.kt
@@ -40,6 +40,7 @@ class InvalidPlugin(override val underlyingDocument: Document) : IdePlugin, Stru
   override val definedModules: Set<String> = emptySet()
   override val optionalDescriptors: List<OptionalPluginDescriptor> = emptyList()
   override val modulesDescriptors: List<ModuleDescriptor> = emptyList()
+  override val contentModules: List<Module> = emptyList()
   override val originalFile: Path? = null
   override val productDescriptor: ProductDescriptor? = null
   override val declaredThemes: List<IdeTheme> = emptyList()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -151,7 +151,6 @@ internal class PluginCreator private constructor(
   }
 
   val optionalDependenciesConfigFiles: MutableMap<PluginDependency, String> = linkedMapOf()
-  val contentModules = arrayListOf<Module>()
 
   internal val plugin = IdePluginImpl()
 
@@ -601,7 +600,7 @@ internal class PluginCreator private constructor(
 
   private fun validatePlugin(plugin: IdePluginImpl) {
     val dependencies = plugin.dependencies
-    if (!plugin.hasPackagePrefix && contentModules.isEmpty()) {
+    if (!plugin.hasPackagePrefix && plugin.contentModules.isEmpty()) {
       if (dependencies.isEmpty()) {
         registerProblem(NoDependencies(descriptorPath))
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -4,33 +4,23 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin.loaders
 
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
-import com.jetbrains.plugin.structure.base.utils.isJar
-import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
-import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
-import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
-import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
 import com.jetbrains.plugin.structure.intellij.plugin.module.FileBasedModuleDescriptorResolver
 import com.jetbrains.plugin.structure.intellij.plugin.module.InlineModuleDescriptorResolver
 import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
-import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.IOException
-import java.net.URI
 import java.nio.file.Path
 
 private val LOG: Logger = LoggerFactory.getLogger(ContentModuleLoader::class.java)
 
-class ContentModuleLoader internal constructor(private val pluginLoader: PluginLoader) {
-  private val fileBasedModuleDescriptorResolver = FileBasedModuleDescriptorResolver()
+class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
+  private val fileBasedModuleDescriptorResolver = FileBasedModuleDescriptorResolver(pluginLoader)
   private val inlineModuleDescriptorResolver = InlineModuleDescriptorResolver()
 
   internal fun resolveContentModules(pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
@@ -53,72 +43,10 @@ class ContentModuleLoader internal constructor(private val pluginLoader: PluginL
   }
 
   private fun resolveFileBasedModule(module: FileBasedModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
-    val configFile = module.configFile
-    val moduleCreator = pluginLoader.load(
-      pluginFile,
-      configFile,
-      false,
-      resourceResolver,
-      currentPlugin,
-      problemResolver
-    )
-    fileBasedModuleDescriptorResolver.add(pluginFile, currentPlugin, module, moduleCreator)
+    fileBasedModuleDescriptorResolver.resolve(pluginFile, currentPlugin, module, resourceResolver, problemResolver)
   }
 
   private fun resolveInlineModule(module: InlineModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver) {
-    val moduleDescriptorResource = getDescriptorResource(module, pluginFile, currentPlugin.descriptorPath)
-    val moduleCreator =
-      loadModuleFromDescriptorResource(module.name, moduleDescriptorResource, currentPlugin, resourceResolver)
-    inlineModuleDescriptorResolver.add(pluginFile, currentPlugin, module, moduleCreator)
-  }
-
-  private fun getDescriptorResource(module: InlineModule, pluginFile: Path, descriptorPath: String): DescriptorResource {
-    // TODO descriptor path is not relative to the pluginFile JAR. See MP-7224
-    val parentUriStr = if (pluginFile.isJar()) {
-      "jar:" + pluginFile.toUri().toString() + "!" + descriptorPath.toSystemIndependentName()
-    } else {
-      pluginFile.toUri().toString() + "/" + descriptorPath.toSystemIndependentName()
-    }
-    val uriStr = parentUriStr + "#modules/" + module.name
-    return DescriptorResource(module.textContent.byteInputStream(), URI(uriStr), URI(parentUriStr))
-  }
-
-  private fun loadModuleFromDescriptorResource(
-    moduleId: String,
-    descriptorResource: DescriptorResource,
-    parentPlugin: PluginCreator? = null,
-    resourceResolver: ResourceResolver
-  ): PluginCreator {
-    return descriptorResource.inputStream.use {
-      try {
-        val problemResolver = AnyProblemToWarningPluginCreationResultResolver
-        val descriptorXml = JDOMUtil.loadDocument(it)
-        createPlugin(
-          descriptorResource,
-          parentPlugin,
-          descriptorXml,
-          resourceResolver,
-          problemResolver
-        ).also { creator ->
-          logPluginCreationWarnings(moduleId, creator)
-        }
-      } catch (e: IOException) {
-        with(descriptorResource) {
-          LOG.warn("Unable to read descriptor stream (source: '$uri')", e)
-          val problem = UnableToReadDescriptor(fileName, e.localizedMessage)
-          createInvalidPlugin(artifactFileName, fileName, problem)
-        }
-      }
-    }
-  }
-
-  private fun logPluginCreationWarnings(pluginId: String, pluginCreator: PluginCreator) {
-    val pluginCreationResult = pluginCreator.pluginCreationResult
-    if (LOG.isDebugEnabled && pluginCreationResult is PluginCreationSuccess) {
-      val warningMessage = pluginCreationResult.warnings.joinToString("\n") {
-        it.message
-      }
-      LOG.debug("Plugin or module '$pluginId' has plugin problems: $warningMessage")
-    }
+    inlineModuleDescriptorResolver.resolve(pluginFile, currentPlugin, module, resourceResolver, AnyProblemToWarningPluginCreationResultResolver)
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -11,11 +11,11 @@ import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
-import com.jetbrains.plugin.structure.intellij.plugin.module.AbstractModuleDescriptorResolver.ResolutionResult
-import com.jetbrains.plugin.structure.intellij.plugin.module.AbstractModuleDescriptorResolver.ResolutionResult.Failed
-import com.jetbrains.plugin.structure.intellij.plugin.module.AbstractModuleDescriptorResolver.ResolutionResult.Found
 import com.jetbrains.plugin.structure.intellij.plugin.module.FileBasedModuleDescriptorResolver
 import com.jetbrains.plugin.structure.intellij.plugin.module.InlineModuleDescriptorResolver
+import com.jetbrains.plugin.structure.intellij.plugin.module.ModuleDescriptorResolver.ResolutionResult
+import com.jetbrains.plugin.structure.intellij.plugin.module.ModuleDescriptorResolver.ResolutionResult.Failed
+import com.jetbrains.plugin.structure.intellij.plugin.module.ModuleDescriptorResolver.ResolutionResult.Found
 import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -43,10 +43,10 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
   }
 
   private fun resolveFileBasedModule(module: FileBasedModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
-    fileBasedModuleDescriptorResolver.resolve(pluginFile, currentPlugin, module, resourceResolver, problemResolver)
+    fileBasedModuleDescriptorResolver.resolveDescriptor(pluginFile, currentPlugin, module, resourceResolver, problemResolver)
   }
 
   private fun resolveInlineModule(module: InlineModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver) {
-    inlineModuleDescriptorResolver.resolve(pluginFile, currentPlugin, module, resourceResolver, AnyProblemToWarningPluginCreationResultResolver)
+    inlineModuleDescriptorResolver.resolveDescriptor(pluginFile, currentPlugin, module, resourceResolver, AnyProblemToWarningPluginCreationResultResolver)
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -5,6 +5,7 @@
 package com.jetbrains.plugin.structure.intellij.plugin.loaders
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.Module
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
@@ -18,11 +19,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.module.InlineModuleDescrip
 import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.nio.file.Path
-
-private val LOG: Logger = LoggerFactory.getLogger(ContentModuleLoader::class.java)
 
 class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
   private val fileBasedModuleDescriptorResolver = FileBasedModuleDescriptorResolver(pluginLoader)
@@ -36,24 +33,40 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
   ) {
     if (currentPlugin.isSuccess) {
       val contentModules = currentPlugin.plugin.contentModules
-      contentModules.map { module ->
-        when (module) {
-          is FileBasedModule -> resolveFileBasedModule(
-            module,
-            pluginFile,
-            currentPlugin,
-            resourceResolver,
-            problemResolver
-          )
+      contentModules
+        .map { resolveContentModule(it, pluginFile, currentPlugin, resourceResolver, problemResolver) }
+        .map {
+          when (it) {
+            is Found -> currentPlugin.addModuleDescriptor(it.resolvedContentModule, it.moduleDescriptor)
+            is Failed -> currentPlugin.registerProblem(it.error)
+          }
+        }
+    }
+  }
 
-          is InlineModule -> resolveInlineModule(module, pluginFile, currentPlugin, resourceResolver)
-        }
-      }.map { resolution ->
-        when (resolution) {
-          is Found -> currentPlugin.addModuleDescriptor(resolution.resolvedContentModule, resolution.moduleDescriptor)
-          is Failed -> currentPlugin.registerProblem(resolution.error)
-        }
-      }
+  private fun resolveContentModule(
+    moduleReference: Module,
+    pluginFile: Path,
+    currentPlugin: PluginCreator,
+    resourceResolver: ResourceResolver,
+    problemResolver: PluginCreationResultResolver
+  ): ResolutionResult {
+    return when (moduleReference) {
+      is FileBasedModule -> fileBasedModuleDescriptorResolver.resolveDescriptor(
+        pluginFile,
+        currentPlugin,
+        moduleReference,
+        resourceResolver,
+        problemResolver
+      )
+
+      is InlineModule -> inlineModuleDescriptorResolver.resolveDescriptor(
+        pluginFile,
+        currentPlugin,
+        moduleReference,
+        resourceResolver,
+        AnyProblemToWarningPluginCreationResultResolver
+      )
     }
   }
 
@@ -62,36 +75,5 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
     plugin.definedModules.add(moduleDescriptor.name)
 
     mergeContent(resolvedContentModule)
-  }
-
-  private fun resolveFileBasedModule(
-    module: FileBasedModule,
-    pluginFile: Path,
-    currentPlugin: PluginCreator,
-    resourceResolver: ResourceResolver,
-    problemResolver: PluginCreationResultResolver
-  ): ResolutionResult {
-    return fileBasedModuleDescriptorResolver.resolveDescriptor(
-      pluginFile,
-      currentPlugin,
-      module,
-      resourceResolver,
-      problemResolver
-    )
-  }
-
-  private fun resolveInlineModule(
-    module: InlineModule,
-    pluginFile: Path,
-    currentPlugin: PluginCreator,
-    resourceResolver: ResourceResolver
-  ): ResolutionResult {
-    return inlineModuleDescriptorResolver.resolveDescriptor(
-      pluginFile,
-      currentPlugin,
-      module,
-      resourceResolver,
-      AnyProblemToWarningPluginCreationResultResolver
-    )
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -27,18 +27,18 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
 
   internal fun resolveContentModules(
     pluginFile: Path,
-    currentPlugin: PluginCreator,
+    contentModulesOwner: PluginCreator,
     resourceResolver: ResourceResolver,
     problemResolver: PluginCreationResultResolver
   ) {
-    if (currentPlugin.isSuccess) {
-      val contentModules = currentPlugin.plugin.contentModules
+    if (contentModulesOwner.isSuccess) {
+      val contentModules = contentModulesOwner.plugin.contentModules
       contentModules
-        .map { resolveContentModule(it, pluginFile, currentPlugin, resourceResolver, problemResolver) }
+        .map { resolveContentModule(it, pluginFile, contentModulesOwner, resourceResolver, problemResolver) }
         .map {
           when (it) {
-            is Found -> currentPlugin.addModuleDescriptor(it.resolvedContentModule, it.moduleDescriptor)
-            is Failed -> currentPlugin.registerProblem(it.error)
+            is Found -> contentModulesOwner.addModuleDescriptor(it.resolvedContentModule, it.moduleDescriptor)
+            is Failed -> contentModulesOwner.registerProblem(it.error)
           }
         }
     }
@@ -47,14 +47,14 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
   private fun resolveContentModule(
     moduleReference: Module,
     pluginFile: Path,
-    currentPlugin: PluginCreator,
+    contentModulesOwner: PluginCreator,
     resourceResolver: ResourceResolver,
     problemResolver: PluginCreationResultResolver
   ): ResolutionResult {
     return when (moduleReference) {
       is FileBasedModule -> fileBasedModuleDescriptorResolver.resolveDescriptor(
         pluginFile,
-        currentPlugin,
+        contentModulesOwner,
         moduleReference,
         resourceResolver,
         problemResolver
@@ -62,7 +62,7 @@ class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
 
       is InlineModule -> inlineModuleDescriptorResolver.resolveDescriptor(
         pluginFile,
-        currentPlugin,
+        contentModulesOwner,
         moduleReference,
         resourceResolver,
         AnyProblemToWarningPluginCreationResultResolver

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -4,18 +4,30 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin.loaders
 
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
 import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.plugin.InlineDeclaredModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
 import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorProblem
+import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
@@ -67,6 +79,87 @@ class ContentModuleLoader internal constructor(private val pluginLoader: PluginL
     currentPlugin.addModuleDescriptor(module, module.loadingRule, moduleDescriptorResource, moduleCreator)
   }
 
+  internal fun PluginCreator.addModuleDescriptor(
+    moduleName: String,
+    loadingRule: ModuleLoadingRule,
+    configurationFile: String,
+    moduleCreator: PluginCreator
+  ) {
+    val pluginCreationResult = moduleCreator.pluginCreationResult
+    if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
+      val module = pluginCreationResult.plugin
+
+      plugin.addDependencies(module, loadingRule)
+      plugin.modulesDescriptors.add(
+        ModuleDescriptor(
+          moduleName,
+          loadingRule,
+          module.dependencies,
+          module,
+          configurationFile
+        )
+      )
+      plugin.definedModules.add(moduleName)
+
+      mergeContent(module)
+    } else {
+      registerProblem(ModuleDescriptorResolutionProblem(moduleName, configurationFile, pluginCreationResult.errors))
+    }
+  }
+
+  internal fun PluginCreator.addModuleDescriptor(
+    inlineModuleReference: InlineModule,
+    loadingRule: ModuleLoadingRule,
+    moduleDescriptorResource: DescriptorResource,
+    moduleCreator: PluginCreator
+  ) {
+    val pluginCreationResult = moduleCreator.pluginCreationResult
+    if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
+      val moduleName = inlineModuleReference.name
+      val inlineModule = pluginCreationResult.plugin
+
+      plugin.addInlineModuleDependencies(inlineModuleReference, inlineModule, loadingRule)
+      plugin.modulesDescriptors.add(
+        ModuleDescriptor.of(
+          moduleName,
+          loadingRule,
+          inlineModule,
+          moduleDescriptorResource
+        )
+      )
+      plugin.definedModules.add(moduleName)
+
+      mergeContent(inlineModule)
+    } else {
+      registerProblem(ModuleDescriptorProblem(inlineModuleReference, pluginCreationResult.errors))
+    }
+  }
+
+  private fun IdePluginImpl.addDependencies(module: IdePlugin, loadingRule: ModuleLoadingRule) {
+    module.forEachDependencyNotIn(this) {
+      val dependency = if (loadingRule.required) it else it.asOptional()
+      dependencies += dependency
+    }
+  }
+
+  private fun IdePluginImpl.addInlineModuleDependencies(
+    inlineModuleReference: InlineModule,
+    module: IdePlugin,
+    loadingRule: ModuleLoadingRule
+  ) {
+    module.forEachDependencyNotIn(this) {
+      dependencies += InlineDeclaredModuleV2Dependency.of(it.id, loadingRule, contentModuleOwner = this, inlineModuleReference)
+    }
+  }
+
+
+  private fun IdePlugin.forEachDependencyNotIn(plugin: IdePlugin, dependencyHandler: (PluginDependency) -> Unit) {
+    return dependencies
+      .filter { dependency -> plugin.dependencies.none { it.id == dependency.id } }
+      .forEach { dependencyHandler(it) }
+  }
+
+
   private fun getDescriptorResource(module: InlineModule, pluginFile: Path, descriptorPath: String): DescriptorResource {
     // TODO descriptor path is not relative to the pluginFile JAR. See MP-7224
     val parentUriStr = if (pluginFile.isJar()) {
@@ -94,8 +187,8 @@ class ContentModuleLoader internal constructor(private val pluginLoader: PluginL
           descriptorXml,
           resourceResolver,
           problemResolver
-        ).also {
-          logPluginCreationWarnings(moduleId, it)
+        ).also { creator ->
+          logPluginCreationWarnings(moduleId, creator)
         }
       } catch (e: IOException) {
         with(descriptorResource) {
@@ -117,4 +210,9 @@ class ContentModuleLoader internal constructor(private val pluginLoader: PluginL
     }
   }
 
+  private val PluginCreationResult<IdePlugin>.errors: List<PluginProblem>
+    get() = when (this) {
+      is PluginCreationSuccess -> emptyList()
+      is PluginCreationFail -> this.errorsAndWarnings.filter { it.level === ERROR }
+    }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
+import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
+import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.net.URI
+import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(ContentModuleLoader::class.java)
+
+class ContentModuleLoader internal constructor(private val pluginLoader: PluginLoader) {
+  internal fun resolveContentModules(pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
+    if (currentPlugin.isSuccess) {
+      val contentModules = currentPlugin.plugin.contentModules
+      for (module in contentModules) {
+        when (module) {
+          is FileBasedModule -> resolveFileBasedModule(
+            module,
+            pluginFile,
+            currentPlugin,
+            resourceResolver,
+            problemResolver
+          )
+
+          is InlineModule -> resolveInlineModule(module, pluginFile, currentPlugin, resourceResolver)
+        }
+      }
+    }
+  }
+
+  private fun resolveFileBasedModule(module: FileBasedModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
+    val configFile = module.configFile
+    val moduleCreator = pluginLoader.load(
+      pluginFile,
+      configFile,
+      false,
+      resourceResolver,
+      currentPlugin,
+      problemResolver
+    )
+    currentPlugin.addModuleDescriptor(module.name, module.loadingRule, configFile, moduleCreator)
+  }
+
+  private fun resolveInlineModule(module: InlineModule, pluginFile: Path, currentPlugin: PluginCreator, resourceResolver: ResourceResolver) {
+    val moduleDescriptorResource = getDescriptorResource(module, pluginFile, currentPlugin.descriptorPath)
+    val moduleCreator =
+      loadModuleFromDescriptorResource(module.name, moduleDescriptorResource, currentPlugin, resourceResolver)
+    currentPlugin.addModuleDescriptor(module, module.loadingRule, moduleDescriptorResource, moduleCreator)
+  }
+
+  private fun getDescriptorResource(module: InlineModule, pluginFile: Path, descriptorPath: String): DescriptorResource {
+    // TODO descriptor path is not relative to the pluginFile JAR. See MP-7224
+    val parentUriStr = if (pluginFile.isJar()) {
+      "jar:" + pluginFile.toUri().toString() + "!" + descriptorPath.toSystemIndependentName()
+    } else {
+      pluginFile.toUri().toString() + "/" + descriptorPath.toSystemIndependentName()
+    }
+    val uriStr = parentUriStr + "#modules/" + module.name
+    return DescriptorResource(module.textContent.byteInputStream(), URI(uriStr), URI(parentUriStr))
+  }
+
+  private fun loadModuleFromDescriptorResource(
+    moduleId: String,
+    descriptorResource: DescriptorResource,
+    parentPlugin: PluginCreator? = null,
+    resourceResolver: ResourceResolver
+  ): PluginCreator {
+    return descriptorResource.inputStream.use {
+      try {
+        val problemResolver = AnyProblemToWarningPluginCreationResultResolver
+        val descriptorXml = JDOMUtil.loadDocument(it)
+        createPlugin(
+          descriptorResource,
+          parentPlugin,
+          descriptorXml,
+          resourceResolver,
+          problemResolver
+        ).also {
+          logPluginCreationWarnings(moduleId, it)
+        }
+      } catch (e: IOException) {
+        with(descriptorResource) {
+          LOG.warn("Unable to read descriptor stream (source: '$uri')", e)
+          val problem = UnableToReadDescriptor(fileName, e.localizedMessage)
+          createInvalidPlugin(artifactFileName, fileName, problem)
+        }
+      }
+    }
+  }
+
+  private fun logPluginCreationWarnings(pluginId: String, pluginCreator: PluginCreator) {
+    val pluginCreationResult = pluginCreator.pluginCreationResult
+    if (LOG.isDebugEnabled && pluginCreationResult is PluginCreationSuccess) {
+      val warningMessage = pluginCreationResult.warnings.joinToString("\n") {
+        it.message
+      }
+      LOG.debug("Plugin or module '$pluginId' has plugin problems: $warningMessage")
+    }
+  }
+
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -46,15 +46,14 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
   ): ResolutionResult {
     val moduleCreator = getModuleCreator(moduleReference, pluginArtifactPath, pluginCreator, resourceResolver, problemResolver)
     val pluginCreationResult = moduleCreator.pluginCreationResult
-    if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
+    return if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
       val resolvedContentModule = pluginCreationResult.plugin
       val moduleDescriptor = getModuleDescriptor(pluginArtifactPath, pluginCreator, resolvedContentModule, moduleCreator, moduleReference)
-      return ResolutionResult.Found(resolvedContentModule, moduleDescriptor)
+      ResolutionResult.Found(resolvedContentModule, moduleDescriptor)
     } else {
-      return ResolutionResult.Failed(getProblem(moduleReference, pluginCreationResult.errors))
+      ResolutionResult.Failed(getProblem(moduleReference, pluginCreationResult.errors))
     }
   }
-
 
   abstract fun getProblem(moduleReference: M, errors: List<PluginProblem>): PluginProblem
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -11,11 +11,8 @@ import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
-import com.jetbrains.plugin.structure.intellij.plugin.InlineDeclaredModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.Module
-import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
-import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
@@ -65,20 +62,7 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
     moduleReference: M
   ): ModuleDescriptor
 
-  protected fun IdePluginImpl.addDependencies(module: IdePlugin, loadingRule: ModuleLoadingRule) {
-    module.forEachDependencyNotIn(this) {
-      val dependency = if (loadingRule.required) it else it.asOptional()
-      dependencies += dependency
-    }
-  }
-
-  protected fun IdePluginImpl.addInlineModuleDependencies(
-    inlineModuleReference: InlineModule,
-    module: IdePlugin) {
-    module.forEachDependencyNotIn(this) {
-      dependencies += InlineDeclaredModuleV2Dependency.of(it.id, inlineModuleReference.loadingRule, contentModuleOwner = this, inlineModuleReference)
-    }
-  }
+  abstract fun addDependencies(moduleOwner: IdePluginImpl, module: IdePlugin, moduleReference: M)
 
   protected fun IdePlugin.forEachDependencyNotIn(plugin: IdePlugin, dependencyHandler: (PluginDependency) -> Unit) {
     return dependencies

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -32,7 +32,7 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
     problemResolver: PluginCreationResultResolver
   ): PluginCreator
 
-  internal fun resolve(
+  internal fun resolveDescriptor(
     pluginArtifactPath: Path,
     pluginCreator: PluginCreator,
     moduleReference: M,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.plugin.InlineDeclaredModuleV2Dependency
+import com.jetbrains.plugin.structure.intellij.plugin.Module
+import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import java.nio.file.Path
+
+internal abstract class AbstractModuleDescriptorResolver<M : Module> {
+  internal fun add(
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    moduleReference: M,
+    moduleCreator: PluginCreator
+  ) {
+    val pluginCreationResult = moduleCreator.pluginCreationResult
+    if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
+      val module = pluginCreationResult.plugin
+
+      val moduleDescriptor = getModuleDescriptor(pluginArtifactPath, pluginCreator, module, moduleCreator, moduleReference)
+      pluginCreator.addModuleDescriptor(module, moduleDescriptor)
+    } else {
+      pluginCreator.registerProblem(getProblem(moduleReference, pluginCreationResult.errors))
+    }
+  }
+
+  private fun PluginCreator.addModuleDescriptor(resolvedContentModule: IdePlugin, moduleDescriptor: ModuleDescriptor) {
+    plugin.modulesDescriptors.add(moduleDescriptor)
+    plugin.definedModules.add(moduleDescriptor.name)
+
+    mergeContent(resolvedContentModule)
+  }
+
+  abstract fun getProblem(moduleReference: M, errors: List<PluginProblem>): PluginProblem
+
+  abstract fun getModuleDescriptor(
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    module: IdePlugin,
+    moduleCreator: PluginCreator,
+    moduleDeclaration: M
+  ): ModuleDescriptor
+
+  protected fun IdePluginImpl.addDependencies(module: IdePlugin, loadingRule: ModuleLoadingRule) {
+    module.forEachDependencyNotIn(this) {
+      val dependency = if (loadingRule.required) it else it.asOptional()
+      dependencies += dependency
+    }
+  }
+
+  protected fun IdePluginImpl.addInlineModuleDependencies(
+    inlineModuleReference: InlineModule,
+    module: IdePlugin,
+    loadingRule: ModuleLoadingRule
+  ) {
+    module.forEachDependencyNotIn(this) {
+      dependencies += InlineDeclaredModuleV2Dependency.of(it.id, loadingRule, contentModuleOwner = this, inlineModuleReference)
+    }
+  }
+
+  protected fun IdePlugin.forEachDependencyNotIn(plugin: IdePlugin, dependencyHandler: (PluginDependency) -> Unit) {
+    return dependencies
+      .filter { dependency -> plugin.dependencies.none { it.id == dependency.id } }
+      .forEach { dependencyHandler(it) }
+  }
+
+  protected val PluginCreationResult<IdePlugin>.errors: List<PluginProblem>
+    get() = when (this) {
+      is PluginCreationSuccess -> emptyList()
+      is PluginCreationFail -> this.errorsAndWarnings.filter { it.level === ERROR }
+    }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -18,15 +18,28 @@ import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
 internal abstract class AbstractModuleDescriptorResolver<M : Module> {
-  internal fun add(
+
+  protected abstract fun getModuleCreator(
+    moduleReference: M,
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    resourceResolver: ResourceResolver,
+    problemResolver: PluginCreationResultResolver
+  ): PluginCreator
+
+  internal fun resolve(
     pluginArtifactPath: Path,
     pluginCreator: PluginCreator,
     moduleReference: M,
-    moduleCreator: PluginCreator
+    resourceResolver: ResourceResolver,
+    problemResolver: PluginCreationResultResolver
   ) {
+    val moduleCreator = getModuleCreator(moduleReference, pluginArtifactPath, pluginCreator, resourceResolver, problemResolver)
     val pluginCreationResult = moduleCreator.pluginCreationResult
     if (pluginCreationResult is PluginCreationSuccess<IdePlugin>) {
       val module = pluginCreationResult.plugin
@@ -52,7 +65,7 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
     pluginCreator: PluginCreator,
     module: IdePlugin,
     moduleCreator: PluginCreator,
-    moduleDeclaration: M
+    moduleReference: M
   ): ModuleDescriptor
 
   protected fun IdePluginImpl.addDependencies(module: IdePlugin, loadingRule: ModuleLoadingRule) {
@@ -83,4 +96,5 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
       is PluginCreationSuccess -> emptyList()
       is PluginCreationFail -> this.errorsAndWarnings.filter { it.level === ERROR }
     }
+
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/AbstractModuleDescriptorResolver.kt
@@ -77,11 +77,9 @@ internal abstract class AbstractModuleDescriptorResolver<M : Module> {
 
   protected fun IdePluginImpl.addInlineModuleDependencies(
     inlineModuleReference: InlineModule,
-    module: IdePlugin,
-    loadingRule: ModuleLoadingRule
-  ) {
+    module: IdePlugin) {
     module.forEachDependencyNotIn(this) {
-      dependencies += InlineDeclaredModuleV2Dependency.of(it.id, loadingRule, contentModuleOwner = this, inlineModuleReference)
+      dependencies += InlineDeclaredModuleV2Dependency.of(it.id, inlineModuleReference.loadingRule, contentModuleOwner = this, inlineModuleReference)
     }
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -55,8 +55,7 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
   }
 
   override fun getProblem(moduleReference: FileBasedModule, errors: List<PluginProblem>): PluginProblem {
-    val (name, _, configFile) = moduleReference
-    return ModuleDescriptorResolutionProblem(name, configFile, errors)
+    return ModuleDescriptorResolutionProblem(moduleReference.name, moduleReference.configFile, errors)
   }
 
   override fun getDependencies(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
@@ -26,7 +27,7 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
     moduleCreator: PluginCreator,
     moduleReference: FileBasedModule
   ): ModuleDescriptor {
-    addDependencies(pluginCreator.plugin, module, moduleReference)
+    pluginCreator.plugin.dependencies += getDependencies(pluginCreator.plugin, module, moduleReference)
     return ModuleDescriptor(
       moduleReference.name,
       moduleReference.loadingRule,
@@ -58,14 +59,15 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
     return ModuleDescriptorResolutionProblem(name, configFile, errors)
   }
 
-  override fun addDependencies(
+  override fun getDependencies(
     moduleOwner: IdePluginImpl,
     module: IdePlugin,
     moduleReference: FileBasedModule
-  ) {
-    module.forEachDependencyNotIn(moduleOwner) {
-      val dependency = if (moduleReference.loadingRule.required) it else it.asOptional()
-      moduleOwner.dependencies += dependency
+  ): List<PluginDependency> {
+    return mutableListOf<PluginDependency>().also { dependencies ->
+      module.forEachDependencyNotIn(moduleOwner) {
+        dependencies += if (moduleReference.loadingRule.required) it else it.asOptional()
+      }
     }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -17,7 +17,7 @@ import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
 internal class FileBasedModuleDescriptorResolver(private val pluginLoader: PluginLoader) :
-  AbstractModuleDescriptorResolver<FileBasedModule>() {
+  ModuleDescriptorResolver<FileBasedModule>() {
 
   override fun getModuleDescriptor(
     pluginArtifactPath: Path,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
+import java.nio.file.Path
+
+internal class FileBasedModuleDescriptorResolver : AbstractModuleDescriptorResolver<FileBasedModule>() {
+  override fun getModuleDescriptor(
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    module: IdePlugin,
+    moduleCreator: PluginCreator,
+    moduleDeclaration: FileBasedModule
+  ): ModuleDescriptor {
+    pluginCreator.plugin.addDependencies(module, moduleDeclaration.loadingRule)
+    return ModuleDescriptor(
+      moduleDeclaration.name,
+      moduleDeclaration.loadingRule,
+      module.dependencies,
+      module,
+      moduleDeclaration.configFile
+    )
+  }
+
+  override fun getProblem(moduleReference: FileBasedModule, errors: List<PluginProblem>): PluginProblem {
+    val (name, _, configFile) = moduleReference
+    return ModuleDescriptorResolutionProblem(name, configFile, errors)
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -6,6 +6,7 @@ package com.jetbrains.plugin.structure.intellij.plugin.module
 
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
@@ -25,7 +26,7 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
     moduleCreator: PluginCreator,
     moduleReference: FileBasedModule
   ): ModuleDescriptor {
-    pluginCreator.plugin.addDependencies(module, moduleReference.loadingRule)
+    addDependencies(pluginCreator.plugin, module, moduleReference)
     return ModuleDescriptor(
       moduleReference.name,
       moduleReference.loadingRule,
@@ -55,5 +56,16 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
   override fun getProblem(moduleReference: FileBasedModule, errors: List<PluginProblem>): PluginProblem {
     val (name, _, configFile) = moduleReference
     return ModuleDescriptorResolutionProblem(name, configFile, errors)
+  }
+
+  override fun addDependencies(
+    moduleOwner: IdePluginImpl,
+    module: IdePlugin,
+    moduleReference: FileBasedModule
+  ) {
+    module.forEachDependencyNotIn(moduleOwner) {
+      val dependency = if (moduleReference.loadingRule.required) it else it.asOptional()
+      moduleOwner.dependencies += dependency
+    }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -9,24 +9,39 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-internal class FileBasedModuleDescriptorResolver : AbstractModuleDescriptorResolver<FileBasedModule>() {
+internal class FileBasedModuleDescriptorResolver(private val pluginLoader: PluginLoader) : AbstractModuleDescriptorResolver<FileBasedModule>() {
+
   override fun getModuleDescriptor(
     pluginArtifactPath: Path,
     pluginCreator: PluginCreator,
     module: IdePlugin,
     moduleCreator: PluginCreator,
-    moduleDeclaration: FileBasedModule
+    moduleReference: FileBasedModule
   ): ModuleDescriptor {
-    pluginCreator.plugin.addDependencies(module, moduleDeclaration.loadingRule)
+    pluginCreator.plugin.addDependencies(module, moduleReference.loadingRule)
     return ModuleDescriptor(
-      moduleDeclaration.name,
-      moduleDeclaration.loadingRule,
+      moduleReference.name,
+      moduleReference.loadingRule,
       module.dependencies,
       module,
-      moduleDeclaration.configFile
+      moduleReference.configFile
+    )
+  }
+
+  override fun getModuleCreator(moduleReference: FileBasedModule, pluginArtifactPath: Path, pluginCreator: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver): PluginCreator {
+    return pluginLoader.load(
+      pluginArtifactPath,
+      moduleReference.configFile,
+      false,
+      resourceResolver,
+      pluginCreator,
+      problemResolver
     )
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -15,7 +15,8 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultReso
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-internal class FileBasedModuleDescriptorResolver(private val pluginLoader: PluginLoader) : AbstractModuleDescriptorResolver<FileBasedModule>() {
+internal class FileBasedModuleDescriptorResolver(private val pluginLoader: PluginLoader) :
+  AbstractModuleDescriptorResolver<FileBasedModule>() {
 
   override fun getModuleDescriptor(
     pluginArtifactPath: Path,
@@ -34,7 +35,13 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
     )
   }
 
-  override fun getModuleCreator(moduleReference: FileBasedModule, pluginArtifactPath: Path, pluginCreator: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver): PluginCreator {
+  override fun getModuleCreator(
+    moduleReference: FileBasedModule,
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    resourceResolver: ResourceResolver,
+    problemResolver: PluginCreationResultResolver
+  ): PluginCreator {
     return pluginLoader.load(
       pluginArtifactPath,
       moduleReference.configFile,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/IdeModule.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
 import com.jetbrains.plugin.structure.intellij.plugin.KotlinPluginMode
+import com.jetbrains.plugin.structure.intellij.plugin.Module
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.MutableIdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.OptionalPluginDescriptor
@@ -30,6 +31,7 @@ class IdeModule(override val pluginId: String, override val classpath: Classpath
   override val appContainerDescriptor = MutableIdePluginContentDescriptor()
   override val projectContainerDescriptor = MutableIdePluginContentDescriptor()
   override val moduleContainerDescriptor = MutableIdePluginContentDescriptor()
+  override val contentModules: List<Module> = emptyList()
   override val dependencies = mutableListOf<PluginDependency>()
   override val definedModules = mutableSetOf<String>()
   override val optionalDescriptors = emptyList<OptionalPluginDescriptor>()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
@@ -4,17 +4,30 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin.module
 
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
 import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorProblem
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.URI
 import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(InlineModuleDescriptorResolver::class.java)
 
 internal class InlineModuleDescriptorResolver  : AbstractModuleDescriptorResolver<InlineModule>() {
 
@@ -23,18 +36,29 @@ internal class InlineModuleDescriptorResolver  : AbstractModuleDescriptorResolve
     pluginCreator: PluginCreator,
     module: IdePlugin,
     moduleCreator: PluginCreator,
-    moduleDeclaration: InlineModule
+    moduleReference: InlineModule
   ): ModuleDescriptor {
-    val moduleName = moduleDeclaration.name
+    val moduleName = moduleReference.name
     val inlineModule = module
-    pluginCreator.plugin.addInlineModuleDependencies(moduleDeclaration, inlineModule, moduleDeclaration.loadingRule)
-    val moduleDescriptorResource = getModuleDescriptorResource(moduleDeclaration, pluginArtifactPath, pluginCreator.descriptorPath)
+    pluginCreator.plugin.addInlineModuleDependencies(moduleReference, inlineModule, moduleReference.loadingRule)
+    val moduleDescriptorResource = getModuleDescriptorResource(moduleReference, pluginArtifactPath, pluginCreator.descriptorPath)
     return ModuleDescriptor.of(
       moduleName,
-      moduleDeclaration.loadingRule,
+      moduleReference.loadingRule,
       inlineModule,
       moduleDescriptorResource
     )
+  }
+
+  override fun getModuleCreator(
+    moduleReference: InlineModule,
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    resourceResolver: ResourceResolver,
+    problemResolver: PluginCreationResultResolver
+  ): PluginCreator {
+    val moduleDescriptorResource = getModuleDescriptorResource(moduleReference, pluginArtifactPath, pluginCreator.descriptorPath)
+    return loadModuleFromDescriptorResource(moduleReference.name, moduleDescriptorResource, pluginCreator, resourceResolver)
   }
 
   override fun getProblem(
@@ -53,5 +77,45 @@ internal class InlineModuleDescriptorResolver  : AbstractModuleDescriptorResolve
     }
     val uriStr = parentUriStr + "#modules/" + module.name
     return DescriptorResource(module.textContent.byteInputStream(), URI(uriStr), URI(parentUriStr))
+  }
+
+  private fun loadModuleFromDescriptorResource(
+    moduleId: String,
+    descriptorResource: DescriptorResource,
+    parentPlugin: PluginCreator? = null,
+    resourceResolver: ResourceResolver
+  ): PluginCreator {
+    return descriptorResource.inputStream.use {
+      try {
+        val problemResolver = AnyProblemToWarningPluginCreationResultResolver
+        val descriptorXml = JDOMUtil.loadDocument(it)
+        createPlugin(
+          descriptorResource,
+          parentPlugin,
+          descriptorXml,
+          resourceResolver,
+          problemResolver
+        ).also { creator ->
+          logPluginCreationWarnings(moduleId, creator)
+        }
+      } catch (e: IOException) {
+        with(descriptorResource) {
+          LOG.warn("Unable to read descriptor stream (source: '$uri')", e)
+          val problem = UnableToReadDescriptor(fileName, e.localizedMessage)
+          createInvalidPlugin(artifactFileName, fileName, problem)
+        }
+      }
+    }
+  }
+
+
+  private fun logPluginCreationWarnings(pluginId: String, pluginCreator: PluginCreator) {
+    val pluginCreationResult = pluginCreator.pluginCreationResult
+    if (LOG.isDebugEnabled && pluginCreationResult is PluginCreationSuccess) {
+      val warningMessage = pluginCreationResult.warnings.joinToString("\n") {
+        it.message
+      }
+      LOG.debug("Plugin or module '$pluginId' has plugin problems: $warningMessage")
+    }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.module
+
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorProblem
+import java.net.URI
+import java.nio.file.Path
+
+internal class InlineModuleDescriptorResolver  : AbstractModuleDescriptorResolver<InlineModule>() {
+
+  override fun getModuleDescriptor(
+    pluginArtifactPath: Path,
+    pluginCreator: PluginCreator,
+    module: IdePlugin,
+    moduleCreator: PluginCreator,
+    moduleDeclaration: InlineModule
+  ): ModuleDescriptor {
+    val moduleName = moduleDeclaration.name
+    val inlineModule = module
+    pluginCreator.plugin.addInlineModuleDependencies(moduleDeclaration, inlineModule, moduleDeclaration.loadingRule)
+    val moduleDescriptorResource = getModuleDescriptorResource(moduleDeclaration, pluginArtifactPath, pluginCreator.descriptorPath)
+    return ModuleDescriptor.of(
+      moduleName,
+      moduleDeclaration.loadingRule,
+      inlineModule,
+      moduleDescriptorResource
+    )
+  }
+
+  override fun getProblem(
+    moduleReference: InlineModule,
+    errors: List<PluginProblem>
+  ): PluginProblem {
+    return ModuleDescriptorProblem(moduleReference, errors)
+  }
+
+  private fun getModuleDescriptorResource(module: InlineModule, pluginFile: Path, descriptorPath: String): DescriptorResource {
+    // TODO descriptor path is not relative to the pluginFile JAR. See MP-7224
+    val parentUriStr = if (pluginFile.isJar()) {
+      "jar:" + pluginFile.toUri().toString() + "!" + descriptorPath.toSystemIndependentName()
+    } else {
+      pluginFile.toUri().toString() + "/" + descriptorPath.toSystemIndependentName()
+    }
+    val uriStr = parentUriStr + "#modules/" + module.name
+    return DescriptorResource(module.textContent.byteInputStream(), URI(uriStr), URI(parentUriStr))
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
@@ -10,6 +10,8 @@ import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
 import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
+import com.jetbrains.plugin.structure.intellij.plugin.InlineDeclaredModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
@@ -38,7 +40,7 @@ internal class InlineModuleDescriptorResolver : AbstractModuleDescriptorResolver
     moduleCreator: PluginCreator,
     moduleReference: InlineModule
   ): ModuleDescriptor {
-    pluginCreator.plugin.addInlineModuleDependencies(moduleReference, module)
+    addDependencies(pluginCreator.plugin, module, moduleReference)
     val moduleDescriptorResource =
       getModuleDescriptorResource(moduleReference, pluginArtifactPath, pluginCreator.descriptorPath)
     return ModuleDescriptor.of(
@@ -114,6 +116,16 @@ internal class InlineModuleDescriptorResolver : AbstractModuleDescriptorResolver
           createInvalidPlugin(artifactFileName, fileName, problem)
         }
       }
+    }
+  }
+
+  override fun addDependencies(
+    moduleOwner: IdePluginImpl,
+    module: IdePlugin,
+    moduleReference: InlineModule
+  ) {
+    module.forEachDependencyNotIn(moduleOwner) {
+      moduleOwner.dependencies += InlineDeclaredModuleV2Dependency.of(it.id, moduleReference.loadingRule, moduleOwner, moduleReference)
     }
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
@@ -31,7 +31,7 @@ import java.nio.file.Path
 
 private val LOG: Logger = LoggerFactory.getLogger(InlineModuleDescriptorResolver::class.java)
 
-internal class InlineModuleDescriptorResolver : AbstractModuleDescriptorResolver<InlineModule>() {
+internal class InlineModuleDescriptorResolver : ModuleDescriptorResolver<InlineModule>() {
 
   override fun getModuleDescriptor(
     pluginArtifactPath: Path,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolver.kt
@@ -17,6 +17,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
 import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorProblem
@@ -40,7 +41,7 @@ internal class InlineModuleDescriptorResolver : ModuleDescriptorResolver<InlineM
     moduleCreator: PluginCreator,
     moduleReference: InlineModule
   ): ModuleDescriptor {
-    addDependencies(pluginCreator.plugin, module, moduleReference)
+    pluginCreator.plugin.dependencies += getDependencies(pluginCreator.plugin, module, moduleReference)
     val moduleDescriptorResource =
       getModuleDescriptorResource(moduleReference, pluginArtifactPath, pluginCreator.descriptorPath)
     return ModuleDescriptor.of(
@@ -119,13 +120,20 @@ internal class InlineModuleDescriptorResolver : ModuleDescriptorResolver<InlineM
     }
   }
 
-  override fun addDependencies(
+  override fun getDependencies(
     moduleOwner: IdePluginImpl,
     module: IdePlugin,
     moduleReference: InlineModule
-  ) {
-    module.forEachDependencyNotIn(moduleOwner) {
-      moduleOwner.dependencies += InlineDeclaredModuleV2Dependency.of(it.id, moduleReference.loadingRule, moduleOwner, moduleReference)
+  ): MutableList<PluginDependency> {
+    return mutableListOf<PluginDependency>().also { dependencies ->
+      module.forEachDependencyNotIn(moduleOwner) {
+        dependencies += InlineDeclaredModuleV2Dependency.of(
+          it.id,
+          moduleReference.loadingRule,
+          moduleOwner,
+          moduleReference
+        )
+      }
     }
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ModuleDescriptorResolver.kt
@@ -19,7 +19,7 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultReso
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-internal abstract class AbstractModuleDescriptorResolver<M : Module> {
+internal abstract class ModuleDescriptorResolver<M : Module> {
 
   sealed class ResolutionResult {
     data class Found(val resolvedContentModule: IdePlugin, val moduleDescriptor: ModuleDescriptor) : ResolutionResult()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ModuleDescriptorResolver.kt
@@ -62,7 +62,7 @@ internal abstract class ModuleDescriptorResolver<M : Module> {
     moduleReference: M
   ): ModuleDescriptor
 
-  abstract fun addDependencies(moduleOwner: IdePluginImpl, module: IdePlugin, moduleReference: M)
+  abstract fun getDependencies(moduleOwner: IdePluginImpl, module: IdePlugin, moduleReference: M): List<PluginDependency>
 
   protected fun IdePlugin.forEachDependencyNotIn(plugin: IdePlugin, dependencyHandler: (PluginDependency) -> Unit) {
     return dependencies

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/InlineModuleTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/InlineModuleTest.kt
@@ -47,6 +47,14 @@ class InlineModuleTest {
         }
     }.plugin
 
+    with(plugin.contentModules) {
+      assertEquals(1, size)
+      with(this[0]) {
+        assertEquals("intellij.java.structuralSearch", name)
+        assertEquals(ModuleLoadingRule.OPTIONAL, this.loadingRule)
+      }
+    }
+
     val modules = plugin.modulesDescriptors
     assertEquals(1, modules.size)
     val structureSearchModule = modules.first().module

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockIdePlugin.kt
@@ -7,6 +7,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
 import com.jetbrains.plugin.structure.intellij.plugin.KotlinPluginMode
+import com.jetbrains.plugin.structure.intellij.plugin.Module
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.MutableIdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.OptionalPluginDescriptor
@@ -43,6 +44,7 @@ data class MockIdePlugin(
   override val moduleContainerDescriptor: IdePluginContentDescriptor = MutableIdePluginContentDescriptor(),
   override val thirdPartyDependencies: List<ThirdPartyDependency> = emptyList(),
   override val modulesDescriptors: List<ModuleDescriptor> = emptyList(),
+
   @Deprecated("See IdePlugin::isV2")
   override val isV2: Boolean = false,
   override val hasPackagePrefix: Boolean = false,
@@ -53,6 +55,7 @@ data class MockIdePlugin(
   override val useIdeClassLoader = false
   override val isImplementationDetail = false
   override val hasDotNetPart: Boolean = false
+  override val contentModules: List<Module> = emptyList()
 
   override val declaredThemes = emptyList<IdeTheme>()
 


### PR DESCRIPTION
Untangle content modules resolution from `PluginCreator`. 

This is a refactoring - no new functionality is introduced.

- `IdePlugin` now keeps track of content module references. See `contentModule` property.
- `PluginCreator` now longer keeps track of content modules. This is now a responsibility of the `IdePlugin`.
- Introduce `ContentModuleLoader` that delegates content module resolution to one of two implementations.
- Introduce `ModuleDescriptorResolver` that resolves nested content module to an actual type-safe `IdePlugin` class.
- Add two implementations: `FileBasedModuleDescriptorResolver` for content modules with external descriptors and `InlineModuleDescriptorResolver` that handles module descriptors in inline CDATA declarations.