### PR TITLE
Extract theme loading to a separate class

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -616,7 +616,8 @@ internal class PluginCreator private constructor(
     val themeResolution = themeLoader.load(plugin, documentPath, pathResolver, ::registerProblem)
     when (themeResolution) {
       is PluginThemeLoader.Result.Found -> plugin.declaredThemes.addAll(themeResolution.themes)
-      PluginThemeLoader.Result.NotFound -> return
+      PluginThemeLoader.Result.NotFound -> Unit
+      PluginThemeLoader.Result.Failed -> return
     }
 
     validatePlugin(plugin)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -4,7 +4,6 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
@@ -56,11 +55,7 @@ internal class PluginCreator private constructor(
   companion object {
     private val LOG = LoggerFactory.getLogger(PluginCreator::class.java)
 
-    private const val INTELLIJ_THEME_EXTENSION = "com.intellij.themeProvider"
-
     val v2ModulePrefix = Regex("^intellij\\..*")
-
-    private val json = jacksonObjectMapper()
 
     private val releaseDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -20,6 +20,7 @@ import com.jetbrains.plugin.structure.intellij.beans.PluginDependencyBean
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDescriptorParser.ParseResult.Parsed
 import com.jetbrains.plugin.structure.intellij.plugin.ValidationContext.ValidationResult
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginThemeLoader
 import com.jetbrains.plugin.structure.intellij.problems.DuplicatedDependencyWarning
 import com.jetbrains.plugin.structure.intellij.problems.ElementMissingAttribute
 import com.jetbrains.plugin.structure.intellij.problems.IntelliJPluginCreationResultResolver
@@ -28,8 +29,6 @@ import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
 import com.jetbrains.plugin.structure.intellij.problems.OptionalDependencyDescriptorCycleProblem
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.problems.SinceBuildGreaterThanUntilBuild
-import com.jetbrains.plugin.structure.intellij.problems.UnableToFindTheme
-import com.jetbrains.plugin.structure.intellij.problems.UnableToReadTheme
 import com.jetbrains.plugin.structure.intellij.problems.UnknownServiceClientValue
 import com.jetbrains.plugin.structure.intellij.resources.PluginArchiveResource
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
@@ -66,6 +65,8 @@ internal class PluginCreator private constructor(
     private val releaseDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
 
     private val pluginModuleResolver = PluginModuleResolver()
+
+    private val themeLoader = PluginThemeLoader()
 
     @JvmStatic
     fun createPlugin(
@@ -617,44 +618,15 @@ internal class PluginCreator private constructor(
     plugin.underlyingDocument = document
     plugin.setInfoFromBean(bean, document)
 
-    val themeFiles = readPluginThemes(plugin, documentPath, pathResolver) ?: return
-    plugin.declaredThemes.addAll(themeFiles)
+    val themeResolution = themeLoader.load(plugin, documentPath, descriptorPath, pathResolver, ::registerProblem)
+    when (themeResolution) {
+      is PluginThemeLoader.Result.Found -> plugin.declaredThemes.addAll(themeResolution.themes)
+      PluginThemeLoader.Result.NotFound -> return
+    }
 
     validatePlugin(plugin)
   }
 
-  private fun readPluginThemes(plugin: IdePlugin, document: Path, pathResolver: ResourceResolver): List<IdeTheme>? {
-    val themePaths = plugin.extensions[INTELLIJ_THEME_EXTENSION]?.mapNotNull {
-      it.getAttribute("path")?.value
-    } ?: emptyList()
-
-    val themes = arrayListOf<IdeTheme>()
-
-    for (themePath in themePaths) {
-      val absolutePath = if (themePath.startsWith("/")) themePath else "/$themePath"
-      when (val resolvedTheme = pathResolver.resolveResource(absolutePath, document)) {
-        is ResourceResolver.Result.Found -> resolvedTheme.use {
-          val theme = try {
-            val themeJson = it.resourceStream.reader().readText()
-            json.readValue(themeJson, IdeTheme::class.java)
-          } catch (e: Exception) {
-            registerProblem(UnableToReadTheme(descriptorPath, themePath))
-            return null
-          }
-          themes.add(theme)
-        }
-
-        is ResourceResolver.Result.NotFound -> {
-          registerProblem(UnableToFindTheme(descriptorPath, themePath))
-        }
-
-        is ResourceResolver.Result.Failed -> {
-          registerProblem(UnableToReadTheme(descriptorPath, themePath))
-        }
-      }
-    }
-    return themes
-  }
 
   internal fun registerProblem(problem: PluginProblem) {
     problems += problem

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginCreator.kt
@@ -618,7 +618,7 @@ internal class PluginCreator private constructor(
     plugin.underlyingDocument = document
     plugin.setInfoFromBean(bean, document)
 
-    val themeResolution = themeLoader.load(plugin, documentPath, descriptorPath, pathResolver, ::registerProblem)
+    val themeResolution = themeLoader.load(plugin, documentPath, pathResolver, ::registerProblem)
     when (themeResolution) {
       is PluginThemeLoader.Result.Found -> plugin.declaredThemes.addAll(themeResolution.themes)
       PluginThemeLoader.Result.NotFound -> return

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
@@ -20,7 +20,7 @@ private const val INTELLIJ_THEME_EXTENSION = "com.intellij.themeProvider"
 class PluginThemeLoader {
   private val json = jacksonObjectMapper()
 
-  fun load(plugin: IdePlugin, document: Path, descriptorPath: String, resolver: ResourceResolver, problemRegistrar: ProblemRegistrar): Result {
+  fun load(plugin: IdePlugin, descriptorPath: Path, resolver: ResourceResolver, problemRegistrar: ProblemRegistrar): Result {
     val themePaths = plugin.extensions[INTELLIJ_THEME_EXTENSION]?.mapNotNull {
       it.getAttribute("path")?.value
     } ?: emptyList()
@@ -29,29 +29,38 @@ class PluginThemeLoader {
 
     for (themePath in themePaths) {
       val absolutePath = if (themePath.startsWith("/")) themePath else "/$themePath"
-      when (val resolvedTheme = resolver.resolveResource(absolutePath, document)) {
+      when (val resolvedTheme = resolver.resolveResource(absolutePath, descriptorPath)) {
         is ResourceResolver.Result.Found -> resolvedTheme.use {
           val theme = try {
             val themeJson = it.resourceStream.reader().readText()
             json.readValue(themeJson, IdeTheme::class.java)
-          } catch (e: Exception) {
-            problemRegistrar.registerProblem(UnableToReadTheme(descriptorPath, themePath))
+          } catch (_: Exception) {
+            problemRegistrar.unableToRead(descriptorPath, themePath)
             return NotFound
           }
           themes.add(theme)
         }
 
         is ResourceResolver.Result.NotFound -> {
-          problemRegistrar.registerProblem(UnableToFindTheme(descriptorPath, themePath))
+          problemRegistrar.unableToFind(descriptorPath, themePath)
         }
 
         is ResourceResolver.Result.Failed -> {
-          problemRegistrar.registerProblem(UnableToReadTheme(descriptorPath, themePath))
+          problemRegistrar.unableToRead(descriptorPath, themePath)
         }
       }
     }
     return Found(themes)
   }
+
+  private fun ProblemRegistrar.unableToRead(descriptorPath: Path, themePath: String) {
+    registerProblem(UnableToReadTheme(descriptorPath.fileName.toString(), themePath))
+  }
+
+  private fun ProblemRegistrar.unableToFind(descriptorPath: Path, themePath: String) {
+    registerProblem(UnableToFindTheme(descriptorPath.fileName.toString(), themePath))
+  }
+
 
   sealed class Result {
     class Found(val themes: List<IdeTheme>) : Result()

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
@@ -30,7 +30,7 @@ class PluginThemeLoader {
     for (themePath in themePaths) {
       val absolutePath = if (themePath.startsWith("/")) themePath else "/$themePath"
       when (val resolvedTheme = resolver.resolveResource(absolutePath, descriptorPath)) {
-        is ResourceResolver.Result.Found -> resolvedTheme.use {
+        is ResourceResolver.Result.Found -> {
           val theme = resolvedTheme.use {
             runCatching {
               json.readValue(it.resourceStream, IdeTheme::class.java)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
@@ -25,7 +25,7 @@ class PluginThemeLoader {
       it.getAttribute("path")?.value
     } ?: emptyList()
 
-    val themes = arrayListOf<IdeTheme>()
+    val themes = mutableListOf<IdeTheme>()
 
     for (themePath in themePaths) {
       val absolutePath = if (themePath.startsWith("/")) themePath else "/$themePath"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginThemeLoader.Result.Found
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.PluginThemeLoader.Result.NotFound
+import com.jetbrains.plugin.structure.intellij.problems.UnableToFindTheme
+import com.jetbrains.plugin.structure.intellij.problems.UnableToReadTheme
+import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
+import com.jetbrains.plugin.structure.intellij.verifiers.ProblemRegistrar
+import java.nio.file.Path
+
+private const val INTELLIJ_THEME_EXTENSION = "com.intellij.themeProvider"
+
+class PluginThemeLoader {
+  private val json = jacksonObjectMapper()
+
+  fun load(plugin: IdePlugin, document: Path, descriptorPath: String, resolver: ResourceResolver, problemRegistrar: ProblemRegistrar): Result {
+    val themePaths = plugin.extensions[INTELLIJ_THEME_EXTENSION]?.mapNotNull {
+      it.getAttribute("path")?.value
+    } ?: emptyList()
+
+    val themes = arrayListOf<IdeTheme>()
+
+    for (themePath in themePaths) {
+      val absolutePath = if (themePath.startsWith("/")) themePath else "/$themePath"
+      when (val resolvedTheme = resolver.resolveResource(absolutePath, document)) {
+        is ResourceResolver.Result.Found -> resolvedTheme.use {
+          val theme = try {
+            val themeJson = it.resourceStream.reader().readText()
+            json.readValue(themeJson, IdeTheme::class.java)
+          } catch (e: Exception) {
+            problemRegistrar.registerProblem(UnableToReadTheme(descriptorPath, themePath))
+            return NotFound
+          }
+          themes.add(theme)
+        }
+
+        is ResourceResolver.Result.NotFound -> {
+          problemRegistrar.registerProblem(UnableToFindTheme(descriptorPath, themePath))
+        }
+
+        is ResourceResolver.Result.Failed -> {
+          problemRegistrar.registerProblem(UnableToReadTheme(descriptorPath, themePath))
+        }
+      }
+    }
+    return Found(themes)
+  }
+
+  sealed class Result {
+    class Found(val themes: List<IdeTheme>) : Result()
+    object NotFound : Result()
+  }
+}

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoader.kt
@@ -33,8 +33,7 @@ class PluginThemeLoader {
         is ResourceResolver.Result.Found -> resolvedTheme.use {
           val theme = resolvedTheme.use {
             runCatching {
-              val themeJson = it.resourceStream.reader().readText()
-              json.readValue(themeJson, IdeTheme::class.java)
+              json.readValue(it.resourceStream, IdeTheme::class.java)
             }.getOrElse {
               problemRegistrar.unableToRead(descriptorPath, themePath)
               return NotFound

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoaderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoaderTest.kt
@@ -34,8 +34,8 @@ class PluginThemeLoaderTest {
 
     val problemRegistrar = SimpleProblemRegistrar()
     val result = loader.load(plugin, Path.of("META-INF/plugin.xml"), DefaultResourceResolver, problemRegistrar)
-    assertTrue(result is PluginThemeLoader.Result.NotFound)
-    result as PluginThemeLoader.Result.NotFound
+    assertTrue(result is PluginThemeLoader.Result.Failed)
+    result as PluginThemeLoader.Result.Failed
 
     assertEquals(2, problemRegistrar.problems.size)
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoaderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/loaders/PluginThemeLoaderTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin.loaders
+
+import com.jetbrains.plugin.structure.intellij.resources.DefaultResourceResolver
+import com.jetbrains.plugin.structure.mocks.MockIdePlugin
+import com.jetbrains.plugin.structure.mocks.SimpleProblemRegistrar
+import org.jdom2.Element
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Path
+
+private const val INTELLIJ_THEME_EXTENSION = "com.intellij.themeProvider"
+
+class PluginThemeLoaderTest {
+  @Test
+  fun `two unavailable themes`() {
+    val loader = PluginThemeLoader()
+
+    val firstMissingThemeElement = Element(INTELLIJ_THEME_EXTENSION).apply {
+      setAttribute("path", "/nonexistent.theme.json")
+    }
+    val secondMissingThemeElement = Element(INTELLIJ_THEME_EXTENSION).apply {
+      setAttribute("path", "/another-nonexistent.theme.json")
+    }
+
+    val extensions = mapOf(
+      INTELLIJ_THEME_EXTENSION to listOf(firstMissingThemeElement, secondMissingThemeElement)
+    )
+    val plugin = MockIdePlugin(extensions = extensions)
+
+    val problemRegistrar = SimpleProblemRegistrar()
+    val result = loader.load(plugin, Path.of("META-INF/plugin.xml"), DefaultResourceResolver, problemRegistrar)
+    assertTrue(result is PluginThemeLoader.Result.NotFound)
+    result as PluginThemeLoader.Result.NotFound
+
+    assertEquals(2, problemRegistrar.problems.size)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
@@ -3,6 +3,8 @@ package com.jetbrains.plugin.structure.mocks
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdeTheme
+import com.jetbrains.plugin.structure.intellij.problems.UnableToFindTheme
+import com.jetbrains.plugin.structure.intellij.problems.UnableToReadTheme
 import com.jetbrains.plugin.structure.rules.FileSystemType
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -55,6 +57,48 @@ class MockThemePluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTes
     }
 
     testMockPluginStructureAndConfiguration(pluginFile)
+  }
+
+  @Test
+  fun `theme not found`() {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar")) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          perfectXmlBuilder.modify {
+            additionalContent = """
+              <extensions defaultExtensionNs="com.intellij">
+                  <themeProvider id="id0" path="/nonexistent.theme.json"/>
+              </extensions>
+            """.trimIndent()
+          }
+        }
+      }
+    }
+
+    assertProblematicPlugin(pluginFile, listOf(UnableToFindTheme( "plugin.xml", "/nonexistent.theme.json")))
+  }
+
+  @Test
+  fun `theme JSON has syntax errors`() {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar")) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          perfectXmlBuilder.modify {
+            additionalContent = """
+              <extensions defaultExtensionNs="com.intellij">
+                  <themeProvider id="id0" path="/syntax-error.theme.json"/>
+              </extensions>
+            """.trimIndent()
+          }
+        }
+      }
+
+      file(
+        "syntax-error.theme.json", "<Intentionally invalid JSON>".trimIndent()
+      )
+    }
+
+    assertProblematicPlugin(pluginFile, listOf(UnableToReadTheme( "plugin.xml", "/syntax-error.theme.json")))
   }
 
   @Suppress("SameParameterValue")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
@@ -125,6 +125,38 @@ class MockThemePluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTes
     assertProblematicPlugin(pluginFile, listOf(UnableToReadTheme( "plugin.xml", "/syntax-error.theme.json")))
   }
 
+  @Test
+  fun `one theme is found, the other is not available`() {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar")) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          perfectXmlBuilder.modify {
+            additionalContent = """
+              <extensions defaultExtensionNs="com.intellij">
+                  <themeProvider id="id0" path="/nonexistent.theme.json"/>
+                  <themeProvider id="id1" path="/theme.theme.json"/>                  
+              </extensions>
+            """.trimIndent()
+          }
+        }
+      }
+
+      file(
+        "theme.theme.json", """
+        {
+          "name": "theme",
+          "dark": true,
+          "author": "",
+          "editorScheme": "/theme.xml",
+          "ui": {}
+        }
+      """.trimIndent()
+      )
+    }
+
+    assertProblematicPlugin(pluginFile, listOf(UnableToFindTheme( "plugin.xml", "/nonexistent.theme.json")))
+  }
+
   @Suppress("SameParameterValue")
   private fun testMockPluginStructureAndConfiguration(pluginFile: Path) {
     val pluginCreationSuccess = createPluginSuccessfully(pluginFile)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
@@ -79,6 +79,30 @@ class MockThemePluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTes
   }
 
   @Test
+  fun `two themes not found`() {
+    val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar")) {
+      dir("META-INF") {
+        file("plugin.xml") {
+          perfectXmlBuilder.modify {
+            additionalContent = """
+              <extensions defaultExtensionNs="com.intellij">
+                  <themeProvider id="id0" path="/nonexistent.theme.json"/>
+                  <themeProvider id="id1" path="/another-nonexistent.theme.json"/>
+              </extensions>
+            """.trimIndent()
+          }
+        }
+      }
+    }
+
+    val expectedProblems = listOf(
+      UnableToFindTheme("plugin.xml", "/nonexistent.theme.json"),
+      UnableToFindTheme("plugin.xml", "/another-nonexistent.theme.json")
+    )
+    assertProblematicPlugin(pluginFile, expectedProblems)
+  }
+
+  @Test
   fun `theme JSON has syntax errors`() {
     val pluginFile = buildZipFile(temporaryFolder.newFile("plugin.jar")) {
       dir("META-INF") {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockThemePluginsTest.kt
@@ -154,7 +154,7 @@ class MockThemePluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTes
       )
     }
 
-    assertProblematicPlugin(pluginFile, listOf(UnableToFindTheme( "plugin.xml", "/nonexistent.theme.json")))
+    assertProblematicPlugin(pluginFile, listOf(UnableToFindTheme("plugin.xml", "/nonexistent.theme.json")))
   }
 
   @Suppress("SameParameterValue")


### PR DESCRIPTION
Introduce `PluginThemeLoader` as a standalone class responsible for plugin theme loading.

Extract it away from `PluginCreator`.