### PR TITLE
Do not delete extracted resources outside of Plugin Archive Manager

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -168,7 +168,6 @@ internal class PluginCreator private constructor(
       val invalidPlugin = invalidPlugin
       if (invalidPlugin != null) {
         return PluginCreationFail<IdePlugin>(invalidPlugin.problems)
-          .also { deleteResources() }
       }
 
       return problemResolver.resolve(resolvePlugin(), problems)
@@ -693,7 +692,7 @@ internal class PluginCreator private constructor(
   private fun PluginCreationResult<IdePlugin>.propagateResources() =
     when (this) {
       is PluginCreationSuccess -> copy(resources = this@PluginCreator.resources)
-      is PluginCreationFail -> also { deleteResources() }
+      is PluginCreationFail -> this
     }
 
   private val PluginCreationSuccess<IdePlugin>.problems: List<PluginProblem>
@@ -704,10 +703,6 @@ internal class PluginCreator private constructor(
       optionalDependenciesConfigFiles[pluginDependency] =
         if (v2ModulePrefix.matches(dependencyBean.configFile)) "../${dependencyBean.configFile}" else dependencyBean.configFile
     }
-  }
-
-  private fun deleteResources() {
-    resources.forEach { it.delete() }
   }
 }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
@@ -24,7 +24,7 @@ import java.nio.file.Path
 
 class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
   @Test
-  fun `plugin is extracted, successfully constructed and the extraction directory is remains undeleted`() {
+  fun `plugin is extracted, successfully constructed and the extraction directory remains undeleted`() {
     val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
       pluginManager.createPlugin(
         pluginArtifactPath,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginExtractionTest.kt
@@ -24,13 +24,12 @@ import java.nio.file.Path
 
 class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fileSystemType) {
   @Test
-  fun `plugin is extracted, successfully constructed and the extraction directory is not deleted`() {
+  fun `plugin is extracted, successfully constructed and the extraction directory is remains undeleted`() {
     val pluginFactory = { pluginManager: IdePluginManager, pluginArtifactPath: Path ->
       pluginManager.createPlugin(
         pluginArtifactPath,
         validateDescriptor = true,
         problemResolver = AnyProblemToWarningPluginCreationResultResolver,
-        deleteExtractedDirectory = false
       )
     }
 
@@ -56,7 +55,7 @@ class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTes
   }
 
   @Test
-  fun `plugin is extracted, intentionally failed on construction, but the extraction directory is automatically deleted`() {
+  fun `plugin is extracted, intentionally failed on construction, but the extraction directory remains undeleted`() {
     val failingProblemRemapper = object : PluginCreationResultResolver {
       override fun resolve(plugin: IdePlugin, problems: List<PluginProblem> ): PluginCreationResult<IdePlugin> {
         return PluginCreationFail(problems)
@@ -68,7 +67,6 @@ class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTes
         pluginArtifactPath,
         validateDescriptor = true,
         problemResolver = failingProblemRemapper,
-        deleteExtractedDirectory = false
       )
     }
 
@@ -84,7 +82,7 @@ class PluginExtractionTest(fileSystemType: FileSystemType) : IdePluginManagerTes
       }
     }
     assertProblematicPlugin(pluginArtifactPath, emptyList(), pluginFactory)
-    assertEquals(emptyList<Path>(), extractedDirectory.listFiles())
+    assertEquals(1, extractedDirectory.listFiles().size)
   }
 
   @After

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/IdePluginManagerTest.kt
@@ -15,7 +15,7 @@ import java.io.Closeable
 import java.nio.file.Path
 
 abstract class IdePluginManagerTest(fileSystemType: FileSystemType) : BasePluginManagerTest<IdePlugin, IdePluginManager>(fileSystemType), Closeable {
-  private val closeables = mutableListOf<Closeable>()
+  protected val closeables = mutableListOf<Closeable>()
 
   override fun createManager(extractDirectory: Path): IdePluginManager {
     val archiveManager = createArchiveManager(extractDirectory)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginsParsing.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/PluginsParsing.kt
@@ -222,8 +222,6 @@ class PluginsParsing(
         pluginFile,
         validateDescriptor,
         problemResolver = PluginParsingConfigurationResolution.of(configuration),
-        // No need to delete the directory, as it will be cached by 'extractedPluginCache'
-        deleteExtractedDirectory = false
       )
     with(pluginCreationResult) {
       when (this) {

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/DefaultPluginDetailsProvider.kt
@@ -69,7 +69,6 @@ class DefaultPluginDetailsProvider(
               pluginArtifactPath,
               validateDescriptor = false,
               problemResolver = dependencyProblemResolver,
-              deleteExtractedDirectory = false
             ).also {
               eventLog.logExtracted(pluginArtifactPath)
               it.registerCloseableResources()


### PR DESCRIPTION
- Remove parameter from `IdePluginManager` that allows to control whether the extracted directory is deleted. It is never deleted. Extraction and deletion is handled by `PluginArchiveManager`.
- Do not delete resources of failed plugin creations. Such resources might contain dependencies which defeats the purpose of shared cache.