### PR TITLE
Check the plugin name contains only allowed symbols

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -88,6 +88,15 @@ class NotNumber(
     get() = Level.ERROR
 }
 
+class InvalidPluginName(descriptorPath: String? = null, val name: String) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage =  "Name '$name' contains invalid characters. Only the following characters are allowed: " +
+          "letters, digits, spaces, and .,+_-/:()#'&[]|"
+) {
+  override val level
+    get() = Level.ERROR
+}
+
 class UnableToReadDescriptor(
   descriptorPath: String,
   exceptionMessage: String?

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/Validator.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/Validator.kt
@@ -1,5 +1,7 @@
 package com.jetbrains.plugin.structure.base.problems
 
+val ALLOWED_NAME_SYMBOLS = Regex("[a-zA-Z0-9 .,+_\\-/:()#'&\\[\\]|]+")
+
 fun validatePropertyLength(
   descriptor: String,
   propertyName: String,
@@ -11,3 +13,16 @@ fun validatePropertyLength(
     problems.add(TooLongPropertyValue(descriptor, propertyName, propertyValue.length, maxLength))
   }
 }
+
+fun validatePluginNameIsCorrect(descriptor: String, name: String, problems: MutableList<PluginProblem>) {
+  validatePluginNameIsCorrect(descriptor, name)?.let {
+    problems.add(it)
+  }
+}
+
+fun validatePluginNameIsCorrect(descriptor: String, name: String): PluginProblem? =
+  if (!name.matches(ALLOWED_NAME_SYMBOLS)) {
+    InvalidPluginName(descriptor, name)
+  } else {
+    null
+  }

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -58,17 +58,24 @@ data class FleetPluginDescriptor(
     val products = supportedProducts.mapNotNull { FleetProduct.fromProductCode(it) }.toSet()
 
     if (products.size != supportedProducts.size) {
-      problems.add(InvalidSupportedProductsListProblem(
-        constraint = "must contain only product codes from ${FleetProduct.values().map { it.productCode }}, got: $supportedProducts"
-      ))
+      problems.add(
+        InvalidSupportedProductsListProblem(
+          constraint = "must contain only product codes from ${
+            FleetProduct.values().map { it.productCode }
+          }, got: $supportedProducts"
+        )
+      )
     }
-    val (isLegacyVersioning, isUnifiedVersioning) = products.partition { it.legacyVersioning }.let { (legacy, unified) ->
-      Pair(legacy.isNotEmpty(), unified.isNotEmpty())
-    }
+    val (isLegacyVersioning, isUnifiedVersioning) = products.partition { it.legacyVersioning }
+      .let { (legacy, unified) ->
+        Pair(legacy.isNotEmpty(), unified.isNotEmpty())
+      }
     if (isLegacyVersioning && isUnifiedVersioning) {
-      problems.add(InvalidSupportedProductsListProblem(
-        constraint = "must contain either only legacy or only unified versioning products"
-      ))
+      problems.add(
+        InvalidSupportedProductsListProblem(
+          constraint = "must contain either only legacy or only unified versioning products"
+        )
+      )
     }
 
     val shipVersionSpec = FleetDescriptorSpec.CompatibleShipVersion
@@ -91,27 +98,33 @@ data class FleetPluginDescriptor(
           val toSemver = parseVersionOrNull(compatibleShipVersionRange.to)
           when {
             fromSemver == null -> {
-              problems.add(InvalidSemverFormat(
-                descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
-                versionName = shipVersionSpec.relativeFieldPath(shipVersionSpec.FROM_FIELD_NAME),
-                version = compatibleShipVersionRange.from
-              ))
+              problems.add(
+                InvalidSemverFormat(
+                  descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
+                  versionName = shipVersionSpec.relativeFieldPath(shipVersionSpec.FROM_FIELD_NAME),
+                  version = compatibleShipVersionRange.from
+                )
+              )
             }
 
             toSemver == null -> {
-              problems.add(InvalidSemverFormat(
-                descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
-                versionName = shipVersionSpec.relativeFieldPath(shipVersionSpec.TO_FIELD_NAME),
-                version = compatibleShipVersionRange.to
-              ))
+              problems.add(
+                InvalidSemverFormat(
+                  descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
+                  versionName = shipVersionSpec.relativeFieldPath(shipVersionSpec.TO_FIELD_NAME),
+                  version = compatibleShipVersionRange.to
+                )
+              )
             }
 
             fromSemver.isGreaterThan(toSemver) -> {
-              problems.add(InvalidVersionRange(
-                descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
-                since = compatibleShipVersionRange.from,
-                until = compatibleShipVersionRange.to
-              ))
+              problems.add(
+                InvalidVersionRange(
+                  descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
+                  since = compatibleShipVersionRange.from,
+                  until = compatibleShipVersionRange.to
+                )
+              )
             }
 
             else -> {
@@ -122,11 +135,13 @@ data class FleetPluginDescriptor(
               )
               problems.addAll(fromVersionProblems)
               if (fromVersionProblems.isEmpty()) {
-                problems.addAll(validateVersion(
-                  fieldName = shipVersionSpec.relativeFieldPath(shipVersionSpec.TO_FIELD_NAME),
-                  semver = toSemver,
-                  isLegacy = isLegacyVersioning
-                ))
+                problems.addAll(
+                  validateVersion(
+                    fieldName = shipVersionSpec.relativeFieldPath(shipVersionSpec.TO_FIELD_NAME),
+                    semver = toSemver,
+                    isLegacy = isLegacyVersioning
+                  )
+                )
               }
             }
           }
@@ -146,6 +161,11 @@ data class FleetPluginDescriptor(
           propertyName = metaSpec.relativeFieldPath(metaSpec.NAME_FIELD_NAME),
           propertyValue = readableName,
           maxLength = MAX_NAME_LENGTH,
+          problems = problems
+        )
+        validatePluginNameIsCorrect(
+          descriptor = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
+          name = readableName,
           problems = problems
         )
       }

--- a/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
+++ b/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
@@ -42,8 +42,18 @@ internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProb
     }
   }
 
-  if (manifest.pluginName.isNullOrBlank()) {
+  val pluginName = manifest.pluginName
+  if (pluginName.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("name"))
+  } else {
+    validatePropertyLength(
+      descriptor = DESCRIPTOR_NAME,
+      propertyName = "name",
+      propertyValue = pluginName,
+      maxLength = MAX_NAME_LENGTH,
+      problems = problems
+    )
+    validatePluginNameIsCorrect(descriptor = DESCRIPTOR_NAME, name = pluginName, problems = problems)
   }
 
   if (manifest.author == null) {
@@ -69,17 +79,6 @@ internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProb
     problems.add(PropertyNotSpecified("products"))
   } else if (manifest.products.isEmpty()) {
     problems.add(HubProductsNotSpecified())
-  }
-  val pluginName = manifest.pluginName
-  if (pluginName != null) {
-    validatePropertyLength(
-        descriptor = DESCRIPTOR_NAME,
-        propertyName = "name",
-        propertyValue = pluginName,
-        maxLength = MAX_NAME_LENGTH,
-        problems = problems
-    )
-    validatePluginNameIsCorrect(descriptor = DESCRIPTOR_NAME, name = pluginName, problems = problems)
   }
   return problems
 }

--- a/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
+++ b/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
@@ -70,8 +70,16 @@ internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProb
   } else if (manifest.products.isEmpty()) {
     problems.add(HubProductsNotSpecified())
   }
-  if (manifest.pluginName != null) {
-    validatePropertyLength(DESCRIPTOR_NAME, "name", manifest.pluginName, MAX_NAME_LENGTH, problems)
+  val pluginName = manifest.pluginName
+  if (pluginName != null) {
+    validatePropertyLength(
+        descriptor = DESCRIPTOR_NAME,
+        propertyName = "name",
+        propertyValue = pluginName,
+        maxLength = MAX_NAME_LENGTH,
+        problems = problems
+    )
+    validatePluginNameIsCorrect(descriptor = DESCRIPTOR_NAME, name = pluginName, problems = problems)
   }
   return problems
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
@@ -96,7 +96,7 @@ class PluginBeanValidator {
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
         verifyNewlines("name", name, descriptorPath, ::registerProblem)
-        validatePluginNameIsCorrect(descriptorPath, name)?.let {
+        validatePluginNameIsCorrect(descriptorPath, name.trim())?.let {
           registerProblem(it)
         }
       }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
@@ -21,7 +21,6 @@ import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginUntilBuildVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ProductReleaseVersionVerifier
 import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
-import com.jetbrains.plugin.structure.intellij.verifiers.verifyNewlines
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import org.jsoup.Jsoup
 import java.time.LocalDate
@@ -95,7 +94,6 @@ class PluginBeanValidator {
           registerProblem(TemplateWordInPluginName(descriptorPath, name, templateWord))
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
-        verifyNewlines("name", name, descriptorPath, ::registerProblem)
         validatePluginNameIsCorrect(descriptorPath, name.trim())?.let {
           registerProblem(it)
         }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.base.problems.NotBoolean
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
 import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
+import com.jetbrains.plugin.structure.base.problems.validatePluginNameIsCorrect
 import com.jetbrains.plugin.structure.intellij.beans.IdeaVersionBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginDependencyBean
@@ -95,6 +96,9 @@ class PluginBeanValidator {
         }
         validatePropertyLength("name", name, MAX_NAME_LENGTH)
         verifyNewlines("name", name, descriptorPath, ::registerProblem)
+        validatePluginNameIsCorrect(descriptorPath, name)?.let {
+          registerProblem(it)
+        }
       }
     }
   }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -99,6 +99,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
     UnexpectedDescriptorElements::class,
     PropertyNotSpecified::class,
     NotBoolean::class,
+    InvalidPluginName::class,
 
     NotNumber::class,
     UnableToReadDescriptor::class,

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
@@ -6,7 +6,7 @@
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
-    "com.jetbrains.plugin.structure.base.problems.InvalidPluginName": "warning"
+    "com.jetbrains.plugin.structure.base.problems.InvalidPluginName": "ignore"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
@@ -5,7 +5,8 @@
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "ignore",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
-    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning"
+    "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
+    "com.jetbrains.plugin.structure.base.problems.InvalidPluginName": "warning"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",

--- a/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/Validator.kt
+++ b/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/Validator.kt
@@ -7,6 +7,7 @@ package com.jetbrains.plugin.structure.teamcity
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.MAX_NAME_LENGTH
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.problems.validatePluginNameIsCorrect
 import com.jetbrains.plugin.structure.base.problems.validatePropertyLength
 import com.jetbrains.plugin.structure.teamcity.TeamcityPluginManager.Companion.DESCRIPTOR_NAME
 import com.jetbrains.plugin.structure.teamcity.beans.TeamcityPluginBean
@@ -25,17 +26,22 @@ internal fun validateTeamcityPluginBean(bean: TeamcityPluginBean): List<PluginPr
   if (beanDisplayName.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("display-name"))
   } else {
+    validatePropertyLength(
+        descriptor = DESCRIPTOR_NAME,
+        propertyName = "display-name",
+        propertyValue = beanDisplayName,
+        maxLength = MAX_NAME_LENGTH,
+        problems = problems
+    )
     val hasForbiddenWords = PLUGIN_NAME_FORBIDDEN_WORDS.any { beanDisplayName.contains(it, ignoreCase = true) }
     if (hasForbiddenWords) {
       problems.add(ForbiddenWordInPluginName(PLUGIN_NAME_FORBIDDEN_WORDS))
     }
+    validatePluginNameIsCorrect(descriptor = DESCRIPTOR_NAME, name = beanDisplayName, problems = problems)
   }
   val name = bean.info?.name
   if (name != null) {
     validatePropertyLength(DESCRIPTOR_NAME, "name", name, MAX_NAME_LENGTH, problems)
-  }
-  if (beanDisplayName != null) {
-    validatePropertyLength(DESCRIPTOR_NAME, "display-name", beanDisplayName, MAX_NAME_LENGTH, problems)
   }
 
   if (bean.info?.version.isNullOrBlank()) {

--- a/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
@@ -77,7 +77,18 @@ data class ToolboxPluginDescriptor(
       }
 
       else -> {
-        validatePropertyLength(ToolboxPluginManager.DESCRIPTOR_NAME, "meta.name", readableName, MAX_NAME_LENGTH, problems)
+        validatePropertyLength(
+          descriptor = ToolboxPluginManager.DESCRIPTOR_NAME,
+          propertyName = "meta.name",
+          propertyValue = readableName,
+          maxLength = MAX_NAME_LENGTH,
+          problems = problems
+        )
+        validatePluginNameIsCorrect(
+          descriptor = ToolboxPluginManager.DESCRIPTOR_NAME,
+          name = readableName,
+          problems = problems
+        )
       }
     }
     val metaUrl = meta?.url

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
@@ -16,13 +16,7 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
 
   validateManifestName(manifest.name, problems)
 
-  if (manifest.title.isNullOrBlank()) {
-    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE))
-  }
-
-  if (manifest.title != null) {
-    validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.TITLE, manifest.title, MAX_NAME_LENGTH, problems)
-  }
+  validateTitle(manifest.title, problems)
 
   if (manifest.description.isNullOrBlank()) {
     problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION))
@@ -52,6 +46,18 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
   return problems
 }
 
+private fun validateTitle(title: String?, problems: MutableList<PluginProblem>) {
+  when {
+    (title.isNullOrBlank()) -> {
+      problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE))
+    }
+    else -> {
+      validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.TITLE, title, MAX_NAME_LENGTH, problems)
+      validatePluginNameIsCorrect(descriptor = DESCRIPTOR_NAME, name = title, problems = problems)
+    }
+  }
+}
+
 private fun validateManifestName(name: String?, problems: MutableList<PluginProblem>) {
   if (name == null) {
     problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.NAME))
@@ -63,7 +69,13 @@ private fun validateManifestName(name: String?, problems: MutableList<PluginProb
     return
   }
 
-  validatePropertyLength(DESCRIPTOR_NAME, YouTrackAppFields.Manifest.NAME, name, MAX_NAME_LENGTH, problems)
+  validatePropertyLength(
+      descriptor = DESCRIPTOR_NAME,
+      propertyName = YouTrackAppFields.Manifest.NAME,
+      propertyValue = name,
+      maxLength = MAX_NAME_LENGTH,
+      problems = problems
+  )
 
   if (!ID_REGEX.matches(name)) {
     problems.add(UnsupportedSymbolsAppNameProblem())

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
@@ -19,7 +19,7 @@ private val xml10BMPCharRanges = listOf(
  *
  * Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
  *
- * @see https://www.w3.org/TR/xml/#charsets
+ * See [XML 1.0 Specification](https://www.w3.org/TR/xml/#charsets).
  */
 internal fun getRandomXmlChar(): Char {
   val range = xml10BMPCharRanges.random()

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.base.utils
+
+import kotlin.random.Random
+
+private val xml10BMPCharRanges = listOf(
+  0x9.range(),
+  0xA.range(),
+  0xD.range(),
+  0x20..0xD7FF,
+  0xE000..0xFFFD
+)
+
+/**
+ * Returns random XML character for XML 1.0 specification, but from BMP plane only.
+ *
+ * Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+ *
+ * @see https://www.w3.org/TR/xml/#charsets
+ */
+internal fun getRandomXmlChar(): Char {
+  val range = xml10BMPCharRanges.random()
+  val codePoint = Random.nextInt(range.first, range.last + 1)
+
+  return codePoint.toChar()
+}
+
+private fun Int.range() = IntRange(this, this)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
@@ -46,5 +46,9 @@ internal fun getRandomInvalidXmlBasedPluginName(length: Int): String {
   }
 }
 
+/**
+ * Normalize new-lines according to [XML 1.0 Specification](https://www.w3.org/TR/xml/#sec-line-ends)
+ */
+internal fun String.normalizeNewLines(): String = replace("\r\n", "\n").replace("\r", "\n")
 
 private fun Int.range() = IntRange(this, this)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.base.utils
 
+import com.jetbrains.plugin.structure.base.problems.ALLOWED_NAME_SYMBOLS
 import kotlin.random.Random
 
 private val xml10BMPCharRanges = listOf(
@@ -27,5 +28,23 @@ internal fun getRandomXmlChar(): Char {
 
   return codePoint.toChar()
 }
+
+/**
+ * Get a random plugin name composed solely of invalid plugin name characters
+ * for plugins based on the XML format.
+ */
+internal fun getRandomInvalidXmlBasedPluginName(length: Int): String {
+  val invalidPluginName = StringBuilder()
+  while (true) {
+    val randomXmlCharacter = getRandomXmlChar()
+    if (!ALLOWED_NAME_SYMBOLS.matches(randomXmlCharacter.toString())) {
+      invalidPluginName.append(randomXmlCharacter)
+      if (invalidPluginName.length == length) {
+        return invalidPluginName.toString()
+      }
+    }
+  }
+}
+
 
 private fun Int.range() = IntRange(this, this)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -41,6 +41,25 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
     ) { it.copy(meta = it.meta?.copy(name = "a".repeat(65))) }
   }
 
+  @Test
+  fun `name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomNotAllowedNameSymbols(i)
+      checkInvalidPlugin(InvalidPluginName("extension.json", name)) {
+        it.copy(meta = it.meta?.copy(name = name))
+      }
+    }
+  }
+
+  @Test
+  fun `name contains only allowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomAllowedNameSymbols(i)
+      checkValidPlugin {
+        it.copy(meta = it.meta?.copy(name = name))
+      }
+    }
+  }
 
   @Test
   fun `id is not specified`() {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubInvalidPluginsTest.kt
@@ -97,6 +97,16 @@ class HubInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerT
   }
 
   @Test
+  fun `name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val pluginName = getRandomNotAllowedNameSymbols(i)
+      checkInvalidPlugin(InvalidPluginName("manifest.json", pluginName)) {
+        name = pluginName
+      }
+    }
+  }
+
+  @Test
   fun `version is not specified`() {
     checkInvalidPlugin(PropertyNotSpecified("version")) { version = null }
     checkInvalidPlugin(PropertyNotSpecified("version")) { version = "" }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
@@ -23,7 +23,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
     Assert.assertNotNull(existingPluginLevelRemapping)
     existingPluginLevelRemapping?.let {
       val ignoredProblems = it.findProblemsByLevel(IgnoredLevel)
-      assertThat(ignoredProblems.size, `is`(3))
+      assertThat(ignoredProblems.size, `is`(4))
     }
 
     val newPluginProblemSet = levelRemappings[RemappingSet.NEW_PLUGIN_REMAPPING_SET]

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/BasePluginManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/BasePluginManagerTest.kt
@@ -5,8 +5,10 @@ import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.plugin.PluginManager
+import com.jetbrains.plugin.structure.base.problems.ALLOWED_NAME_SYMBOLS
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.rules.FileSystemType
+import org.apache.commons.lang3.RandomStringUtils
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import java.nio.file.Path
@@ -50,6 +52,23 @@ abstract class BasePluginManagerTest<P : Plugin, M : PluginManager<P>>(fileSyste
 
   protected val extractedDirectory: Path by lazy {
     temporaryFolder.newFolder("extract")
+  }
+
+  protected fun getRandomNotAllowedNameSymbols(length: Int): String {
+    val pattern = ALLOWED_NAME_SYMBOLS
+    while (true) {
+      val randomChar = RandomStringUtils.random(length)
+      if (!randomChar.matches(pattern)) {
+        return randomChar
+      }
+    }
+  }
+
+  protected fun getRandomAllowedNameSymbols(length: Int): String {
+    val allowedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,+_-/:()#'[]|"
+    return (1..length)
+      .map { allowedCharacters.random() }
+      .joinToString("")
   }
 }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -17,6 +17,7 @@ import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
+import com.jetbrains.plugin.structure.base.utils.normalizeNewLines
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.problems.*
@@ -221,7 +222,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         perfectXmlBuilder.modify {
           name = "<name>$pluginName</name>"
         },
-        listOf(InvalidPluginName("plugin.xml", pluginName))
+        listOf(InvalidPluginName("plugin.xml", pluginName.normalizeNewLines()))
       )
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -100,11 +100,15 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
 
   @Test
   fun `plugin name contains newline`() {
+    val name = "Some\nname"
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        name = "<name>Some\nname</name>"
+        this.name = "<name>$name</name>"
       },
-      listOf(ContainsNewlines("name", "plugin.xml"))
+      listOf(
+        ContainsNewlines("name", "plugin.xml"),
+        InvalidPluginName("plugin.xml", name)
+      )
     )
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -106,7 +106,6 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         this.name = "<name>$name</name>"
       },
       listOf(
-        ContainsNewlines("name", "plugin.xml"),
         InvalidPluginName("plugin.xml", name)
       )
     )

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -3,6 +3,7 @@ package com.jetbrains.plugin.structure.mocks
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
 import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
+import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
 import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
 import com.jetbrains.plugin.structure.base.problems.NotBoolean
 import com.jetbrains.plugin.structure.base.problems.NotNumber
@@ -195,6 +196,41 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
       ).warnings.single()
       assertEquals(TemplateWordInPluginName("plugin.xml", pluginName, templateWord), warning)
     }
+  }
+
+  @Test
+  fun `plugin name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val pluginName = "bla ${getRandomNotAllowedNameSymbols(i)}bla"
+      `test invalid plugin xml`(
+        perfectXmlBuilder.modify {
+          name = "<name>$pluginName</name>"
+        },
+        listOf(InvalidPluginName("plugin.xml", pluginName))
+      )
+    }
+  }
+
+  @Test
+  fun `plugin name contains only allowed symbols`() {
+      (1..10).forEach { _ ->
+          val pluginName = getRandomAllowedNameSymbols(5)
+          val result = `test valid plugin xml`(
+              perfectXmlBuilder.modify {
+                  name = "<name>$pluginName</name>"
+              }
+          )
+          assertTrue(result.warnings.isEmpty())
+          assertTrue(result.unacceptableWarnings.isEmpty())
+      }
+    val nameWithAmpersand = "${getRandomAllowedNameSymbols(2)} &amp; ${getRandomAllowedNameSymbols(3)}"
+    val result = `test valid plugin xml`(
+      perfectXmlBuilder.modify {
+        name = "<name>$nameWithAmpersand</name>"
+      }
+    )
+    assertTrue(result.warnings.isEmpty())
+    assertTrue(result.unacceptableWarnings.isEmpty())
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
@@ -1,10 +1,11 @@
 package com.jetbrains.plugin.structure.teamcity.mock
 
 import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
+import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
+import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.base.utils.writeText
 import com.jetbrains.plugin.structure.mocks.BasePluginManagerTest
@@ -111,7 +112,7 @@ class TeamcityInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMan
   @Test
   fun `plugin display name name contains unallowed symbols`() {
     for (i in 1..10) {
-      val name = getRandomNotAllowedNameSymbols(i)
+      val name = getRandomInvalidXmlBasedPluginName(i)
       `test invalid plugin xml`(
         perfectXmlBuilder.modify {
           displayName = "<display-name>$name</display-name>"

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
@@ -6,6 +6,7 @@ import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
+import com.jetbrains.plugin.structure.base.utils.normalizeNewLines
 import com.jetbrains.plugin.structure.base.utils.simpleName
 import com.jetbrains.plugin.structure.base.utils.writeText
 import com.jetbrains.plugin.structure.mocks.BasePluginManagerTest
@@ -113,11 +114,16 @@ class TeamcityInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMan
   fun `plugin display name name contains unallowed symbols`() {
     for (i in 1..10) {
       val name = getRandomInvalidXmlBasedPluginName(i)
+      val expectedProblems = if (name.isBlank()) {
+        PropertyNotSpecified("display-name")
+      } else {
+        InvalidPluginName("teamcity-plugin.xml", name.normalizeNewLines())
+      }
       `test invalid plugin xml`(
         perfectXmlBuilder.modify {
           displayName = "<display-name>$name</display-name>"
         },
-        listOf(InvalidPluginName("teamcity-plugin.xml", name))
+        listOf(expectedProblems)
       )
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
@@ -1,5 +1,6 @@
 package com.jetbrains.plugin.structure.teamcity.mock
 
+import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
@@ -77,7 +78,6 @@ class TeamcityInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMan
     )
   }
 
-
   @Test
   fun `plugin display name is not specified`() {
     `test invalid plugin xml`(
@@ -106,6 +106,19 @@ class TeamcityInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMan
       },
       listOf(ForbiddenWordInPluginName(PLUGIN_NAME_FORBIDDEN_WORDS))
     )
+  }
+
+  @Test
+  fun `plugin display name name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomNotAllowedNameSymbols(i)
+      `test invalid plugin xml`(
+        perfectXmlBuilder.modify {
+          displayName = "<display-name>$name</display-name>"
+        },
+        listOf(InvalidPluginName("teamcity-plugin.xml", name))
+      )
+    }
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
@@ -40,6 +40,26 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
   }
 
   @Test
+  fun `name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomNotAllowedNameSymbols(i)
+      checkInvalidPlugin(InvalidPluginName("extension.json", name)) {
+        it.copy(meta = it.meta?.copy(name = name))
+      }
+    }
+  }
+
+  @Test
+  fun `name contains only allowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomAllowedNameSymbols(i)
+      checkValidPlugin {
+        it.copy(meta = it.meta?.copy(name = name))
+      }
+    }
+  }
+
+  @Test
   fun `id is not specified`() {
     checkInvalidPlugin(PropertyNotSpecified("id")) { it.copy(id = null) }
     checkInvalidPlugin(PropertyNotSpecified("id")) { it.copy(id = "") }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -59,7 +59,7 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
   }
 
   @Test
-  fun `name contains unallowed symbols`() {
+  fun `title contains unallowed symbols`() {
     for (i in 1..10) {
       val name = getRandomNotAllowedNameSymbols(i)
       checkInvalidPlugin(InvalidPluginName("manifest.json", name)) {
@@ -69,11 +69,11 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
   }
 
   @Test
-  fun `name contains only allowed symbols`() {
+  fun `title contains only allowed symbols`() {
     for (i in 1..10) {
       val name = getRandomAllowedNameSymbols(i)
       checkValidPlugin {
-        it.copy(name = name)
+        it.copy(title = name)
       }
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -59,6 +59,26 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
   }
 
   @Test
+  fun `name contains unallowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomNotAllowedNameSymbols(i)
+      checkInvalidPlugin(InvalidPluginName("manifest.json", name)) {
+        it.copy(title = name)
+      }
+    }
+  }
+
+  @Test
+  fun `name contains only allowed symbols`() {
+    for (i in 1..10) {
+      val name = getRandomAllowedNameSymbols(i)
+      checkValidPlugin {
+        it.copy(name = name)
+      }
+    }
+  }
+
+  @Test
   fun `invalid app title`() {
     checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE)) { it.copy(title = null) }
     checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.TITLE)) { it.copy(title = "") }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -3,7 +3,6 @@ package com.jetbrains.pluginverifier.tests
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
@@ -583,8 +582,7 @@ class ExistingPluginValidationTest : BasePluginTest() {
             }
         }
         assertSuccess(result)
-        result.assertContainsWarning<InvalidPluginName>("Invalid plugin descriptor 'plugin.xml'. " +
-                "Name '$name' contains invalid characters. Only the following characters are allowed: letters, digits, spaces, and .,+_-/:()#'&[]|")
+        assertNoProblems((result as PluginCreationSuccess).warnings)
     }
 
   private fun pluginOf(header: String): ContentBuilder.() -> Unit = {


### PR DESCRIPTION
Introduce `InvalidPluginName` as an error for plugins that do not have a valid name.

This is an _error_ for new IntelliJ plugins and a _warning_ for existing IntelliJ plugins.

Note that plugin names that contain newlines will be automatically checked by the new rule, instead of `ContainsNewLine`.

See [MP-7202](https://youtrack.jetbrains.com/issue/MP-7202)