### PR TITLE
Local plugin repository honors problem remapping and allows to ignore IDE compatibility rules

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -110,7 +110,7 @@ object PluginVerifierMain {
     val outputOptions = OptionsParser.parseOutputOptions(opts)
 
     val pluginRepository = if (opts.offlineMode) {
-      LocalPluginRepositoryFactory.createLocalPluginRepository(downloadDirectory)
+      LocalPluginRepositoryFactory.createLocalPluginRepository(downloadDirectory, opts.forceOfflineCompatibility)
     } else {
       MarketplaceRepository(URL(pluginRepositoryUrl))
     }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -26,6 +26,9 @@ open class CmdOpts(
   @set:Argument("offline", alias = "offline", description = "Specify this flag if the Plugin Verifier must use only locally downloaded dependencies of plugins")
   var offlineMode: Boolean = false,
 
+  @set:Argument("force-offline-compatibility", description = "When using offline mode, consider any plugin in the local plugin repository to be compatible with the major or trunk IDE. This applies to 'check-trunk-api' command only.")
+  var forceOfflineCompatibility: Boolean = false,
+
   @set:Argument("tc-grouping", alias = "g", description = "How to group the TeamCity presentation of the problems: either 'plugin' to group by each plugin or 'problem_type' to group by problem type")
   var teamCityGroupType: String? = null,
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginParsingConfigurationResolution.kt
@@ -1,6 +1,9 @@
 package com.jetbrains.pluginverifier.options
 
-import com.jetbrains.plugin.structure.intellij.problems.*
+import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.LevelRemappingPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.remapping.JsonUrlProblemLevelRemappingManager
 import com.jetbrains.plugin.structure.intellij.problems.remapping.ProblemLevelRemappingManager
 import com.jetbrains.plugin.structure.intellij.problems.remapping.RemappingSet
 import com.jetbrains.plugin.structure.intellij.problems.remapping.ignored.CliIgnoredProblemLevelRemappingManager
@@ -24,5 +27,16 @@ class PluginParsingConfigurationResolution {
     val cliIgnoredProblems = CliIgnoredProblemLevelRemappingManager(configuration.ignoredPluginProblems).asLevelRemappingDefinition()
     return LevelRemappingPluginCreationResultResolver(this, cliIgnoredProblems, unwrapRemappedProblems = true)
   }
-}
 
+  companion object {
+    fun of(opts: CmdOpts): PluginCreationResultResolver {
+      val config = OptionsParser.createPluginParsingConfiguration(opts)
+      return of(config)
+    }
+
+    fun of(configuration: PluginParsingConfiguration): PluginCreationResultResolver {
+      val remappingManager = JsonUrlProblemLevelRemappingManager.fromClassPathJson()
+      return PluginParsingConfigurationResolution().resolveProblemLevelMapping(configuration, remappingManager)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginsParsing.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginsParsing.kt
@@ -12,8 +12,6 @@ import com.jetbrains.plugin.structure.base.utils.readLines
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.caches.PluginResourceCache
-import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
-import com.jetbrains.plugin.structure.intellij.problems.remapping.JsonUrlProblemLevelRemappingManager
 import com.jetbrains.plugin.structure.intellij.resources.ZipPluginResource
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.dependencies.resolution.LastVersionSelector
@@ -39,8 +37,6 @@ class PluginsParsing(
   private val pluginsSet: PluginsSet,
   private val configuration: PluginParsingConfiguration = PluginParsingConfiguration()
 ) {
-
-  private val pluginParsingConfigurationResolution = PluginParsingConfigurationResolution()
 
   /**
    * Parses command line options and add specified plugins compatible with [ideVersion].
@@ -225,7 +221,7 @@ class PluginsParsing(
       .createPlugin(
         pluginFile,
         validateDescriptor,
-        problemResolver = configuration.problemResolver,
+        problemResolver = PluginParsingConfigurationResolution.of(configuration),
         // No need to delete the directory, as it will be cached by 'extractedPluginCache'
         deleteExtractedDirectory = false
       )
@@ -248,9 +244,6 @@ class PluginsParsing(
   private fun reportLocalPluginTelemetry(plugin: IdePlugin, telemetry: PluginTelemetry) {
     reportage.reportTelemetry(LocalPluginInfo(plugin), telemetry)
   }
-
-  private val PluginParsingConfiguration.problemResolver: PluginCreationResultResolver
-    get() = pluginParsingConfigurationResolution.resolveProblemLevelMapping(this, JsonUrlProblemLevelRemappingManager.fromClassPathJson())
 
   private fun PluginCreationSuccess<IdePlugin>.cacheExtractedPlugins() {
     resources

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/repository/LocalPluginRepositoryProvider.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/repository/LocalPluginRepositoryProvider.kt
@@ -4,19 +4,13 @@
 
 package com.jetbrains.pluginverifier.options.repository
 
-import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
-import com.jetbrains.plugin.structure.intellij.problems.remapping.JsonUrlProblemLevelRemappingManager
 import com.jetbrains.pluginverifier.options.CmdOpts
-import com.jetbrains.pluginverifier.options.OptionsParser
-import com.jetbrains.pluginverifier.options.PluginParsingConfiguration
 import com.jetbrains.pluginverifier.options.PluginParsingConfigurationResolution
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
 import java.nio.file.Path
 
 object LocalPluginRepositoryProvider {
-
-  private val pluginParsingConfigurationResolution = PluginParsingConfigurationResolution()
 
   fun getLocalPluginRepository(opts: CmdOpts, downloadDirectory: Path): Result {
     return if (!opts.offlineMode) {
@@ -25,20 +19,10 @@ object LocalPluginRepositoryProvider {
       LocalPluginRepositoryFactory.createLocalPluginRepository(
         downloadDirectory,
         opts.forceOfflineCompatibility,
-        opts.problemResolver
+        PluginParsingConfigurationResolution.of(opts)
       ).let { Result.Provided(it) }
     }
   }
-
-  // TODO duplicate with PluginsParsing
-  private val PluginParsingConfiguration.problemResolver: PluginCreationResultResolver
-    get() = pluginParsingConfigurationResolution.resolveProblemLevelMapping(
-      this,
-      JsonUrlProblemLevelRemappingManager.fromClassPathJson()
-    )
-
-  private val CmdOpts.problemResolver: PluginCreationResultResolver
-    get() = OptionsParser.createPluginParsingConfiguration(this).problemResolver
 
   sealed class Result {
     data class Provided(val pluginRepository: PluginRepository) : Result()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/repository/LocalPluginRepositoryProvider.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/repository/LocalPluginRepositoryProvider.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.options.repository
+
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.remapping.JsonUrlProblemLevelRemappingManager
+import com.jetbrains.pluginverifier.options.CmdOpts
+import com.jetbrains.pluginverifier.options.OptionsParser
+import com.jetbrains.pluginverifier.options.PluginParsingConfiguration
+import com.jetbrains.pluginverifier.options.PluginParsingConfigurationResolution
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
+import java.nio.file.Path
+
+object LocalPluginRepositoryProvider {
+
+  private val pluginParsingConfigurationResolution = PluginParsingConfigurationResolution()
+
+  fun getLocalPluginRepository(opts: CmdOpts, downloadDirectory: Path): Result {
+    return if (!opts.offlineMode) {
+      Result.Unavailable
+    } else {
+      LocalPluginRepositoryFactory.createLocalPluginRepository(
+        downloadDirectory,
+        opts.forceOfflineCompatibility,
+        opts.problemResolver
+      ).let { Result.Provided(it) }
+    }
+  }
+
+  // TODO duplicate with PluginsParsing
+  private val PluginParsingConfiguration.problemResolver: PluginCreationResultResolver
+    get() = pluginParsingConfigurationResolution.resolveProblemLevelMapping(
+      this,
+      JsonUrlProblemLevelRemappingManager.fromClassPathJson()
+    )
+
+  private val CmdOpts.problemResolver: PluginCreationResultResolver
+    get() = OptionsParser.createPluginParsingConfiguration(this).problemResolver
+
+  sealed class Result {
+    data class Provided(val pluginRepository: PluginRepository) : Result()
+    object Unavailable : Result()
+  }
+}

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/processAllPlugins/ProcessAllPluginsCommand.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/processAllPlugins/ProcessAllPluginsCommand.kt
@@ -60,7 +60,10 @@ class ProcessAllPluginsCommand : CommandRunner {
       val compatiblePluginsList = pluginRepository.retry("Request plugins compatible with ${ideDescriptor.ideVersion}") {
         getLastCompatiblePlugins(ideDescriptor.ideVersion)
       }
-      val localPluginRepository = LocalPluginRepositoryFactory.createLocalPluginRepository(idePluginsRoot)
+      val localPluginRepository = LocalPluginRepositoryFactory.createLocalPluginRepository(
+        idePluginsRoot,
+        opts.forceOfflineCompatibility
+      )
       val additionalIdePlugins = localPluginRepository.getLastCompatiblePlugins(ideDescriptor.ideVersion)
 
       return CountUsagesOfExtensionPointsParameters(ideDescriptor, additionalIdePlugins, compatiblePluginsList, outputJson)

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/CompatibilityPredicate.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/CompatibilityPredicate.kt
@@ -18,9 +18,5 @@ fun interface CompatibilityPredicate {
     val DEFAULT : CompatibilityPredicate = CompatibilityPredicate { pluginInfo, ideVersion ->
       pluginInfo.isCompatibleWith(ideVersion)
     }
-
-    fun of(ideVersion: IdeVersion) {
-
-    }
   }
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/CompatibilityPredicate.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/CompatibilityPredicate.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.repository.repositories
+
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.repository.PluginInfo
+
+fun interface CompatibilityPredicate {
+  fun isCompatible(pluginInfo: PluginInfo, ideVersion: IdeVersion): Boolean
+
+  companion object {
+    @JvmField
+    val ALWAYS_COMPATIBLE = CompatibilityPredicate { _, _ -> true }
+
+    @JvmField
+    val DEFAULT : CompatibilityPredicate = CompatibilityPredicate { pluginInfo, ideVersion ->
+      pluginInfo.isCompatibleWith(ideVersion)
+    }
+
+    fun of(ideVersion: IdeVersion) {
+
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
@@ -26,10 +26,15 @@ object LocalPluginRepositoryFactory {
   /**
    * Creates a [LocalPluginRepository] by parsing
    * all [plugin][com.jetbrains.plugin.structure.intellij.plugin.IdePlugin] files under the [repositoryRoot].
+   *
+   * @param repositoryRoot a root of the local plugin repository that contains plugin artifacts.
+   * @param forcePluginCompatibility if `true`, plugins in this repository are compatible with any IDE.
+   * No _since build_ or _until build_ checks are made.
+   * @param problemRemapper plugin problem remapper used for plugin construction.
    */
   fun createLocalPluginRepository(
     repositoryRoot: Path,
-    forceOfflineCompatibility: Boolean,
+    forcePluginCompatibility: Boolean,
     problemRemapper: PluginCreationResultResolver = IntelliJPluginCreationResultResolver()
   ): PluginRepository {
     val pluginFiles = Files.list(repositoryRoot).use { stream ->
@@ -38,7 +43,7 @@ object LocalPluginRepositoryFactory {
         .toList()
     }
 
-    val localPluginRepository = LocalPluginRepository(compatibilityPredicate = forceOfflineCompatibility.asPredicate())
+    val localPluginRepository = LocalPluginRepository(compatibilityPredicate = forcePluginCompatibility.asPredicate())
     for (pluginFile in pluginFiles) {
       IdePluginManager
         .createManager()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
@@ -19,13 +19,13 @@ import java.nio.file.Path
 import kotlin.streams.toList
 
 /**
- * Utility class that [creates] [createLocalPluginRepository] the [LocalPluginRepository].
+ * Utility class that [creates][createLocalPluginRepository] the [LocalPluginRepository].
  */
 object LocalPluginRepositoryFactory {
 
   /**
    * Creates a [LocalPluginRepository] by parsing
-   * all [plugin] [com.jetbrains.plugin.structure.intellij.plugin.IdePlugin] files under the [repositoryRoot].
+   * all [plugin][com.jetbrains.plugin.structure.intellij.plugin.IdePlugin] files under the [repositoryRoot].
    */
   fun createLocalPluginRepository(
     repositoryRoot: Path,

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/repositories/local/LocalPluginRepositoryFactory.kt
@@ -10,6 +10,8 @@ import com.jetbrains.plugin.structure.base.utils.extension
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.CompatibilityPredicate.Companion.ALWAYS_COMPATIBLE
+import com.jetbrains.pluginverifier.repository.repositories.CompatibilityPredicate.Companion.DEFAULT
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory.createLocalPluginRepository
 import java.nio.file.Files
 import java.nio.file.Path
@@ -24,14 +26,14 @@ object LocalPluginRepositoryFactory {
    * Creates a [LocalPluginRepository] by parsing
    * all [plugin] [com.jetbrains.plugin.structure.intellij.plugin.IdePlugin] files under the [repositoryRoot].
    */
-  fun createLocalPluginRepository(repositoryRoot: Path): PluginRepository {
+  fun createLocalPluginRepository(repositoryRoot: Path, forceOfflineCompatibility: Boolean): PluginRepository {
     val pluginFiles = Files.list(repositoryRoot).use { stream ->
       stream
         .filter { it.isDirectory || it.extension == "zip" || it.extension == "jar" }
         .toList()
     }
 
-    val localPluginRepository = LocalPluginRepository()
+    val localPluginRepository = LocalPluginRepository(compatibilityPredicate = forceOfflineCompatibility.asPredicate())
     for (pluginFile in pluginFiles) {
       with(IdePluginManager.createManager().createPlugin(pluginFile)) {
         when (this) {
@@ -43,4 +45,6 @@ object LocalPluginRepositoryFactory {
     return localPluginRepository
   }
 
+  private fun Boolean.asPredicate() =
+    if (this) ALWAYS_COMPATIBLE else DEFAULT
 }


### PR DESCRIPTION
- Make the local plugin repository honor plugin problem remapping provided by the CLI.  
- Allow the local repository to be configured with a predicate that indicates compatibility between a plugin and an IDE.  
- Introduce the `-force-offline-compatibility` CLI parameter. When enabled, the `check-plugin-api` command in `-offline` mode will treat any plugin in the local repository as compatible with the major or trunk IDE. This is used for local investigations or tracing API compatibility checks for batches of plugins.
