### PR TITLE
Fix the `supportedProducts` field in fleet plugin descriptor

### DIFF
--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -54,11 +54,8 @@ data class FleetPluginDescriptor(
       problems.add(PropertyNotSpecified(metaSpec.relativeFieldPath(metaSpec.VENDOR_FIELD_NAME)))
     }
 
-    val supportedProducts = meta?.supportedProducts ?: emptySet()
-    val products = meta
-      ?.supportedProducts
-      ?.mapNotNull { FleetProduct.fromProductCode(it) }
-      ?.toSet() ?: emptySet()
+    val supportedProducts = meta?.getSupportedProductCodes() ?: emptySet()
+    val products = supportedProducts.mapNotNull { FleetProduct.fromProductCode(it) }.toSet()
 
     if (products.size != supportedProducts.size) {
       problems.add(InvalidSupportedProductsListProblem(
@@ -159,7 +156,7 @@ data class FleetPluginDescriptor(
   private fun parseVersionOrNull(version: String): Semver? {
     return try {
       Semver(version)
-    } catch (e: SemverException) {
+    } catch (_: SemverException) {
       null
     }
   }
@@ -208,8 +205,15 @@ data class FleetMeta(
   @JsonProperty(FleetDescriptorSpec.Meta.HUMAN_VISIBLE_FIELD_NAME)
   val humanVisible: Boolean?,
   @JsonProperty(FleetDescriptorSpec.Meta.SUPPORTED_PRODUCTS_FIELD_NAME)
-  val supportedProducts: Set<String>? = emptySet(),
-)
+  private val supportedProducts: String? = null
+) {
+  fun getSupportedProductCodes(): Set<String> {
+    if (supportedProducts.isNullOrBlank()) return emptySet()
+    return supportedProducts
+      .split(",")
+      .toSet()
+  }
+}
 
 data class FleetShipVersionRange(
   @JsonProperty(FleetDescriptorSpec.CompatibleShipVersion.FROM_FIELD_NAME)

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginManager.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginManager.kt
@@ -107,7 +107,7 @@ class FleetPluginManager private constructor(private val extractDirectory: Path)
         description = descriptor.meta?.description,
         vendor = descriptor.meta?.vendor,
         humanVisible = descriptor.meta?.humanVisible ?: true,
-        supportedProducts = descriptor.meta?.supportedProducts ?: emptySet(),
+        supportedProducts = descriptor.meta?.getSupportedProductCodes() ?: emptySet(),
         icons = icons,
         descriptorFileName = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
         frontendOnly = descriptor.meta?.frontendOnly,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -80,27 +80,27 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `invalid supported product`() {
-    val supportedProducts = setOf("LOL")
+    val supportedProducts = "LOL"
     checkInvalidPlugin(
-      InvalidSupportedProductsListProblem("must contain only product codes from ${FleetProduct.values().map { it.productCode }}, got: $supportedProducts")
+      InvalidSupportedProductsListProblem("must contain only product codes from ${FleetProduct.values().map { it.productCode }}, got: [$supportedProducts]")
     ) { it.copy(meta = it.meta?.copy(supportedProducts = supportedProducts)) }
   }
 
   @Test
   fun `mix of legacy and unified versioning in supported product`() {
     checkInvalidPlugin(InvalidSupportedProductsListProblem("must contain either only legacy or only unified versioning products")) {
-      it.copy(meta = it.meta?.copy(supportedProducts = setOf("FL", "AIR")))
+      it.copy(meta = it.meta?.copy(supportedProducts = "FL,AIR"))
     }
   }
 
   @Test
   fun `legacy versioning product`() {
-    checkValidPlugin { it.copy(meta = it.meta?.copy(supportedProducts = setOf("FL"))) }
+    checkValidPlugin { it.copy(meta = it.meta?.copy(supportedProducts = "FL")) }
   }
 
   @Test
   fun `unified versioning product`() {
-    checkValidPlugin { it.copy(meta = it.meta?.copy(supportedProducts = setOf("AIR"))) }
+    checkValidPlugin { it.copy(meta = it.meta?.copy(supportedProducts = "AIR")) }
   }
 
   @Test
@@ -118,7 +118,7 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `legacy compatibility range is valid`() {
-    val supportedProducts = setOf("FL")
+    val supportedProducts = "FL"
     val legacyVersioningSpec = FleetDescriptorSpec.CompatibleShipVersion.LegacyVersioningSpec
 
     checkInvalidPlugin(InvalidSemverFormat(
@@ -236,7 +236,7 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `unified compatibility range is valid`() {
-    val supportedProducts = setOf("AIR")
+    val supportedProducts = "AIR"
     val legacyVersioningSpec = FleetDescriptorSpec.CompatibleShipVersion.UnifiedVersioningSpec
 
     checkInvalidPlugin(InvalidSemverFormat(

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetPluginMockTest.kt
@@ -125,6 +125,7 @@ class FleetPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTes
     assertEquals("JetBrains", plugin.vendor)
     assertEquals("CSS language support", plugin.description)
     assertEquals("1.0.0-SNAPSHOT", plugin.pluginVersion)
+    assertEquals(setOf("AIR", "AINEXT"), plugin.supportedProducts)
     assertEquals(FleetShipVersionRange("1.1000.1", "1.1001.10"), plugin.compatibleShipVersionRange)
     assertEquals(true, plugin.frontendOnly)
   }

--- a/intellij-plugin-structure/tests/src/test/resources/fleet/extension.json
+++ b/intellij-plugin-structure/tests/src/test/resources/fleet/extension.json
@@ -7,7 +7,8 @@
     "readableName": "CSS",
     "description": "CSS language support",
     "vendor": "JetBrains",
-    "visible": "false"
+    "visible": "false",
+    "supportedProducts": "AIR,AINEXT"
   },
   "compatibleShipVersionRange": {
     "from": "1.1000.1",


### PR DESCRIPTION
Fleet API is required to use a backward and forward compatible loose string to string map format. 

Use comma separated list for supported products, instead of JSON arrays.