### PR TITLE
Remove the ability to disable downloading of unavailable optional dependencies

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -73,7 +73,6 @@ class CheckPluginParamsBuilder(
         dependencyFinder,
         ideDescriptor,
         externalClassesPackageFilter,
-        downloadUnavailableBundledPlugins = true,
         archiveManager = archiveManager
       )
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -42,7 +42,6 @@ class DefaultClassResolverProvider(
   private val externalClassesPackageFilter: PackageFilter,
   private val additionalClassResolvers: List<Resolver> = emptyList(),
   private val pluginDetailsBasedResolverProvider: PluginDetailsBasedResolverProvider = DefaultPluginDetailsBasedResolverProvider(),
-  private val downloadUnavailableBundledPlugins: Boolean = false,
   archiveManager: PluginArchiveManager
 ) : ClassResolverProvider {
 
@@ -55,14 +54,10 @@ class DefaultClassResolverProvider(
     NegativeIdeModulePredicate
   }
 
-  private val pluginResolverProvider = if (downloadUnavailableBundledPlugins) {
-    CompositePluginProvider.of(
+  private val pluginResolverProvider = CompositePluginProvider.of(
       ideDescriptor.ide,
       DependencyFinderPluginProvider(dependencyFinder, ideDescriptor.ide, archiveManager)
-    )
-  } else {
-    ideDescriptor.ide
-  }.let { pluginProvider ->
+    ).let { pluginProvider ->
     val dependenciesModifier = LegacyPluginDependencyContributor(ideDescriptor.ide)
     CachingPluginDependencyResolverProvider(pluginProvider, secondaryResolver, ideModulePredicate, dependenciesModifier)
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
@@ -125,7 +125,6 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
       ideDescriptor,
       packageFilter,
       pluginDetailsBasedResolverProvider = pluginDetailsResolverProvider,
-      downloadUnavailableBundledPlugins = true,
       archiveManager = archiveManager
     )
 
@@ -159,7 +158,6 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
       dependencyFinder,
       ideDescriptor,
       packageFilter,
-      downloadUnavailableBundledPlugins = true,
       archiveManager = archiveManager
     )
 
@@ -193,7 +191,6 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
       dependencyFinder,
       ideDescriptor,
       packageFilter,
-      downloadUnavailableBundledPlugins = true,
       archiveManager = archiveManager
     )
 


### PR DESCRIPTION
If a plugin declares an optional dependency on another plugin that isn’t available in the IDE, that dependency is downloaded from the JetBrains Marketplace.

This was in the Plugin Verifier as per original specs, but has been removed in the new dependency tree based resolution mechanism.

Remove ability to disable this dependency download mechanism, as there is no use-case for that.