### PR TITLE
Consolidate ZIP-based plugin handling in tests

### DIFF
--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.base.utils.isDirectory
+import com.jetbrains.plugin.structure.base.utils.listFiles
+import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.PluginArchiveResource
+import com.jetbrains.plugin.structure.mocks.IdePluginManagerTest
+import com.jetbrains.plugin.structure.mocks.modify
+import com.jetbrains.plugin.structure.mocks.perfectXmlBuilder
+import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.Assert.*
+import org.junit.Test
+import java.nio.file.Path
+
+class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
+  @Test
+  fun `plugin is extracted, successfully constructed and the extraction directory is not deleted`() {
+    val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
+      pluginManager.createPlugin(
+        pluginArtifactPath,
+        validateDescriptor = true,
+        problemResolver = AnyProblemToWarningPluginCreationResultResolver,
+        deleteExtractedDirectory = false
+      )
+    }
+
+    val pluginArtifactPath = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
+      dir("plugin") {
+        dir("lib") {
+          zip("plugin.jar") {
+            dir("META-INF") {
+              file("plugin.xml") { perfectXmlBuilder.modify { } }
+            }
+          }
+        }
+      }
+    }
+    val successResult = createPluginSuccessfully(pluginArtifactPath, pluginFactory)
+    assertEquals(1, successResult.resources.size)
+    val resource = successResult.resources.first()
+    assertTrue(resource is PluginArchiveResource)
+    resource as PluginArchiveResource
+    assertTrue(resource.extractedPath.isDirectory)
+    resource.delete()
+    assertFalse(resource.extractedPath.isDirectory)
+  }
+
+  @Test
+  fun `plugin is extracted, intentionally failed on construction, but the extraction directory is automatically deleted`() {
+    val failingProblemRemapper = object : PluginCreationResultResolver {
+      override fun resolve(plugin: IdePlugin, problems: List<PluginProblem> ): PluginCreationResult<IdePlugin> {
+        return PluginCreationFail(problems)
+      }
+    }
+
+    val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
+      pluginManager.createPlugin(
+        pluginArtifactPath,
+        validateDescriptor = true,
+        problemResolver = failingProblemRemapper,
+        deleteExtractedDirectory = false
+      )
+    }
+
+    val pluginArtifactPath = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
+      dir("plugin") {
+        dir("lib") {
+          zip("plugin.jar") {
+            dir("META-INF") {
+              file("plugin.xml") { perfectXmlBuilder.modify { } }
+            }
+          }
+        }
+      }
+    }
+    val creationResult = assertProblematicPlugin(pluginArtifactPath, emptyList(), pluginFactory)
+    assertEquals(emptyList<Path>(), extractedDirectory.listFiles())
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
@@ -17,6 +17,7 @@ import com.jetbrains.plugin.structure.mocks.IdePluginManagerTest
 import com.jetbrains.plugin.structure.mocks.modify
 import com.jetbrains.plugin.structure.mocks.perfectXmlBuilder
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Test
 import java.nio.file.Path
@@ -82,7 +83,12 @@ class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTes
         }
       }
     }
-    val creationResult = assertProblematicPlugin(pluginArtifactPath, emptyList(), pluginFactory)
+    assertProblematicPlugin(pluginArtifactPath, emptyList(), pluginFactory)
     assertEquals(emptyList<Path>(), extractedDirectory.listFiles())
+  }
+
+  @After
+  fun tearDown() {
+    close()
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/DefinedModulesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/DefinedModulesTest.kt
@@ -2,9 +2,10 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.nio.file.Paths
-import org.junit.Assert.assertEquals
 
 class DefinedModulesTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
 
@@ -185,5 +186,10 @@ class DefinedModulesTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         expectedModules.forEach {
             assert(modules.contains(it)) { "There is no module $it" }
         }
+    }
+
+    @After
+    fun tearDown() {
+        close()
     }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
@@ -2,17 +2,26 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
+import com.jetbrains.plugin.structure.base.utils.closeAll
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
+import com.jetbrains.plugin.structure.intellij.plugin.createIdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.JetBrainsPluginCreationResultResolver
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.assertEquals
+import java.io.Closeable
 import java.nio.file.Path
 
-abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
+abstract class IdePluginManagerTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType), Closeable {
+  private val closeables = mutableListOf<Closeable>()
+
+  override fun createManager(extractDirectory: Path): IdePluginManager {
+    val archiveManager = createArchiveManager(extractDirectory)
+    closeables += archiveManager
+    return createIdePluginManager(archiveManager)
+  }
 
   protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFileBuilder: () -> Path): IdePlugin {
     return buildPluginSuccess(expectedWarnings, ::pluginFactory, pluginFileBuilder)
@@ -30,5 +39,13 @@ abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePlugi
   protected fun pluginFactory(pluginManager: IdePluginManager, pluginArtifactPath: Path): PluginCreationResult<IdePlugin> {
     val problemResolver = JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
     return pluginManager.createPlugin(pluginArtifactPath, validateDescriptor = true, problemResolver = problemResolver)
+  }
+
+  protected fun createArchiveManager(extractDirectory: Path): PluginArchiveManager {
+    return PluginArchiveManager(extractDirectory)
+  }
+
+  override fun close() {
+    closeables.closeAll()
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
@@ -11,24 +11,24 @@ import org.junit.Assert.assertEquals
 import java.nio.file.Path
 
 abstract class IdePluginManagerTest (fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
-    override fun createManager(extractDirectory: Path): IdePluginManager =
-        IdePluginManager.createManager(extractDirectory)
+  override fun createManager(extractDirectory: Path): IdePluginManager =
+    IdePluginManager.createManager(extractDirectory)
 
-    protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFileBuilder: () -> Path): IdePlugin {
-        return buildPluginSuccess(expectedWarnings, ::pluginFactory, pluginFileBuilder)
-    }
+  protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFileBuilder: () -> Path): IdePlugin {
+    return buildPluginSuccess(expectedWarnings, ::pluginFactory, pluginFileBuilder)
+  }
 
-    protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
-        val pluginFile = pluginFileBuilder()
-        val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
-        val (plugin, warnings) = successResult
-        assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
-        assertEquals(pluginFile, plugin.originalFile)
-        return plugin
-    }
+  protected fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
+    val pluginFile = pluginFileBuilder()
+    val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
+    val (plugin, warnings) = successResult
+    assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
+    assertEquals(pluginFile, plugin.originalFile)
+    return plugin
+  }
 
-    protected fun pluginFactory(pluginManager: IdePluginManager, pluginArtifactPath: Path): PluginCreationResult<IdePlugin> {
-        val problemResolver = JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
-        return pluginManager.createPlugin(pluginArtifactPath, validateDescriptor = true, problemResolver = problemResolver)
-    }
+  protected fun pluginFactory(pluginManager: IdePluginManager, pluginArtifactPath: Path): PluginCreationResult<IdePlugin> {
+    val problemResolver = JetBrainsPluginCreationResultResolver.fromClassPathJson(IntelliJPluginCreationResultResolver())
+    return pluginManager.createPlugin(pluginArtifactPath, validateDescriptor = true, problemResolver = problemResolver)
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -17,12 +17,12 @@ import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.verifiers.PRODUCT_ID_RESTRICTED_WORDS
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.After
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -33,7 +33,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 
-class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
+class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
   private val DEFAULT_TEMPLATE_NAMES = setOf("Plugin display name here", "My Framework Support", "Template", "Demo")
   private val PLUGIN_NAME_RESTRICTED_WORDS = setOf(
     "plugin", "JetBrains", "IDEA", "PyCharm", "CLion", "AppCode", "DataGrip", "Fleet", "GoLand", "PhpStorm", "WebStorm",
@@ -44,9 +44,6 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
   )
 
   private val LONG_LATIN_DESCRIPTION = "Latin description, 1234 &amp; ;,.!-–— () long enough"
-
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
 
   @Test
   fun `incorrect plugin file type`() {
@@ -1269,5 +1266,10 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       },
       listOf(UnknownServiceClientValue("plugin.xml", "xxx"))
     )
+  }
+
+  @After
+  fun tearDown() {
+    close()
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -22,6 +22,7 @@ import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Test
 import java.nio.file.Paths
@@ -296,5 +297,10 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
       setOf("org.jetbrains.vuejs2.optionalUpdaterV2Ultimate"),
       module.appContainerDescriptor.extensionPoints.map { it.extensionPointName }.toSet()
     )
+  }
+
+  @After
+  fun tearDown() {
+    close()
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -30,6 +30,7 @@ import com.jetbrains.plugin.structure.intellij.problems.UnexpectedPluginZipStruc
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Test
 import java.nio.file.Paths
@@ -922,6 +923,10 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
     )
   }
 
+  @After
+  fun tearDown() {
+    close()
+  }
 }
 
 typealias IdePluginFactory = PluginFactory<IdePlugin, IdePluginManager>

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -1,15 +1,10 @@
 package com.jetbrains.plugin.structure.mocks
 
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
-import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.binaryClassNames
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.base.utils.isDirectory
-import com.jetbrains.plugin.structure.base.utils.listFiles
 import com.jetbrains.plugin.structure.classes.resolvers.AbstractJarResolver
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
 import com.jetbrains.plugin.structure.classes.resolvers.DirectoryFileOrigin
@@ -26,21 +21,17 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.plugin.PluginXmlUtil.getAllClassesReferencedFromXml
-import com.jetbrains.plugin.structure.intellij.problems.AnyProblemToWarningPluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.DuplicatedDependencyWarning
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyDescriptorResolutionProblem
-import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsMultipleFiles
 import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsSingleJarInRoot
 import com.jetbrains.plugin.structure.intellij.problems.PluginZipContainsUnknownFile
 import com.jetbrains.plugin.structure.intellij.problems.UnexpectedPluginZipStructure
-import com.jetbrains.plugin.structure.intellij.resources.PluginArchiveResource
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.Assert.*
 import org.junit.Test
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
 import java.util.*
@@ -656,70 +647,6 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
     }
 
     assertTrue(plugin.hasDotNetPart)
-  }
-
-  @Test
-  fun `plugin is extracted, successfully constructed and the extraction directory is not deleted`() {
-    val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
-      pluginManager.createPlugin(
-        pluginArtifactPath,
-        validateDescriptor = true,
-        problemResolver = AnyProblemToWarningPluginCreationResultResolver,
-        deleteExtractedDirectory = false
-      )
-    }
-
-    val pluginArtifactPath = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
-      dir("plugin") {
-        dir("lib") {
-          zip("plugin.jar") {
-            dir("META-INF") {
-              file("plugin.xml") { perfectXmlBuilder.modify { } }
-            }
-          }
-        }
-      }
-    }
-    val successResult = createPluginSuccessfully(pluginArtifactPath, pluginFactory)
-    assertEquals(1, successResult.resources.size)
-    val resource = successResult.resources.first()
-    assertTrue(resource is PluginArchiveResource)
-    resource as PluginArchiveResource
-    assertTrue(resource.extractedPath.isDirectory)
-    resource.delete()
-    assertFalse(resource.extractedPath.isDirectory)
-  }
-
-  @Test
-  fun `plugin is extracted, intentionally failed on construction, but the extraction directory is automatically deleted`() {
-    val failingProblemRemapper = object : PluginCreationResultResolver {
-      override fun resolve(plugin: IdePlugin, problems: List<PluginProblem> ): PluginCreationResult<IdePlugin> {
-        return PluginCreationFail(problems)
-      }
-    }
-
-    val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
-      pluginManager.createPlugin(
-        pluginArtifactPath,
-        validateDescriptor = true,
-        problemResolver = failingProblemRemapper,
-        deleteExtractedDirectory = false
-      )
-    }
-
-    val pluginArtifactPath = buildZipFile(temporaryFolder.newFile("plugin.zip")) {
-      dir("plugin") {
-        dir("lib") {
-          zip("plugin.jar") {
-            dir("META-INF") {
-              file("plugin.xml") { perfectXmlBuilder.modify { } }
-            }
-          }
-        }
-      }
-    }
-    val creationResult = assertProblematicPlugin(pluginArtifactPath, emptyList(), pluginFactory)
-    assertEquals(emptyList<Path>(), extractedDirectory.listFiles())
   }
 
   private fun checkPluginValues(plugin: IdePlugin, isDirectoryBasedPlugin: Boolean) {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
@@ -2,17 +2,14 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.nio.file.Path
 
-class MockThemePluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType)  {
-
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
+class MockThemePluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType)  {
 
   @Test
   fun `jar file packed in zip`() {
@@ -71,5 +68,10 @@ class MockThemePluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTe
       setOf(IdeTheme("theme", true), IdeTheme("relativeTheme", false)),
       plugin.declaredThemes.toSet()
     )
+  }
+
+  @After
+  fun tearDown() {
+    close()
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/XIncludePluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/XIncludePluginTest.kt
@@ -1,18 +1,15 @@
 package com.jetbrains.plugin.structure.mocks
 
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
-import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import com.jetbrains.plugin.structure.xinclude.withConditionalXIncludes
 import com.jetbrains.plugin.structure.xinclude.withSystemProperty
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.nio.file.Path
 
-class XIncludePluginTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType) {
+class XIncludePluginTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
 
   @Test
   fun `xinclude includeUnless with system property being set to false`() {
@@ -213,18 +210,6 @@ class XIncludePluginTest(fileSystemType: FileSystemType) : BasePluginManagerTest
     assert(plugin.extensions.isEmpty())
   }
 
-  override fun createManager(extractDirectory: Path): IdePluginManager =
-    IdePluginManager.createManager(extractDirectory)
-
-  private fun buildPluginSuccess(expectedWarnings: List<PluginProblem>, pluginFactory: IdePluginFactory = ::defaultPluginFactory, pluginFileBuilder: () -> Path): IdePlugin {
-    val pluginFile = pluginFileBuilder()
-    val successResult = createPluginSuccessfully(pluginFile, pluginFactory)
-    val (plugin, warnings) = successResult
-    assertEquals(expectedWarnings.toSet().sortedBy { it.message }, warnings.toSet().sortedBy { it.message })
-    assertEquals(pluginFile, plugin.originalFile)
-    return plugin
-  }
-
   private val optionalDependencyXml = """
     <idea-plugin>
       <extensions defaultExtensionNs="com.intellij">
@@ -232,4 +217,9 @@ class XIncludePluginTest(fileSystemType: FileSystemType) : BasePluginManagerTest
       </extensions>
     </idea-plugin>
     """.trimIndent()
+
+  @After
+  fun tearDown() {
+    close()
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/zipBombs/ZipBombsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/zipBombs/ZipBombsTest.kt
@@ -1,11 +1,16 @@
 package com.jetbrains.plugin.structure.zipBombs
 
-import com.jetbrains.plugin.structure.base.plugin.*
+import com.jetbrains.plugin.structure.base.plugin.Plugin
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
+import com.jetbrains.plugin.structure.base.plugin.PluginManager
+import com.jetbrains.plugin.structure.base.plugin.Settings
 import com.jetbrains.plugin.structure.base.problems.PluginFileSizeIsTooLarge
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.dotnet.ReSharperPluginManager
 import com.jetbrains.plugin.structure.hub.HubPluginManager
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
+import com.jetbrains.plugin.structure.intellij.plugin.createIdePluginManager
 import com.jetbrains.plugin.structure.mocks.BaseFileSystemAwareTest
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import com.jetbrains.plugin.structure.teamcity.TeamcityPluginManager
@@ -58,6 +63,9 @@ class ZipBombsTest(fileSystemType: FileSystemType) : BaseFileSystemAwareTest(fil
 
     checkTooLargeProblem(IdePluginManager.createManager(), zipBomb)
     checkTooLargeProblem(IdePluginManager.createManager(temporaryFolder.newFolder()), zipBomb)
+    PluginArchiveManager(temporaryFolder.newFolder()).use {
+      checkTooLargeProblem(createIdePluginManager(it), zipBomb)
+    }
     checkTooLargeProblem(TeamcityPluginManager.createManager(), zipBomb)
     checkTooLargeProblem(TeamcityPluginManager.createManager(temporaryFolder.newFolder()), zipBomb)
     checkTooLargeProblem(HubPluginManager.createManager(), zipBomb)


### PR DESCRIPTION
Remove as much of the implicit extracted directory in ZIP tests as possible.