### PR TITLE
Increase unpacked IntelliJ plugin size to 5GB

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/Settings.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/plugin/Settings.kt
@@ -4,14 +4,14 @@
 
 package com.jetbrains.plugin.structure.base.plugin
 
-import com.jetbrains.plugin.structure.base.utils.ONE_POINT_FIVE_GB
+import com.jetbrains.plugin.structure.base.utils.FIVE_GB
 import org.apache.commons.io.FileUtils
 import java.nio.file.Path
 import java.nio.file.Paths
 
 enum class Settings(private val key: String, private val defaultValue: () -> String) {
   EXTRACT_DIRECTORY("intellij.structure.temp.dir", { Paths.get(FileUtils.getTempDirectory().absolutePath).resolve("extracted-plugins").toString() }),
-  INTELLIJ_PLUGIN_SIZE_LIMIT("intellij.structure.intellij.plugin.size.limit", { ONE_POINT_FIVE_GB.toString() }),
+  INTELLIJ_PLUGIN_SIZE_LIMIT("intellij.structure.intellij.plugin.size.limit", { FIVE_GB.toString() }),
   FLEET_PLUGIN_SIZE_LIMIT("intellij.structure.fleet.plugin.size.limit", { FileUtils.ONE_GB.toString() }),
   TOOLBOX_PLUGIN_SIZE_LIMIT("intellij.structure.toolbox.plugin.size.limit", { FileUtils.ONE_GB.toString() }),
   TEAM_CITY_PLUGIN_SIZE_LIMIT("intellij.structure.team.city.plugin.size.limit", { FileUtils.ONE_GB.toString() }),

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
 package com.jetbrains.plugin.structure.base.utils
@@ -22,6 +22,7 @@ import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.stream.Collectors
+import kotlin.streams.toList
 
 private val LOG = LoggerFactory.getLogger("structure.FileUtil")
 
@@ -38,7 +39,8 @@ fun Path.hasExtension(expected: String) =
   Files.isRegularFile(this) && expected == extension
 
 fun Path.listRecursivelyAllFilesWithExtension(extension: String) =
-  Files.walk(this, FileVisitOption.FOLLOW_LINKS).use { stream -> stream.filter { it.toString().endsWith(".${extension}") }.toList() }
+  Files.walk(this, FileVisitOption.FOLLOW_LINKS)
+    .use { stream -> stream.filter { it.toString().endsWith(".${extension}") }.toList() }
 
 fun String.withPathSeparatorOf(path: Path) = replace('\\', '/').replace("/", path.fileSystem.separator)
 fun String.withZipFsSeparator() = replace('\\', '/')

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/utils/FileUtil.kt
@@ -22,14 +22,13 @@ import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.stream.Collectors
-import kotlin.streams.toList
 
 private val LOG = LoggerFactory.getLogger("structure.FileUtil")
 
 typealias Bytes = Long
 
 internal val ONE_GB_BD = BigDecimal(ONE_GB)
-internal val ONE_POINT_FIVE_GB = BigDecimal("1.5").multiply(ONE_GB_BD).toLong()
+internal val FIVE_GB = BigDecimal("5").multiply(ONE_GB_BD).toLong()
 
 fun Path.isZip(): Boolean = this.hasExtension("zip")
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/plugin/SettingsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/plugin/SettingsTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class SettingsTest {
   @Test
-  fun `1_5GB is the IntelliJ plugin size limit`() {
-    assertEquals(1_610_612_736L,Settings.INTELLIJ_PLUGIN_SIZE_LIMIT.getAsLong())
+  fun `5GB is the IntelliJ plugin size limit`() {
+    assertEquals(5_368_709_120L,Settings.INTELLIJ_PLUGIN_SIZE_LIMIT.getAsLong())
   }
 }


### PR DESCRIPTION
There are plugins which contain platform-specific binaries. After decompression, they surpass the original limit.

Increase this limit to 5GB.