### PR TITLE
Extract away plugin component loaders from PluginCreator

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -32,9 +32,9 @@ import com.jetbrains.plugin.structure.intellij.extractor.PluginExtractor.extract
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.ContentModuleLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarLoadingContext
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarPluginLoader
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginIconLoader
-import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginLoadingContext
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.ThirdPartyDependencyLoader
 import com.jetbrains.plugin.structure.intellij.plugin.module.ContentModuleScanner
 import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
@@ -192,7 +192,7 @@ class IdePluginManager private constructor(
       val innerCreator: PluginCreator = if (file.isJar() || file.isZip()) {
         //Use the composite resource resolver, which can resolve resources in lib's jar files.
         jarLoader.loadPlugin(
-          PluginLoadingContext(
+          JarLoadingContext(
             file,
             descriptorPath,
             validateDescriptor,
@@ -258,14 +258,15 @@ class IdePluginManager private constructor(
       }
 
       pluginFile.isJar() -> jarLoader.loadPlugin(
-        PluginLoadingContext(
+        JarLoadingContext(
           pluginFile,
           systemIndependentDescriptorPath,
           validateDescriptor,
           resourceResolver,
           parentPlugin,
           problemResolver
-      ))
+        )
+      )
 
       else -> throw IllegalArgumentException()
     }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -4,58 +4,38 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.plugin.PluginManager
 import com.jetbrains.plugin.structure.base.plugin.Settings
 import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
-import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
-import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
-import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
-import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
-import com.jetbrains.plugin.structure.base.problems.isInvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.utils.exists
-import com.jetbrains.plugin.structure.base.utils.getShortExceptionMessage
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.isZip
-import com.jetbrains.plugin.structure.base.utils.listFiles
 import com.jetbrains.plugin.structure.base.utils.pluginSize
 import com.jetbrains.plugin.structure.base.utils.simpleName
-import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
-import com.jetbrains.plugin.structure.base.utils.withPathSeparatorOf
 import com.jetbrains.plugin.structure.intellij.extractor.ExtractorResult
 import com.jetbrains.plugin.structure.intellij.extractor.PluginExtractor.extractPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
-import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.ContentModuleLoader
-import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarLoadingContext
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarModuleLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarOrDirectoryPluginLoader
 import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarPluginLoader
-import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginIconLoader
-import com.jetbrains.plugin.structure.intellij.plugin.loaders.ThirdPartyDependencyLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.LibDirectoryPluginLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.ModuleFromDescriptorLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginDirectoryLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginLoaderProvider
 import com.jetbrains.plugin.structure.intellij.plugin.module.ContentModuleScanner
 import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
-import com.jetbrains.plugin.structure.intellij.problems.PluginLibDirectoryIsEmpty
-import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.DefaultResourceResolver
-import com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
-import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
-import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
-import com.jetbrains.plugin.structure.jar.PluginJar
 import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
-import org.jdom2.Document
-import org.jdom2.input.JDOMParseException
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.system.measureTimeMillis
@@ -65,212 +45,53 @@ import kotlin.system.measureTimeMillis
  *
  * Handles the plugin provided in JAR, ZIP or directory.
  */
+@Suppress("UNCHECKED_CAST")
 class IdePluginManager private constructor(
   private val myResourceResolver: ResourceResolver,
   private val extractDirectory: Path,
   private val fileSystemProvider: JarFileSystemProvider = SingletonCachingJarFileSystemProvider
 ) : PluginManager<IdePlugin> {
 
-  private val jarLoader = JarPluginLoader(fileSystemProvider)
+  private val pluginLoaderRegistry = PluginLoaderProvider().apply {
+    register(JarPluginLoader.Context::class.java, JarPluginLoader(fileSystemProvider))
+    register(JarModuleLoader.Context::class.java, JarModuleLoader(fileSystemProvider))
+    register(PluginDirectoryLoader.Context::class.java, PluginDirectoryLoader(pluginLoaderRegistry = this))
+    register(LibDirectoryPluginLoader.Context::class.java,
+      LibDirectoryPluginLoader(pluginLoaderRegistry = this, fileSystemProvider)
+    )
+    register(ModuleFromDescriptorLoader.Context::class.java, ModuleFromDescriptorLoader())
+    register(JarOrDirectoryPluginLoader.Context::class.java, JarOrDirectoryPluginLoader(pluginLoaderRegistry = this))
+  }
 
-  private val optionalDependencyResolver = OptionalDependencyResolver(this::loadPluginInfoFromJarOrDirectory)
+  private val moduleFromDescriptorLoader = pluginLoaderRegistry.get<ModuleFromDescriptorLoader.Context, ModuleFromDescriptorLoader>()
+  private val jarModuleLoader = pluginLoaderRegistry.get<JarModuleLoader.Context, JarModuleLoader>()
+  private val jarOrDirLoader = pluginLoaderRegistry.get<JarOrDirectoryPluginLoader.Context, JarOrDirectoryPluginLoader>()
 
-  private val contentModuleLoader = ContentModuleLoader(this::loadPluginInfoFromJarOrDirectory)
+  private val contentModuleLoader = ContentModuleLoader(jarOrDirLoader, moduleFromDescriptorLoader)
 
   private val contentModuleScanner = ContentModuleScanner(fileSystemProvider)
 
-  private val pluginIconLoader = PluginIconLoader()
-
-  private val thirdPartyDependencyLoader = ThirdPartyDependencyLoader()
-
-  private fun loadModuleInfoFromJarFile(
-    jarFile: Path,
-    descriptorPath: String,
-    resourceResolver: ResourceResolver,
-    problemResolver: PluginCreationResultResolver,
-  ): PluginCreator {
-    return try {
-      PluginJar(jarFile, fileSystemProvider).use { jar ->
-        when (val descriptor = jar.getPluginDescriptor(descriptorPath)) {
-          is Found -> {
-            try {
-              val descriptorXml = descriptor.loadXml()
-              createPlugin(
-                jarFile.simpleName,
-                descriptorPath,
-                parentPlugin = null,
-                validateDescriptor = false,
-                descriptorXml,
-                descriptor.path, resourceResolver, problemResolver
-              )
-            } catch (e: Exception) {
-              LOG.warn("Unable to read descriptor [$descriptorPath] from [$jarFile]", e)
-              val message = e.localizedMessage
-              createInvalidPlugin(jarFile, descriptorPath, UnableToReadDescriptor(descriptorPath, message))
-            }
-          }
-
-          else -> createInvalidPlugin(jarFile, descriptorPath, PluginDescriptorIsNotFound(descriptorPath)).also {
-            LOG.debug("Unable to resolve descriptor [{}] from [{}] ({})", descriptorPath, jarFile, descriptor)
-          }
-        }
-      }
-    } catch (e: JarArchiveCannotBeOpenException) {
-      LOG.warn("Unable to extract {} (searching for {}): {}", jarFile, descriptorPath, e.getShortExceptionMessage())
-      createInvalidPlugin(jarFile, descriptorPath, UnableToExtractZip())
-    }
-  }
-
-  private fun Found.loadXml(): Document {
-    return inputStream.use {
-      JDOMUtil.loadDocument(it)
-    }
-  }
-
-   private fun loadPluginInfoFromDirectory(
-    pluginDirectory: Path,
-    descriptorPath: String,
-    validateDescriptor: Boolean,
-    resourceResolver: ResourceResolver,
-    parentPlugin: PluginCreator?,
-    problemResolver: PluginCreationResultResolver,
-    hasDotNetDirectory: Boolean = false
-  ): PluginCreator {
-    val descriptorFile = pluginDirectory.resolve(META_INF).resolve(descriptorPath.withPathSeparatorOf(pluginDirectory))
-    return if (!descriptorFile.exists()) {
-      loadPluginInfoFromLibDirectory(pluginDirectory,
-        descriptorPath,
-        validateDescriptor,
-        resourceResolver,
-        parentPlugin,
-        problemResolver)
-    } else try {
-      val document = JDOMUtil.loadDocument(Files.newInputStream(descriptorFile))
-      val icons = pluginIconLoader.load(pluginDirectory)
-      val dependencies = thirdPartyDependencyLoader.load(pluginDirectory)
-      createPlugin(
-        pluginDirectory.simpleName, descriptorPath, parentPlugin,
-        validateDescriptor, document, descriptorFile,
-        resourceResolver, problemResolver
-      ).apply {
-          setIcons(icons)
-          setThirdPartyDependencies(dependencies)
-          setHasDotNetPart(hasDotNetDirectory)
-      }
-    } catch (e: JDOMParseException) {
-      LOG.info("Unable to parse plugin descriptor $descriptorPath of plugin $descriptorFile", e)
-      createInvalidPlugin(pluginDirectory, descriptorPath, UnexpectedDescriptorElements(e.lineNumber, descriptorPath))
-    } catch (e: Exception) {
-      LOG.info("Unable to read plugin descriptor $descriptorPath of plugin $descriptorFile", e)
-      createInvalidPlugin(pluginDirectory, descriptorPath, UnableToReadDescriptor(descriptorPath, descriptorPath))
-    }
-  }
-
-  private fun loadPluginInfoFromLibDirectory(
-    root: Path,
-    descriptorPath: String,
-    validateDescriptor: Boolean,
-    resourceResolver: ResourceResolver,
-    parentPlugin: PluginCreator?,
-    problemResolver: PluginCreationResultResolver
-  ): PluginCreator {
-    val libDir = root.resolve("lib")
-    val hasDotNetDirectory = root.resolve("dotnet").exists()
-    if (!libDir.isDirectory) {
-      return createInvalidPlugin(root, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
-    }
-    val files = libDir.listFiles()
-    if (files.isEmpty()) {
-      return createInvalidPlugin(root, descriptorPath, PluginLibDirectoryIsEmpty())
-    }
-    val jarFiles = files.filter { it.isJar() }
-    val libResourceResolver: ResourceResolver = JarsResourceResolver(jarFiles, fileSystemProvider)
-    val compositeResolver: ResourceResolver = CompositeResourceResolver(listOf(libResourceResolver, resourceResolver))
-
-    val results: MutableList<CreationResult> = ArrayList()
-    for (file in files) {
-      val innerCreator: PluginCreator = if (file.isJar() || file.isZip()) {
-        //Use the composite resource resolver, which can resolve resources in lib's jar files.
-        jarLoader.loadPlugin(
-          JarLoadingContext(
-            file,
-            descriptorPath,
-            validateDescriptor,
-            compositeResolver,
-            parentPlugin,
-            problemResolver,
-            hasDotNetDirectory
-          )
-        )
-      } else if (file.isDirectory) {
-        //Use the common resource resolver, which is unaware of lib's jar files.
-        loadPluginInfoFromDirectory(
-            pluginDirectory = file,
-            descriptorPath = descriptorPath,
-            validateDescriptor = validateDescriptor,
-            resourceResolver = resourceResolver,
-            parentPlugin = parentPlugin,
-            problemResolver = problemResolver,
-            hasDotNetDirectory = hasDotNetDirectory
-        )
-      } else {
-        continue
-      }
-      results.add(CreationResult(root, innerCreator))
-    }
-    val possibleResults = results
-      .filter { (_, r: PluginCreator)  -> r.isSuccess || hasOnlyInvalidDescriptorErrors(r) }
-    return when(possibleResults.size) {
-      0 -> createInvalidPlugin(root, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
-      1 -> possibleResults[0].withResolvedClasspath().creator
-      else -> {
-        val first = possibleResults[0].creator
-        val second = possibleResults[1].creator
-        val multipleDescriptorsProblem: PluginProblem = MultiplePluginDescriptors(
-                first.descriptorPath,
-                first.pluginFileName,
-                second.descriptorPath,
-                second.pluginFileName
-        )
-        createInvalidPlugin(root, descriptorPath, multipleDescriptorsProblem)
-      }
-    }
-  }
-
-  private fun loadPluginInfoFromJarOrDirectory(
-    pluginFile: Path,
-    descriptorPath: String,
-    validateDescriptor: Boolean,
-    resourceResolver: ResourceResolver,
-    parentPlugin: PluginCreator?,
-    problemResolver: PluginCreationResultResolver
-  ): PluginCreator {
-    LOG.debug("Loading {} with descriptor [{}]", pluginFile, descriptorPath)
-    val systemIndependentDescriptorPath = descriptorPath.toSystemIndependentName()
-    return when {
-      pluginFile.isDirectory -> {
-        loadPluginInfoFromDirectory(pluginFile,
-          systemIndependentDescriptorPath,
-          validateDescriptor,
-          resourceResolver,
-          parentPlugin,
-          problemResolver)
-      }
-
-      pluginFile.isJar() -> jarLoader.loadPlugin(
-        JarLoadingContext(
+  private val optionalDependencyResolver = OptionalDependencyResolver(object : PluginLoader {
+    override fun load(
+      pluginFile: Path,
+      descriptorPath: String,
+      validateDescriptor: Boolean,
+      resourceResolver: ResourceResolver,
+      parentPlugin: PluginCreator?,
+      problemResolver: PluginCreationResultResolver
+    ): PluginCreator {
+      return jarOrDirLoader.loadPlugin(
+        JarOrDirectoryPluginLoader.Context(
           pluginFile,
-          systemIndependentDescriptorPath,
+          descriptorPath,
           validateDescriptor,
           resourceResolver,
           parentPlugin,
           problemResolver
         )
       )
-
-      else -> throw IllegalArgumentException()
     }
-  }
+  })
 
   private fun resolveOptionalDependencies(pluginFile: Path, pluginCreator: PluginCreator, resourceResolver: ResourceResolver, problemResolver: PluginCreationResultResolver) {
     if (pluginCreator.isSuccess) {
@@ -360,10 +181,12 @@ class IdePluginManager private constructor(
     descriptorPath: String,
     problemResolver: PluginCreationResultResolver = IntelliJPluginCreationResultResolver()
   ): PluginCreationResult<IdePlugin> {
-    return loadModuleInfoFromJarFile(pluginFile, descriptorPath, myResourceResolver, problemResolver).apply {
-      setPluginVersion(ideVersion.asStringWithoutProductCode())
-      setOriginalFile(pluginFile)
-    }.pluginCreationResult
+    return jarModuleLoader
+      .loadPlugin(JarModuleLoader.Context(pluginFile, descriptorPath, myResourceResolver, problemResolver))
+      .apply {
+        setPluginVersion(ideVersion.asStringWithoutProductCode())
+        setOriginalFile(pluginFile)
+      }.pluginCreationResult
   }
 
   @Throws(PluginFileNotFoundException::class)
@@ -401,7 +224,7 @@ class IdePluginManager private constructor(
     resourceResolver: ResourceResolver,
     problemResolver: PluginCreationResultResolver
   ): PluginCreator {
-    val pluginCreator = loadPluginInfoFromJarOrDirectory(pluginFile, descriptorPath, validateDescriptor, resourceResolver, null, problemResolver)
+    val pluginCreator = jarOrDirLoader.loadPlugin(JarOrDirectoryPluginLoader.Context(pluginFile, descriptorPath, validateDescriptor, resourceResolver, null, problemResolver))
     resolveOptionalDependencies(pluginFile, pluginCreator, myResourceResolver, problemResolver)
     resolveContentModules(pluginFile, pluginCreator, myResourceResolver, problemResolver)
 
@@ -425,7 +248,7 @@ class IdePluginManager private constructor(
     creator.setClasspath(classpath.getUnique())
   }
 
-  private data class CreationResult(val artifact: Path, val creator: PluginCreator)
+  internal data class CreationResult(val artifact: Path, val creator: PluginCreator)
 
   companion object {
     private val LOG = LoggerFactory.getLogger(IdePluginManager::class.java)
@@ -467,15 +290,5 @@ class IdePluginManager private constructor(
     @JvmStatic
     fun createManager(resourceResolver: ResourceResolver, extractDirectory: File): IdePluginManager =
       createManager(resourceResolver, extractDirectory.toPath())
-
-    private fun hasOnlyInvalidDescriptorErrors(creator: PluginCreator): Boolean {
-      return when (val pluginCreationResult = creator.pluginCreationResult) {
-        is PluginCreationSuccess<*> -> false
-        is PluginCreationFail<*> -> {
-          val errorsAndWarnings = pluginCreationResult.errorsAndWarnings
-          errorsAndWarnings.all { it.level !== PluginProblem.Level.ERROR || it.isInvalidDescriptorProblem }
-        }
-      }
-    }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ContentModuleLoader.kt
@@ -8,7 +8,6 @@ import com.jetbrains.plugin.structure.intellij.plugin.Module
 import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
-import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
 import com.jetbrains.plugin.structure.intellij.plugin.module.ContentModuleLoadingResults
 import com.jetbrains.plugin.structure.intellij.plugin.module.FileBasedModuleDescriptorResolver
 import com.jetbrains.plugin.structure.intellij.plugin.module.InlineModuleDescriptorResolver
@@ -20,9 +19,12 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultReso
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-class ContentModuleLoader internal constructor(pluginLoader: PluginLoader) {
-  private val fileBasedModuleDescriptorResolver = FileBasedModuleDescriptorResolver(pluginLoader)
-  private val inlineModuleDescriptorResolver = InlineModuleDescriptorResolver()
+class ContentModuleLoader internal constructor(
+  jarOrDirLoader: JarOrDirectoryPluginLoader,
+  moduleFromDescriptorLoader: ModuleFromDescriptorLoader
+) {
+  private val fileBasedModuleDescriptorResolver = FileBasedModuleDescriptorResolver(jarOrDirLoader)
+  private val inlineModuleDescriptorResolver = InlineModuleDescriptorResolver(moduleFromDescriptorLoader)
 
   internal fun resolveContentModules(
     pluginFile: Path,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarOrDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarOrDirectoryPluginLoader.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.toSystemIndependentName
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(JarOrDirectoryPluginLoader::class.java)
+
+internal class JarOrDirectoryPluginLoader(private val pluginLoaderRegistry: PluginLoaderProvider) : PluginLoader<JarOrDirectoryPluginLoader.Context> {
+  private val jarLoader: JarPluginLoader
+    get() = pluginLoaderRegistry.get<JarPluginLoader.Context, JarPluginLoader>()
+
+  private val dirLoader: PluginDirectoryLoader
+    get() = pluginLoaderRegistry.get<PluginDirectoryLoader.Context, PluginDirectoryLoader>()
+
+  override fun loadPlugin(pluginLoadingContext: Context): PluginCreator = with(pluginLoadingContext) {
+    LOG.debug("Loading {} with descriptor [{}]", jarOrDirectory, descriptorPath)
+    val systemIndependentDescriptorPath = descriptorPath.toSystemIndependentName()
+    return when {
+      jarOrDirectory.isDirectory -> {
+        dirLoader.loadPlugin(PluginDirectoryLoader.Context(jarOrDirectory,
+          systemIndependentDescriptorPath,
+          validateDescriptor,
+          resourceResolver,
+          parentPlugin,
+          problemResolver))
+      }
+
+      jarOrDirectory.isJar() -> jarLoader.loadPlugin(
+        JarPluginLoader.Context(
+          jarOrDirectory,
+          systemIndependentDescriptorPath,
+          validateDescriptor,
+          resourceResolver,
+          parentPlugin,
+          problemResolver
+        )
+      )
+
+      else -> throw IllegalArgumentException("Plugin artifact path '${jarOrDirectory}' is neither a JAR file nor a directory.")
+    }
+  }
+
+  internal data class Context(
+    val jarOrDirectory: Path,
+    val descriptorPath: String,
+    val validateDescriptor: Boolean,
+    override val resourceResolver: ResourceResolver,
+    val parentPlugin: PluginCreator?,
+    override val problemResolver: PluginCreationResultResolver,
+    val hasDotNetDirectory: Boolean = false
+  ) : PluginLoadingContext(
+    resourceResolver,
+    problemResolver,
+  )
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
+import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
+import com.jetbrains.plugin.structure.base.utils.getShortExceptionMessage
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
+import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
+import com.jetbrains.plugin.structure.jar.PluginJar
+import org.jdom2.Document
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val LOG: Logger = LoggerFactory.getLogger(JarPluginLoader::class.java)
+
+internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProvider) {
+  fun loadPlugin(pluginLoadingContext: PluginLoadingContext): PluginCreator = with(pluginLoadingContext) {
+    val jarFile = artifactPath
+    return try {
+      PluginJar(jarFile, fileSystemProvider).use { jar ->
+        when (val descriptor = jar.getPluginDescriptor("$META_INF/$descriptorPath")) {
+          is Found -> {
+            try {
+              val descriptorXml = descriptor.loadXml()
+              createPlugin(jarFile.simpleName, descriptorPath, parentPlugin, validateDescriptor, descriptorXml, descriptor.path, resourceResolver, problemResolver).apply {
+                setIcons(jar.getIcons())
+                setThirdPartyDependencies(jar.getThirdPartyDependencies())
+                setHasDotNetPart(hasDotNetDirectory)
+              }
+            } catch (e: Exception) {
+              LOG.warn("Unable to read descriptor [$descriptorPath] from [$jarFile]", e)
+              val message = e.localizedMessage
+              createInvalidPlugin(jarFile, descriptorPath, UnableToReadDescriptor(descriptorPath, message))
+            }
+          }
+          else -> createInvalidPlugin(jarFile, descriptorPath, PluginDescriptorIsNotFound(descriptorPath)).also {
+            LOG.debug("Unable to resolve descriptor [{}] from [{}] ({})", descriptorPath, jarFile, descriptor)
+          }
+        }
+      }
+    } catch (e: JarArchiveCannotBeOpenException) {
+      LOG.warn("Unable to extract {} (searching for {}): {}", jarFile, descriptorPath, e.getShortExceptionMessage())
+      createInvalidPlugin(jarFile, descriptorPath, UnableToExtractZip())
+    }
+  }
+
+  private fun Found.loadXml(): Document {
+    return inputStream.use {
+      JDOMUtil.loadDocument(it)
+    }
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory
 
 private val LOG: Logger = LoggerFactory.getLogger(JarPluginLoader::class.java)
 
-internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProvider) {
-  fun loadPlugin(pluginLoadingContext: PluginLoadingContext): PluginCreator = with(pluginLoadingContext) {
+internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProvider) : PluginLoader {
+  override fun loadPlugin(pluginLoadingContext: PluginLoadingContext): PluginCreator = with(pluginLoadingContext) {
     val jarFile = artifactPath
     return try {
       PluginJar(jarFile, fileSystemProvider).use { jar ->

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
+import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.problems.isInvalidDescriptorProblem
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.isZip
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.CreationResult
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.module.ContentModuleScanner
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginLibDirectoryIsEmpty
+import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolver
+import com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import java.nio.file.Path
+
+internal class LibDirectoryPluginLoader(
+  private val pluginLoaderRegistry: PluginLoaderProvider,
+  private val fileSystemProvider: JarFileSystemProvider
+) : PluginLoader<LibDirectoryPluginLoader.Context> {
+
+  private val jarLoader: JarPluginLoader
+    get() = pluginLoaderRegistry.get<JarPluginLoader.Context, JarPluginLoader>()
+
+  private val directoryLoader: PluginDirectoryLoader
+    get() = pluginLoaderRegistry.get<PluginDirectoryLoader.Context, PluginDirectoryLoader>()
+
+  private val contentModuleScanner = ContentModuleScanner(fileSystemProvider)
+
+  override fun loadPlugin(pluginLoadingContext: Context): PluginCreator = with(pluginLoadingContext) {
+    val libDir = libDirectoryParent.resolve("lib")
+    val hasDotNetDirectory = libDirectoryParent.resolve("dotnet").exists()
+    if (!libDir.isDirectory) {
+      return createInvalidPlugin(libDirectoryParent, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
+    }
+    val files = libDir.listFiles()
+    if (files.isEmpty()) {
+      return createInvalidPlugin(libDirectoryParent, descriptorPath, PluginLibDirectoryIsEmpty())
+    }
+    val jarFiles = files.filter { it.isJar() }
+    val libResourceResolver: ResourceResolver = JarsResourceResolver(jarFiles, fileSystemProvider)
+    val compositeResolver: ResourceResolver = CompositeResourceResolver(listOf(libResourceResolver, resourceResolver))
+
+    val results: MutableList<CreationResult> = ArrayList()
+    for (file in files) {
+      val innerCreator: PluginCreator = if (file.isJar() || file.isZip()) {
+        //Use the composite resource resolver, which can resolve resources in lib's jar files.
+        jarLoader.loadPlugin(
+          JarPluginLoader.Context(
+            file,
+            descriptorPath,
+            validateDescriptor,
+            compositeResolver,
+            parentPlugin,
+            problemResolver,
+            hasDotNetDirectory
+          )
+        )
+      } else if (file.isDirectory) {
+        //Use the common resource resolver, which is unaware of lib's jar files.
+        directoryLoader.loadPlugin(PluginDirectoryLoader.Context(
+          pluginDirectory = file,
+          descriptorPath = descriptorPath,
+          validateDescriptor = validateDescriptor,
+          resourceResolver = resourceResolver,
+          parentPlugin = parentPlugin,
+          problemResolver = problemResolver,
+          hasDotNetDirectory = hasDotNetDirectory
+        ))
+      } else {
+        continue
+      }
+      results.add(CreationResult(libDirectoryParent, innerCreator))
+    }
+    val possibleResults = results
+      .filter { (_, r: PluginCreator)  -> r.isSuccess || hasOnlyInvalidDescriptorErrors(r) }
+    return when(possibleResults.size) {
+      0 -> createInvalidPlugin(libDirectoryParent, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
+      1 -> possibleResults[0].withResolvedClasspath().creator
+      else -> {
+        val first = possibleResults[0].creator
+        val second = possibleResults[1].creator
+        val multipleDescriptorsProblem: PluginProblem = MultiplePluginDescriptors(
+          first.descriptorPath,
+          first.pluginFileName,
+          second.descriptorPath,
+          second.pluginFileName
+        )
+        createInvalidPlugin(libDirectoryParent, descriptorPath, multipleDescriptorsProblem)
+      }
+    }
+  }
+
+  private fun CreationResult.withResolvedClasspath(): CreationResult = apply {
+    val contentModules = contentModuleScanner.getContentModules(artifact)
+    val classpath = contentModules.asClasspath()
+    creator.setClasspath(classpath.getUnique())
+  }
+
+  private fun hasOnlyInvalidDescriptorErrors(creator: PluginCreator): Boolean {
+    return when (val pluginCreationResult = creator.pluginCreationResult) {
+      is PluginCreationSuccess<*> -> false
+      is PluginCreationFail<*> -> {
+        val errorsAndWarnings = pluginCreationResult.errorsAndWarnings
+        errorsAndWarnings.all { it.level !== PluginProblem.Level.ERROR || it.isInvalidDescriptorProblem }
+      }
+    }
+  }
+
+  internal data class Context(
+    val libDirectoryParent: Path,
+    val descriptorPath: String,
+    val validateDescriptor: Boolean,
+    override val resourceResolver: ResourceResolver,
+    val parentPlugin: PluginCreator?,
+    override val problemResolver: PluginCreationResultResolver,
+    val hasDotNetDirectory: Boolean = false
+  ) : PluginLoadingContext(
+    resourceResolver,
+    problemResolver,
+  )
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ModuleFromDescriptorLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/ModuleFromDescriptorLoader.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.IOException
+
+private val LOG: Logger = LoggerFactory.getLogger(ModuleFromDescriptorLoader::class.java)
+
+internal class ModuleFromDescriptorLoader : PluginLoader<ModuleFromDescriptorLoader.Context> {
+  override fun loadPlugin(pluginLoadingContext: Context): PluginCreator = with(pluginLoadingContext) {
+    return descriptorResource.inputStream.use {
+      try {
+        val problemResolver = AnyProblemToWarningPluginCreationResultResolver
+        val descriptorXml = JDOMUtil.loadDocument(it)
+        createPlugin(
+          descriptorResource,
+          parentPlugin,
+          descriptorXml,
+          resourceResolver,
+          problemResolver
+        ).also {
+          logPluginCreationWarnings(moduleId, it)
+        }
+      } catch (e: IOException) {
+        with(descriptorResource) {
+          LOG.warn("Unable to read descriptor stream (source: '$uri')", e)
+          val problem = UnableToReadDescriptor(fileName, e.localizedMessage)
+          createInvalidPlugin(artifactFileName, fileName, problem)
+        }
+      }
+    }
+  }
+
+  private fun logPluginCreationWarnings(pluginId: String, pluginCreator: PluginCreator) {
+    val pluginCreationResult = pluginCreator.pluginCreationResult
+    if (LOG.isDebugEnabled && pluginCreationResult is PluginCreationSuccess) {
+      val warningMessage = pluginCreationResult.warnings.joinToString("\n") {
+        it.message
+      }
+      LOG.debug("Plugin or module '$pluginId' has plugin problems: $warningMessage")
+    }
+  }
+
+  internal data class Context(
+    val moduleId: String,
+    val descriptorResource: DescriptorResource,
+    val parentPlugin: PluginCreator? = null,
+    override val resourceResolver: ResourceResolver
+  ) : PluginLoadingContext(
+    resourceResolver,
+    AnyProblemToWarningPluginCreationResultResolver,
+  )
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginDirectoryLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginDirectoryLoader.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
+import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.base.utils.withPathSeparatorOf
+import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import org.jdom2.input.JDOMParseException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(PluginDirectoryLoader::class.java)
+
+internal class PluginDirectoryLoader(private val pluginLoaderRegistry: PluginLoaderProvider) : PluginLoader<PluginDirectoryLoader.Context> {
+  private val libDirectoryLoader: LibDirectoryPluginLoader
+    get() = pluginLoaderRegistry.get<LibDirectoryPluginLoader.Context, LibDirectoryPluginLoader>()
+
+  private val pluginIconLoader = PluginIconLoader()
+
+  private val thirdPartyDependencyLoader = ThirdPartyDependencyLoader()
+
+  override fun loadPlugin(pluginLoadingContext: Context): PluginCreator = with(pluginLoadingContext) {
+    val descriptorFile = pluginDirectory.resolve(META_INF).resolve(descriptorPath.withPathSeparatorOf(pluginDirectory))
+    return if (!descriptorFile.exists()) {
+      libDirectoryLoader
+        .loadPlugin(
+          LibDirectoryPluginLoader.Context(
+            pluginDirectory,
+            descriptorPath,
+            validateDescriptor,
+            resourceResolver,
+            parentPlugin,
+            problemResolver
+          )
+        )
+    } else try {
+      val document = JDOMUtil.loadDocument(Files.newInputStream(descriptorFile))
+      val icons = pluginIconLoader.load(pluginDirectory)
+      val dependencies = thirdPartyDependencyLoader.load(pluginDirectory)
+      createPlugin(
+        pluginDirectory.simpleName, descriptorPath, parentPlugin,
+        validateDescriptor, document, descriptorFile,
+        resourceResolver, problemResolver
+      ).apply {
+        setIcons(icons)
+        setThirdPartyDependencies(dependencies)
+        setHasDotNetPart(hasDotNetDirectory)
+      }
+    } catch (e: JDOMParseException) {
+      LOG.info("Unable to parse plugin descriptor $descriptorPath of plugin $descriptorFile", e)
+      createInvalidPlugin(pluginDirectory, descriptorPath, UnexpectedDescriptorElements(e.lineNumber, descriptorPath))
+    } catch (e: Exception) {
+      LOG.info("Unable to read plugin descriptor $descriptorPath of plugin $descriptorFile", e)
+      createInvalidPlugin(pluginDirectory, descriptorPath, UnableToReadDescriptor(descriptorPath, descriptorPath))
+    }
+  }
+
+  internal data class Context(
+    val pluginDirectory: Path,
+    val descriptorPath: String,
+    val validateDescriptor: Boolean,
+    override val resourceResolver: ResourceResolver,
+    val parentPlugin: PluginCreator?,
+    override val problemResolver: PluginCreationResultResolver,
+    val hasDotNetDirectory: Boolean = false
+  ) : PluginLoadingContext(
+    resourceResolver,
+    problemResolver,
+  )
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoader.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+
+internal interface PluginLoader {
+  fun loadPlugin(pluginLoadingContext: PluginLoadingContext): PluginCreator
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoader.kt
@@ -6,6 +6,6 @@ package com.jetbrains.plugin.structure.intellij.plugin.loaders
 
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 
-internal interface PluginLoader {
-  fun loadPlugin(pluginLoadingContext: PluginLoadingContext): PluginCreator
+internal interface PluginLoader<C : PluginLoadingContext> {
+  fun loadPlugin(pluginLoadingContext: C): PluginCreator
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoaderProvider.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoaderProvider.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+internal class PluginLoaderProvider {
+  private val loaderRegistry = HashMap<String, PluginLoader<*>>()
+
+  internal fun <C : PluginLoadingContext> register(contextClass: Class<out C>, loader: PluginLoader<C>) {
+    loaderRegistry[contextClass.name] = loader
+  }
+  @Throws(NoSuchElementException::class)
+  internal fun <C : PluginLoadingContext> get(contextClass: Class<out C>): PluginLoader<C> {
+    @Suppress("UNCHECKED_CAST")
+    return loaderRegistry.getValue(contextClass.name) as PluginLoader<C>
+  }
+
+  @Throws(NoSuchElementException::class)
+  internal inline fun <reified T : PluginLoadingContext, reified L : PluginLoader<T>> get(): L {
+    return get(T::class.java) as L
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoaders.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoaders.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
+import org.jdom2.Document
+
+internal fun PluginDescriptorResult.Found.loadXml(): Document = inputStream.use {
+  JDOMUtil.loadDocument(it)
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
@@ -9,12 +9,31 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultReso
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-internal data class PluginLoadingContext(
-  val artifactPath: Path,
-  val descriptorPath: String,
-  val validateDescriptor: Boolean,
-  val resourceResolver: ResourceResolver,
-  val parentPlugin: PluginCreator?,
-  val problemResolver: PluginCreationResultResolver,
-  val hasDotNetDirectory: Boolean = false
+internal sealed class PluginLoadingContext(
+  open val artifactPath: Path,
+  open val descriptorPath: String,
+  open val validateDescriptor: Boolean,
+  open val resourceResolver: ResourceResolver,
+  open val parentPlugin: PluginCreator?,
+  open val problemResolver: PluginCreationResultResolver,
+  open val hasDotNetDirectory: Boolean = false
 )
+
+internal data class JarLoadingContext(
+  val jarPath: Path,
+  override val descriptorPath: String,
+  override val validateDescriptor: Boolean,
+  override val resourceResolver: ResourceResolver,
+  override val parentPlugin: PluginCreator?,
+  override val problemResolver: PluginCreationResultResolver,
+  override val hasDotNetDirectory: Boolean = false
+) : PluginLoadingContext(
+  jarPath,
+  descriptorPath,
+  validateDescriptor,
+  resourceResolver,
+  parentPlugin,
+  problemResolver,
+  hasDotNetDirectory
+)
+

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import java.nio.file.Path
+
+internal data class PluginLoadingContext(
+  val artifactPath: Path,
+  val descriptorPath: String,
+  val validateDescriptor: Boolean,
+  val resourceResolver: ResourceResolver,
+  val parentPlugin: PluginCreator?,
+  val problemResolver: PluginCreationResultResolver,
+  val hasDotNetDirectory: Boolean = false
+)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginLoadingContext.kt
@@ -4,36 +4,11 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin.loaders
 
-import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
-import java.nio.file.Path
 
-internal sealed class PluginLoadingContext(
-  open val artifactPath: Path,
-  open val descriptorPath: String,
-  open val validateDescriptor: Boolean,
+internal open class PluginLoadingContext(
   open val resourceResolver: ResourceResolver,
-  open val parentPlugin: PluginCreator?,
   open val problemResolver: PluginCreationResultResolver,
-  open val hasDotNetDirectory: Boolean = false
-)
-
-internal data class JarLoadingContext(
-  val jarPath: Path,
-  override val descriptorPath: String,
-  override val validateDescriptor: Boolean,
-  override val resourceResolver: ResourceResolver,
-  override val parentPlugin: PluginCreator?,
-  override val problemResolver: PluginCreationResultResolver,
-  override val hasDotNetDirectory: Boolean = false
-) : PluginLoadingContext(
-  jarPath,
-  descriptorPath,
-  validateDescriptor,
-  resourceResolver,
-  parentPlugin,
-  problemResolver,
-  hasDotNetDirectory
 )
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/FileBasedModuleDescriptorResolver.kt
@@ -11,13 +11,13 @@ import com.jetbrains.plugin.structure.intellij.plugin.Module.FileBasedModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleDescriptor
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
-import com.jetbrains.plugin.structure.intellij.plugin.PluginLoader
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarOrDirectoryPluginLoader
 import com.jetbrains.plugin.structure.intellij.problems.ModuleDescriptorResolutionProblem
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import java.nio.file.Path
 
-internal class FileBasedModuleDescriptorResolver(private val pluginLoader: PluginLoader) :
+internal class FileBasedModuleDescriptorResolver(private val pluginLoader: JarOrDirectoryPluginLoader) :
   ModuleDescriptorResolver<FileBasedModule>() {
 
   override fun getModuleDescriptor(
@@ -44,14 +44,14 @@ internal class FileBasedModuleDescriptorResolver(private val pluginLoader: Plugi
     resourceResolver: ResourceResolver,
     problemResolver: PluginCreationResultResolver
   ): PluginCreator {
-    return pluginLoader.load(
+    return pluginLoader.loadPlugin(JarOrDirectoryPluginLoader.Context(
       pluginArtifactPath,
       moduleReference.configFile,
       false,
       resourceResolver,
       pluginCreator,
       problemResolver
-    )
+    ))
   }
 
   override fun getProblem(moduleReference: FileBasedModule, errors: List<PluginProblem>): PluginProblem {

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolverTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/InlineModuleDescriptorResolverTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.Module.InlineModule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginV2Dependency
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.ModuleFromDescriptorLoader
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -49,7 +50,8 @@ class InlineModuleDescriptorResolverTest {
       contentModules += thymeleafSpringElInlineModule
     }
 
-    val resolver = InlineModuleDescriptorResolver()
+    val loader = ModuleFromDescriptorLoader()
+    val resolver = InlineModuleDescriptorResolver(loader)
     val dependencies = resolver.getDependencies(thymeleafPlugin, thymeleafSpringElPlugin, thymeleafSpringElInlineModule)
     with(dependencies) {
       assertEquals(1, size)
@@ -102,7 +104,8 @@ class InlineModuleDescriptorResolverTest {
       contentModules += intellijTomJsonInlineModule
     }
 
-    val resolver = InlineModuleDescriptorResolver()
+    val loader = ModuleFromDescriptorLoader()
+    val resolver = InlineModuleDescriptorResolver(loader)
     val dependencies = resolver.getDependencies(tomlPlugin, intellijTomJsonPlugin, intellijTomJsonInlineModule)
     with(dependencies) {
       assertEquals(1, size)


### PR DESCRIPTION
Split `PluginCreator` into distinct classes. Each class is handling a specific resource that will provide a plugin.

- Introduce a `PluginLoadingContext` as a type-safe holder for plugin loading parameters
- Introduce loaders:
  * `JarModuleLoader` constructs bundled modules
  * `JarOrDirectoryPluginLoader` loads plugins from either a JAR or a extracted plugin directory
  * `JarPluginLoader` loads a plugin from a JAR archive
  * `LibDirectoryLoader` loads a plugin from the `lib` directory of the plugin
  * `ModuleFromDescriptorLoader` loads a plugin module from a file or from an inline CDATA declaration
  * `PluginDirectoryLoader` loads a plugin from an extracted directory

  The plugin loading logic might be intertwined. One plugin loader might delegate to another loader.
  Introduce `PluginLoaderProvider` as a registry of plugin loaders that provides a necessary specific loader according to requirements or available context.