### PR TITLE
Improve exception handling in ZIP handlers

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginFileError.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/PluginFileError.kt
@@ -29,6 +29,21 @@ class IncorrectZipOrJarFile(
     get() = "The plugin archive contains an unexpected file $fileName: it must be .zip, .jar or a directory."
 }
 
+class UnreadableZipOrJarFile(
+  private val fileName: String,
+  private val reason: String
+) : PluginFileError() {
+  override val message
+    get() = "The plugin archive contains an unreadable or malformed file $fileName: $reason"
+
+  companion object {
+    fun of(zipOrJar: Path, throwable: Throwable) = UnreadableZipOrJarFile(
+      zipOrJar.fileName.toString(),
+      throwable.message ?: ""
+    )
+  }
+}
+
 class IncorrectJarOrDirectory(
   private val path: Path
 ) : PluginFileError() {

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
@@ -6,7 +6,13 @@ package com.jetbrains.plugin.structure.base.zip
 
 import java.io.File
 
-sealed class ZipArchiveException(zipFile: File, reason: String, cause: Throwable) : RuntimeException("$reason ZIP archive [$zipFile]: ${cause.message}", cause)
-
+sealed class ZipArchiveException(zipFile: File, reason: String, cause: Throwable) : RuntimeException("$reason ${zipFile.type} archive [$zipFile]: ${cause.message}", cause)
 class MalformedZipArchiveException(zipFile: File, cause: Throwable) : ZipArchiveException(zipFile, "Malformed", cause)
 class ZipArchiveIOException(zipFile: File, cause: Throwable) : ZipArchiveException(zipFile, "Unreadable or I/O error in", cause)
+
+private val File.type: String
+  get() = when (extension.toLowerCase()) {
+    "zip" -> "ZIP"
+    "jar" -> "JAR"
+    else -> extension.toUpperCase() + " Archive"
+  }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base.zip
+
+import java.io.File
+
+sealed class ZipArchiveException(zipFile: File, reason: String, cause: Throwable) : RuntimeException("$reason ZIP archive [$zipFile]: ${cause.message}", cause)
+
+class MalformedZipArchiveException(zipFile: File, cause: Throwable) : ZipArchiveException(zipFile, "Malformed", cause)
+class ZipArchiveIOException(zipFile: File, cause: Throwable) : ZipArchiveException(zipFile, "Unreadable or I/O error in", cause)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipHandler.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipHandler.kt
@@ -14,7 +14,9 @@ interface ZipHandler<Z: ZipResource> {
    * All results of the [handler] invocations are collected and returned.
    * @param handler a handler to be invoked for each ZIP entry
    * @return a list of results produced by the [handler] function,
+   * @throws ZipArchiveException when a ZIP archive is malformed or an I/O error occurred while reading it
    */
+  @Throws(ZipArchiveException::class)
   fun <T> iterate(handler: (ZipEntry, Z) -> T?): List<T>
 
   /**
@@ -23,7 +25,9 @@ interface ZipHandler<Z: ZipResource> {
    *
    * @param entryName the name of the ZIP entry, usually a filename, to find in the ZIP
    * @param handler a handler to invoke on the encountered entry
+   * @throws ZipArchiveException when a ZIP archive is malformed or an I/O error occurred while reading it
    */
+  @Throws(ZipArchiveException::class)
   fun <T> handleEntry(entryName: CharSequence, handler: (ZipEntry, Z) -> T?): T?
 }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/Jar.kt
@@ -6,6 +6,8 @@ import com.jetbrains.plugin.structure.base.utils.charseq.CharReplacingCharSequen
 import com.jetbrains.plugin.structure.base.utils.getBundleBaseName
 import com.jetbrains.plugin.structure.base.utils.isFile
 import com.jetbrains.plugin.structure.base.utils.occurrences
+import com.jetbrains.plugin.structure.base.zip.MalformedZipArchiveException
+import com.jetbrains.plugin.structure.base.zip.ZipArchiveIOException
 import com.jetbrains.plugin.structure.base.zip.newZipHandler
 import com.jetbrains.plugin.structure.jar.Jar.DescriptorType.*
 import com.jetbrains.plugin.structure.jar.JarEntryResolver.Key
@@ -93,6 +95,10 @@ class Jar(
             scan(zipEntry)
           }
         }
+    } catch (e: MalformedZipArchiveException) {
+      throw JarArchiveException("JAR archive malformed at [$jarPath]: ${e.message} ", e)
+    } catch (e: ZipArchiveIOException) {
+      throw JarArchiveException("JAR archive cannot be read at [$jarPath]: ${e.message} ", e)
     } catch (e: NoSuchElementException) {
       throw JarArchiveException("JAR archive is not found at [$jarPath]: ${e.message} ", e)
     } catch (e: IOException) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -78,7 +78,12 @@ internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProv
   fun isLoadable(pluginLoadingContext: Context): Boolean {
     val descriptorPath = FilenameUtils.normalize("$META_INF/${pluginLoadingContext.descriptorPath}")
     return pluginLoadingContext.jarPath.newZipHandler()
-      .handleEntry(descriptorPath) { _, _ -> true } ?: false
+      .runCatching {
+        handleEntry(descriptorPath) { _, _ -> true } ?: false
+      }.getOrElse {
+        LOG.debug(it.message)
+        false
+      }
   }
 
   internal data class Context(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/JarPluginLoader.kt
@@ -14,6 +14,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager.Companion
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createInvalidPlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginCreator.Companion.createPlugin
+import com.jetbrains.plugin.structure.intellij.plugin.loaders.JarPluginLoader.Loadability.*
 import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.jar.JarArchiveCannotBeOpenException
@@ -75,15 +76,21 @@ internal class JarPluginLoader(private val fileSystemProvider: JarFileSystemProv
     }
   }
 
-  fun isLoadable(pluginLoadingContext: Context): Boolean {
+  fun isLoadable(pluginLoadingContext: Context): Loadability {
     val descriptorPath = FilenameUtils.normalize("$META_INF/${pluginLoadingContext.descriptorPath}")
     return pluginLoadingContext.jarPath.newZipHandler()
       .runCatching {
-        handleEntry(descriptorPath) { _, _ -> true } ?: false
+        handleEntry(descriptorPath) { _, _ -> Loadable } ?: NotLoadable
       }.getOrElse {
         LOG.debug(it.message)
-        false
+        Failed(it)
       }
+  }
+
+  sealed class Loadability {
+    object Loadable : Loadability()
+    object NotLoadable : Loadability()
+    class Failed(val exception: Throwable) : Loadability()
   }
 
   internal data class Context(

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -90,6 +90,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
 
     IncorrectPluginFile::class,
     IncorrectZipOrJarFile::class,
+    UnreadableZipOrJarFile::class,
     IncorrectJarOrDirectory::class,
     PluginFileSizeIsTooLarge::class,
     UnableToExtractZip::class,

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -14,8 +14,6 @@ import com.jetbrains.plugin.structure.classes.resolvers.Resolver
 import com.jetbrains.plugin.structure.ide.util.KnownIdePackages
 import com.jetbrains.plugin.structure.intellij.classes.plugin.IdePluginClassesLocations
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.jar.BinaryPackageName
-import com.jetbrains.plugin.structure.jar.Packages
 import com.jetbrains.pluginverifier.analysis.ExtractedJsonPluginAnalyzer
 import com.jetbrains.pluginverifier.analysis.ReachabilityGraph
 import com.jetbrains.pluginverifier.analysis.buildClassReachabilityGraph
@@ -343,7 +341,9 @@ class PluginVerifier(
   }
 
   private fun PluginVerificationContext.findMistakenlyBundledIdeClasses(pluginResolver: Resolver) {
-    val idePackages = getAllPackages(pluginResolver).filter { KnownIdePackages.isKnownPackage(it) }
+    val idePackages = pluginResolver.packages
+      .filter { KnownIdePackages.isKnownPackage(it) }
+
     if (idePackages.isNotEmpty()) {
       registerCompatibilityWarning(MistakenlyBundledIdePackagesWarning(idePackages.map { it.replace('/', '.') }))
     }
@@ -357,12 +357,6 @@ class PluginVerifier(
       classesForCheck += classesSelector.getClassesForCheck(pluginDetails.pluginClassesLocations)
     }
     return classesForCheck
-  }
-
-  private fun getAllPackages(resolver: Resolver): Set<BinaryPackageName> {
-    val allPackages = Packages()
-    resolver.packages.forEach { allPackages.addPackage(it) }
-    return allPackages.all
   }
 
   private fun Set<BinaryClassName>.reportTelemetry(pluginDetails: PluginDetails, context: PluginVerificationContext) {


### PR DESCRIPTION
- Introduce `UnreadableZipOrJarFile` for malformed or unreadable ZIPs and JARs
- Make `ZipFileHandler` throw explicit exception: a `ZipArchiveException` hierarchy
- Catch `ZipArchiveException`s in `Jar`
- Improve exception handling in `JarPluginLoader` and `LibDirectoryPluginLoader`
- Measure extraction duration in `PluginArchiveManager`
- Do not unnecessarily create full `Package` tree when just searching for package