### PR TITLE
Query plugin provider for plugin by explicit attributes

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
@@ -6,6 +6,8 @@ package com.jetbrains.plugin.structure.ide;
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin;
 import com.jetbrains.plugin.structure.intellij.plugin.PluginProvider;
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision;
+import com.jetbrains.plugin.structure.intellij.plugin.PluginQuery;
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,6 +21,8 @@ import java.util.Objects;
  * IDE can be created via {@link IdeManager#createIde(java.nio.file.Path)}.
  */
 public abstract class Ide implements PluginProvider {
+  private final PluginQueryMatcher queryMatcher = new PluginQueryMatcher();
+
   /**
    * Returns the IDE version either from 'build.txt' or specified with {@link IdeManager#createIde(java.nio.file.Path, IdeVersion)}
    *
@@ -76,6 +80,23 @@ public abstract class Ide implements PluginProvider {
       }
     }
     return null;
+  }
+
+  /**
+   * Finds bundled plugin according to specified query.
+   *
+   * @param query plugin search query.
+   * @return a plugin provision class of corresponding type. Never returns {@code null}.
+   */
+  @Override
+  public @NotNull PluginProvision query(@NotNull PluginQuery query) {
+    for (IdePlugin plugin : getBundledPlugins()) {
+      PluginProvision pluginProvision = queryMatcher.matches(plugin, query);
+      if (pluginProvision instanceof PluginProvision.Found) {
+        return pluginProvision;
+      }
+    }
+    return PluginProvision.NotFound.INSTANCE;
   }
 
   /**

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
@@ -54,7 +54,7 @@ public abstract class Ide implements PluginProvider {
   @Override
   final public IdePlugin findPluginById(@NotNull String pluginId) {
     for (IdePlugin plugin : getBundledPlugins()) {
-      String id = plugin.getPluginId() != null ? plugin.getPluginId() : plugin.getPluginName();
+      String id = getId(plugin);
       if (Objects.equals(id, pluginId))
         return plugin;
     }
@@ -76,6 +76,22 @@ public abstract class Ide implements PluginProvider {
       }
     }
     return null;
+  }
+
+  /**
+   * Returns a plugin ID of the specified plugin. It uses the ID of the plugin if it is specified,
+   * or a plugin name if the ID is not specified.
+   *
+   * @param plugin plugin to get the ID of
+   * @return plugin identifier of the specified plugin
+   */
+  @Nullable
+  protected String getId(@NotNull IdePlugin plugin) {
+    String id = plugin.getPluginId();
+    if (id == null) {
+      id = plugin.getPluginName();
+    }
+    return id;
   }
 
   /**

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/PluginQueryMatcher.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/PluginQueryMatcher.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision.Source.*
+import com.jetbrains.plugin.structure.intellij.plugin.PluginQuery
+
+class PluginQueryMatcher {
+  fun matches(plugin: IdePlugin, query: PluginQuery): PluginProvision {
+    val identifier = query.identifier
+    return if (query.searchId() && plugin.pluginId == identifier) {
+      PluginProvision.Found(plugin, ID)
+    } else if (query.searchName() && plugin.pluginName == identifier) {
+      PluginProvision.Found(plugin, NAME)
+    } else if (query.searchPluginAliases() && plugin.definedModules.contains(identifier)) {
+      PluginProvision.Found(plugin, ALIAS)
+    } else PluginProvision.NotFound
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginProvider.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginProvider.java
@@ -25,4 +25,7 @@ public interface PluginProvider {
      */
     @Nullable
     IdePlugin findPluginByModule(@NotNull String moduleId);
+
+    @NotNull
+    PluginProvision query(@NotNull PluginQuery query);
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginProvision.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginProvision.kt
@@ -1,0 +1,15 @@
+package com.jetbrains.plugin.structure.intellij.plugin
+
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+sealed class PluginProvision {
+  enum class Source {
+    ID,
+    NAME,
+    ALIAS
+  }
+
+  class Found(val plugin: IdePlugin, val source: Source) : PluginProvision()
+  object NotFound : PluginProvision()
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginQuery.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginQuery.java
@@ -9,18 +9,14 @@ public class PluginQuery {
 
     private String identifier;
 
-    private boolean searchPluginAliases;
-
     private boolean searchId;
 
     private boolean searchName;
 
+    private boolean searchPluginAliases;
+
     public @NotNull String getIdentifier() {
         return identifier;
-    }
-
-    public boolean searchPluginAliases() {
-        return searchPluginAliases;
     }
 
     public boolean searchId() {
@@ -29,6 +25,10 @@ public class PluginQuery {
 
     public boolean searchName() {
         return searchName;
+    }
+
+    public boolean searchPluginAliases() {
+        return searchPluginAliases;
     }
 
     public static class Builder {
@@ -46,12 +46,6 @@ public class PluginQuery {
         }
 
         @NotNull
-        public Builder inPluginAliases() {
-            query.searchPluginAliases = true;
-            return this;
-        }
-
-        @NotNull
         public Builder inId() {
             query.searchId = true;
             return this;
@@ -60,6 +54,12 @@ public class PluginQuery {
         @NotNull
         public Builder inName() {
             query.searchName = true;
+            return this;
+        }
+
+        @NotNull
+        public Builder inPluginAliases() {
+            query.searchPluginAliases = true;
             return this;
         }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginQuery.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginQuery.java
@@ -1,0 +1,71 @@
+package com.jetbrains.plugin.structure.intellij.plugin;
+
+import org.jetbrains.annotations.NotNull;
+
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+public class PluginQuery {
+
+    private String identifier;
+
+    private boolean searchPluginAliases;
+
+    private boolean searchId;
+
+    private boolean searchName;
+
+    public @NotNull String getIdentifier() {
+        return identifier;
+    }
+
+    public boolean searchPluginAliases() {
+        return searchPluginAliases;
+    }
+
+    public boolean searchId() {
+        return searchId;
+    }
+
+    public boolean searchName() {
+        return searchName;
+    }
+
+    public static class Builder {
+        private final PluginQuery query = new PluginQuery();
+
+        @NotNull
+        public static Builder of(@NotNull String identifier) {
+            return new Builder().setIdentifier(identifier);
+        }
+
+        @NotNull
+        public Builder setIdentifier(@NotNull String identifier) {
+            query.identifier = identifier;
+            return this;
+        }
+
+        @NotNull
+        public Builder inPluginAliases() {
+            query.searchPluginAliases = true;
+            return this;
+        }
+
+        @NotNull
+        public Builder inId() {
+            query.searchId = true;
+            return this;
+        }
+
+        @NotNull
+        public Builder inName() {
+            query.searchName = true;
+            return this;
+        }
+
+        @NotNull
+        public PluginQuery build() {
+            return query;
+        }
+    }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdePluginProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdePluginProviderTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.domain
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.IdeManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision.Source.*
+import com.jetbrains.plugin.structure.intellij.plugin.PluginQuery
+import com.jetbrains.plugin.structure.mocks.modify
+import com.jetbrains.plugin.structure.mocks.perfectXmlBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+private const val JAVA_PLUGIN_ID = "com.intellij.java"
+private const val JAVA_PLUGIN_NAME = "Java"
+private const val MODULE_ALIAS = "com.intellij.modules.java"
+
+class IdePluginProviderTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var ide: Ide
+
+  @Before
+  fun setUp() {
+    val ideRoot = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
+      file("build.txt", "IE-221.5591.62")
+
+      dir("lib") {
+        zip("app.jar") {
+          dir("META-INF") {
+            file("PlatformLangPlugin.xml") {
+              perfectXmlBuilder.modify {
+                id = "<id>com.intellij</id>"
+                name = "<name>IDEA CORE</name>"
+                modules = listOf("some.idea.module")
+              }
+            }
+          }
+        }
+      }
+
+      dir("plugins") {
+        dir("java") {
+          dir("lib") {
+            zip("java-impl.jar") {
+              dir("META-INF") {
+                file("plugin.xml") {
+                  perfectXmlBuilder.modify {
+                    id = "<id>$JAVA_PLUGIN_ID</id>"
+                    name = "<name>$JAVA_PLUGIN_NAME</name>"
+                    vendor = "<vendor>JetBrains</vendor>"
+                    modules = listOf(MODULE_ALIAS)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    ide = IdeManager.createManager().createIde(ideRoot)
+  }
+
+  @Test
+  fun `resolve plugin by ID`() {
+    val query =
+      PluginQuery.Builder
+        .of(JAVA_PLUGIN_ID)
+        .inId()
+        .build()
+    val pluginProvision = ide.query(query)
+    assertTrue(pluginProvision is PluginProvision.Found)
+    pluginProvision as PluginProvision.Found
+    with(pluginProvision) {
+      assertEquals(JAVA_PLUGIN_ID, pluginProvision.plugin.pluginId)
+      assertEquals(ID, pluginProvision.source)
+    }
+  }
+
+  @Test
+  fun `resolve plugin by name`() {
+    val query = PluginQuery.Builder
+      .of(JAVA_PLUGIN_NAME)
+      .inName()
+      .build()
+    val pluginProvision = ide.query(query)
+    assertTrue(pluginProvision is PluginProvision.Found)
+    pluginProvision as PluginProvision.Found
+    assertEquals(JAVA_PLUGIN_ID, pluginProvision.plugin.pluginId)
+    assertEquals(JAVA_PLUGIN_NAME, pluginProvision.plugin.pluginName)
+    assertEquals(NAME, pluginProvision.source)
+  }
+
+  @Test
+  fun `resolve plugin by plugin alias`() {
+    val query = PluginQuery.Builder
+      .of(MODULE_ALIAS)
+      .inPluginAliases()
+      .build()
+    val pluginProvision = ide.query(query)
+    assertTrue(pluginProvision is PluginProvision.Found)
+    pluginProvision as PluginProvision.Found
+    assertEquals(JAVA_PLUGIN_ID, pluginProvision.plugin.pluginId)
+    assertEquals(ALIAS, pluginProvision.source)
+  }
+}


### PR DESCRIPTION
Semantics of `findPluginByModule` in `PluginProvider` is historically unclear. In this class, module might be a plugin alias or a content module ID.

Add an additional method that allows to query plugins by searching in an explicit places:

- plugin identifier
- plugin name
- plugin aliases
