### PR TITLE
Optimize JarPluginLoader in descriptor detection

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -242,8 +242,6 @@ class IdePluginManager private constructor(
     }
   }
 
-  internal data class CreationResult(val artifact: Path, val creator: PluginCreator)
-
   companion object {
     private val LOG = LoggerFactory.getLogger(IdePluginManager::class.java)
     const val PLUGIN_XML = "plugin.xml"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
 import com.jetbrains.plugin.structure.base.problems.UnableToReadDescriptor
 import com.jetbrains.plugin.structure.base.utils.getShortExceptionMessage
 import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.base.zip.newZipHandler
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion.META_INF
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
@@ -20,6 +21,7 @@ import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
 import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
 import com.jetbrains.plugin.structure.jar.PluginJar
+import org.apache.commons.io.FilenameUtils
 import org.jdom2.input.JDOMParseException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -71,6 +73,12 @@ internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProv
       LOG.warn("Unable to extract {} (searching for {}): {}", jarPath, descriptorPath, e.getShortExceptionMessage())
       createInvalidPlugin(jarPath, descriptorPath, UnableToExtractZip())
     }
+  }
+
+  fun isLoadable(pluginLoadingContext: Context): Boolean {
+    val descriptorPath = FilenameUtils.normalize("$META_INF/${pluginLoadingContext.descriptorPath}")
+    return pluginLoadingContext.jarPath.newZipHandler()
+      .handleEntry(descriptorPath) { _, _ -> true } ?: false
   }
 
   internal data class Context(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -19,6 +19,7 @@ import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
 import com.jetbrains.plugin.structure.jar.PluginJar
+import org.jdom2.input.JDOMParseException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
@@ -38,6 +39,10 @@ internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProv
                 setThirdPartyDependencies(jar.getThirdPartyDependencies())
                 setHasDotNetPart(hasDotNetDirectory)
               }
+            } catch (e: JDOMParseException) {
+              val message = e.localizedMessage
+              LOG.warn("Unable to read descriptor [$descriptorPath] from [$jarPath]: $message")
+              createInvalidPlugin(jarPath, descriptorPath, UnableToReadDescriptor(descriptorPath, message))
             } catch (e: Exception) {
               LOG.warn("Unable to read descriptor [$descriptorPath] from [$jarPath]", e)
               val message = e.localizedMessage

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -17,6 +17,7 @@ import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultReso
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
 import com.jetbrains.plugin.structure.jar.PluginDescriptorResult.Found
 import com.jetbrains.plugin.structure.jar.PluginJar
 import org.jdom2.input.JDOMParseException
@@ -49,7 +50,19 @@ internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProv
               createInvalidPlugin(jarPath, descriptorPath, UnableToReadDescriptor(descriptorPath, message))
             }
           }
-          else -> createInvalidPlugin(jarPath, descriptorPath, PluginDescriptorIsNotFound(descriptorPath)).also {
+          PluginDescriptorResult.NotFound -> createInvalidPlugin(
+            jarPath,
+            descriptorPath,
+            PluginDescriptorIsNotFound(descriptorPath)
+          ).also {
+            LOG.debug("Descriptor [{}] not found in [{}]", descriptorPath, jarPath)
+          }
+
+          is PluginDescriptorResult.Failed -> createInvalidPlugin(
+            jarPath,
+            descriptorPath,
+            PluginDescriptorIsNotFound(descriptorPath)
+          ).also {
             LOG.debug("Unable to resolve descriptor [{}] from [{}] ({})", descriptorPath, jarPath, descriptor)
           }
         }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
@@ -13,7 +13,6 @@ import com.jetbrains.plugin.structure.base.problems.isInvalidDescriptorProblem
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.isJar
-import com.jetbrains.plugin.structure.base.utils.isZip
 import com.jetbrains.plugin.structure.base.utils.listFiles
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.CreationResult
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
@@ -25,7 +24,11 @@ import com.jetbrains.plugin.structure.intellij.resources.CompositeResourceResolv
 import com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
+
+private val LOG: Logger = LoggerFactory.getLogger(LibDirectoryPluginLoader::class.java)
 
 internal class LibDirectoryPluginLoader(
   private val pluginLoaderRegistry: PluginLoaderProvider,
@@ -54,37 +57,34 @@ internal class LibDirectoryPluginLoader(
     val libResourceResolver: ResourceResolver = JarsResourceResolver(jarFiles, fileSystemProvider)
     val compositeResolver: ResourceResolver = CompositeResourceResolver(listOf(libResourceResolver, resourceResolver))
 
-    val results: MutableList<CreationResult> = ArrayList()
-    for (file in files) {
-      val innerCreator: PluginCreator = if (file.isJar() || file.isZip()) {
-        //Use the composite resource resolver, which can resolve resources in lib's jar files.
-        jarLoader.loadPlugin(
-          JarPluginLoader.Context(
-            file,
-            descriptorPath,
-            validateDescriptor,
-            compositeResolver,
-            parentPlugin,
-            problemResolver,
-            hasDotNetDirectory
-          )
-        )
-      } else if (file.isDirectory) {
-        //Use the common resource resolver, which is unaware of lib's jar files.
-        directoryLoader.loadPlugin(PluginDirectoryLoader.Context(
-          pluginDirectory = file,
-          descriptorPath = descriptorPath,
-          validateDescriptor = validateDescriptor,
-          resourceResolver = resourceResolver,
-          parentPlugin = parentPlugin,
-          problemResolver = problemResolver,
-          hasDotNetDirectory = hasDotNetDirectory
-        ))
+    val jarResults = jarFiles.mapNotNull { jarPath ->
+      //Use the composite resource resolver, which can resolve resources in lib's jar files.
+      val jarContext = getJarContext(jarPath, compositeResolver, hasDotNetDirectory)
+      if (jarLoader.isLoadable(jarContext)) {
+        val jarCreator = jarLoader.loadPlugin(jarContext)
+        CreationResult(libDirectoryParent, jarCreator).also {
+          logFoundDescriptor(libDirectoryParent, jarPath, descriptorPath)
+        }
       } else {
-        continue
+        null
       }
-      results.add(CreationResult(libDirectoryParent, innerCreator))
     }
+    val dirResults = files.filter { it.isDirectory }.map { dirPath ->
+      //Use the common resource resolver, which is unaware of lib's jar files.
+      val dirCreator = directoryLoader.loadPlugin(PluginDirectoryLoader.Context(
+        pluginDirectory = dirPath,
+        descriptorPath = descriptorPath,
+        validateDescriptor = validateDescriptor,
+        resourceResolver = resourceResolver,
+        parentPlugin = parentPlugin,
+        problemResolver = problemResolver,
+        hasDotNetDirectory = hasDotNetDirectory
+      ))
+      CreationResult(libDirectoryParent, dirCreator)
+    }
+
+    val results = jarResults + dirResults
+
     val possibleResults = results
       .filter { (_, r: PluginCreator)  -> r.isSuccess || hasOnlyInvalidDescriptorErrors(r) }
     return when(possibleResults.size) {
@@ -120,6 +120,26 @@ internal class LibDirectoryPluginLoader(
     }
   }
 
+  private fun Context.getJarContext(jarPath: Path, resolver: ResourceResolver, hasDotNetDirectory: Boolean): JarPluginLoader.Context {
+    return JarPluginLoader.Context(
+      jarPath,
+      descriptorPath,
+      validateDescriptor,
+      resolver,
+      parentPlugin,
+      problemResolver,
+      hasDotNetDirectory
+    )
+  }
+
+  private fun logFoundDescriptor(
+    libDir: Path,
+    jar: Path,
+    descriptorPath: String
+  ) {
+    LOG.debug("Found plugin descriptor [{}] in [{}/{}]", descriptorPath, libDir, jar)
+  }
+
   internal data class Context(
     val libDirectoryParent: Path,
     val descriptorPath: String,
@@ -133,3 +153,4 @@ internal class LibDirectoryPluginLoader(
     problemResolver,
   )
 }
+

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
@@ -14,7 +14,6 @@ import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isDirectory
 import com.jetbrains.plugin.structure.base.utils.isJar
 import com.jetbrains.plugin.structure.base.utils.listFiles
-import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.CreationResult
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.module.ContentModuleScanner
@@ -61,8 +60,7 @@ internal class LibDirectoryPluginLoader(
       //Use the composite resource resolver, which can resolve resources in lib's jar files.
       val jarContext = getJarContext(jarPath, compositeResolver, hasDotNetDirectory)
       if (jarLoader.isLoadable(jarContext)) {
-        val jarCreator = jarLoader.loadPlugin(jarContext)
-        CreationResult(libDirectoryParent, jarCreator).also {
+        jarLoader.loadPlugin(jarContext).also {
           logFoundDescriptor(libDirectoryParent, jarPath, descriptorPath)
         }
       } else {
@@ -71,7 +69,7 @@ internal class LibDirectoryPluginLoader(
     }
     val dirResults = files.filter { it.isDirectory }.map { dirPath ->
       //Use the common resource resolver, which is unaware of lib's jar files.
-      val dirCreator = directoryLoader.loadPlugin(PluginDirectoryLoader.Context(
+      directoryLoader.loadPlugin(PluginDirectoryLoader.Context(
         pluginDirectory = dirPath,
         descriptorPath = descriptorPath,
         validateDescriptor = validateDescriptor,
@@ -80,19 +78,18 @@ internal class LibDirectoryPluginLoader(
         problemResolver = problemResolver,
         hasDotNetDirectory = hasDotNetDirectory
       ))
-      CreationResult(libDirectoryParent, dirCreator)
     }
 
     val results = jarResults + dirResults
 
     val possibleResults = results
-      .filter { (_, r: PluginCreator)  -> r.isSuccess || hasOnlyInvalidDescriptorErrors(r) }
+      .filter { it.isSuccess || hasOnlyInvalidDescriptorErrors(it) }
     return when(possibleResults.size) {
       0 -> createInvalidPlugin(libDirectoryParent, descriptorPath, PluginDescriptorIsNotFound(descriptorPath))
-      1 -> possibleResults[0].withResolvedClasspath().creator
+      1 -> possibleResults.single().withResolvedClasspath(libDirectoryParent)
       else -> {
-        val first = possibleResults[0].creator
-        val second = possibleResults[1].creator
+        val first = possibleResults[0]
+        val second = possibleResults[1]
         val multipleDescriptorsProblem: PluginProblem = MultiplePluginDescriptors(
           first.descriptorPath,
           first.pluginFileName,
@@ -104,10 +101,10 @@ internal class LibDirectoryPluginLoader(
     }
   }
 
-  private fun CreationResult.withResolvedClasspath(): CreationResult = apply {
-    val contentModules = contentModuleScanner.getContentModules(artifact)
+  private fun PluginCreator.withResolvedClasspath(path: Path): PluginCreator = apply {
+    val contentModules = contentModuleScanner.getContentModules(path)
     val classpath = contentModules.asClasspath()
-    creator.setClasspath(classpath.getUnique())
+    setClasspath(classpath.getUnique())
   }
 
   private fun hasOnlyInvalidDescriptorErrors(creator: PluginCreator): Boolean {

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoaderTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoaderTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.intellij.plugin.createZip
+import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
+import com.jetbrains.plugin.structure.intellij.resources.DefaultResourceResolver
+import com.jetbrains.plugin.structure.jar.CachingJarFileSystemProvider
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+class JarPluginLoaderTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var jarFileSystemProvider: CachingJarFileSystemProvider
+
+  @Before
+  fun setUp() {
+    this.jarFileSystemProvider = CachingJarFileSystemProvider()
+  }
+
+  @Test
+  fun `JAR contains a descriptor`() {
+    val loader = JarPluginLoader(jarFileSystemProvider)
+    val pluginJar = newJar()
+    val descriptorPath = "plugin.xml"
+    createZip(pluginJar, mapOf("META-INF/plugin.xml" to "<idea-plugin />"))
+
+    val context = JarPluginLoader.Context(
+      pluginJar,
+      descriptorPath,
+      validateDescriptor = true,
+      resourceResolver = DefaultResourceResolver,
+      parentPlugin = null,
+      problemResolver = IntelliJPluginCreationResultResolver()
+    )
+
+    assertTrue(loader.isLoadable(context))
+  }
+
+  @Test
+  fun `JAR contains a descriptor with slash-based path which is against the ZIP specs`() {
+    val loader = JarPluginLoader(jarFileSystemProvider)
+    val pluginJar = newJar()
+    val descriptorPath = "plugin.xml"
+    createZip(pluginJar, mapOf("META-INF\\plugin.xml" to "<idea-plugin />"))
+
+    val context = JarPluginLoader.Context(
+      pluginJar,
+      descriptorPath,
+      validateDescriptor = true,
+      resourceResolver = DefaultResourceResolver,
+      parentPlugin = null,
+      problemResolver = IntelliJPluginCreationResultResolver()
+    )
+
+    assertFalse(loader.isLoadable(context))
+  }
+
+  @Test
+  fun `JAR contains a descriptor with relative path`() {
+    val loader = JarPluginLoader(jarFileSystemProvider)
+    val pluginJar = newJar()
+    val descriptorPath = "../module.xml"
+    createZip(pluginJar, mapOf(
+      "module.xml" to "<idea-plugin />"
+    ))
+
+    val context = JarPluginLoader.Context(
+      pluginJar,
+      descriptorPath,
+      validateDescriptor = true,
+      resourceResolver = DefaultResourceResolver,
+      parentPlugin = null,
+      problemResolver = IntelliJPluginCreationResultResolver()
+    )
+
+    assertTrue(loader.isLoadable(context))
+  }
+
+  @Test
+  fun `JAR contains a descriptor with relative path and backslash`() {
+    val loader = JarPluginLoader(jarFileSystemProvider)
+    val pluginJar = newJar()
+    val descriptorPath = "..\\module.xml"
+    createZip(pluginJar, mapOf(
+      "module.xml" to "<idea-plugin />"
+    ))
+
+    val context = JarPluginLoader.Context(
+      pluginJar,
+      descriptorPath,
+      validateDescriptor = true,
+      resourceResolver = DefaultResourceResolver,
+      parentPlugin = null,
+      problemResolver = IntelliJPluginCreationResultResolver()
+    )
+
+    assertTrue(loader.isLoadable(context))
+  }
+
+  @Test
+  fun `JAR does not contain a descriptor`() {
+    val loader = JarPluginLoader(jarFileSystemProvider)
+    val pluginJar = newJar()
+    createZip(pluginJar, mapOf("README.txt" to "This is not a plugin ZIP"))
+
+    val context = JarPluginLoader.Context(
+      pluginJar,
+      "META-INF/plugin.xml",
+      validateDescriptor = true,
+      resourceResolver = DefaultResourceResolver,
+      parentPlugin = null,
+      problemResolver = IntelliJPluginCreationResultResolver()
+    )
+
+    assertFalse(loader.isLoadable(context))
+  }
+
+  private fun newJar(jarName: String = "plugin.jar"): Path {
+    return temporaryFolder.newFile(jarName).toPath()
+  }
+
+  @After
+  fun tearDown() {
+    jarFileSystemProvider.close()
+  }
+}


### PR DESCRIPTION
- Distinguish between failed plugin descriptor and unavailable plugin descriptor. Log different exception when plugin is not found.
- On JDOM issues, do not log verbose stack trace, as this is an internal issue that cannot be actioned.
- Use `ZipHandler` to quickly detect presence of plugin descriptor in the set of JARs
- Separate JAR and directory parsing to quickly detect descriptor
