### PR TITLE
Extract icon loading and dependency loading into separate class

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginDirectoryResourceLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginDirectoryResourceLoader.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import java.io.IOException
+import java.nio.file.Path
+
+interface PluginDirectoryResourceLoader<T> {
+  @Throws(IOException::class)
+  fun load(pluginDirectory: Path): List<T>
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginIconLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginIconLoader.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.IconTheme
+import com.jetbrains.plugin.structure.base.plugin.PluginIcon
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PluginIconLoader : PluginDirectoryResourceLoader<PluginIcon> {
+  @Throws(IOException::class)
+  override fun load(pluginDirectory: Path): List<PluginIcon> {
+    return IconTheme.values().mapNotNull { theme ->
+      val iconFile = pluginDirectory.resolve(META_INF).resolve(getIconFileName(theme))
+      if (iconFile.exists()) {
+        PluginIcon(theme, Files.readAllBytes(iconFile), iconFile.simpleName)
+      } else {
+        null
+      }
+    }
+  }
+
+  private fun getIconFileName(iconTheme: IconTheme) = "pluginIcon${iconTheme.suffix}.svg"
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ThirdPartyDependencyLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ThirdPartyDependencyLoader.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.ThirdPartyDependency
+import com.jetbrains.plugin.structure.base.plugin.parseThirdPartyDependenciesByPath
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
+import java.nio.file.Path
+
+private val THIRD_PARTY_LIBRARIES_FILE_NAME = "dependencies.json"
+
+class ThirdPartyDependencyLoader : PluginDirectoryResourceLoader<ThirdPartyDependency> {
+  override fun load(pluginDirectory: Path): List<ThirdPartyDependency> {
+    val path = pluginDirectory.resolve(META_INF).resolve(THIRD_PARTY_LIBRARIES_FILE_NAME)
+    return parseThirdPartyDependenciesByPath(path)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginIconLoaderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginIconLoaderTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.IconTheme
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+private const val DEFAULT_ICON_SVG = """<svg xmlns="http://www.w3.org/2000/svg"><circle r="9" /></svg>"""
+private const val DARK_ICON_SVG = """<svg xmlns="http://www.w3.org/2000/svg"><circle r="9" fill="gray" /></svg>"""
+
+class PluginIconLoaderTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var pluginIconLoader: PluginIconLoader
+
+  @Before
+  fun setUp() {
+    pluginIconLoader = PluginIconLoader()
+  }
+
+  @Test
+  fun `plugin icon is loaded`() {
+    val pluginDirectory: Path = temporaryFolder.newFolder("plugin").toPath()
+    buildDirectory(pluginDirectory) {
+      dir("META-INF") {
+        file("pluginIcon.svg", DEFAULT_ICON_SVG)
+      }
+    }
+    val icons = pluginIconLoader.load(pluginDirectory)
+    with(icons) {
+      assertEquals(1, size)
+      val icon = first()
+      assertEquals(IconTheme.DEFAULT, icon.theme)
+      assertEquals("pluginIcon.svg", icon.fileName)
+    }
+  }
+
+  @Test
+  fun `plugin icons are loaded for default and dark mode`() {
+    val pluginDirectory: Path = temporaryFolder.newFolder("plugin").toPath()
+    buildDirectory(pluginDirectory) {
+      dir("META-INF") {
+        file("pluginIcon.svg", DEFAULT_ICON_SVG)
+        file("pluginIcon_dark.svg", DARK_ICON_SVG)
+      }
+    }
+    val icons = pluginIconLoader.load(pluginDirectory)
+    with(icons) {
+      assertEquals(2, size)
+      with(first()) {
+        assertEquals(IconTheme.DEFAULT, theme)
+        assertEquals("pluginIcon.svg", fileName)
+      }
+
+      with(get(1)) {
+        assertEquals(IconTheme.DARCULA, theme)
+        assertEquals("pluginIcon_dark.svg", fileName)
+      }
+    }
+  }
+}


### PR DESCRIPTION
In order to simplify `PluginCreator`, extract the following functionality to separate class:

- icon loading
- legacy 3rd party dependency loading