### PR TITLE
Add JARs in the 'lib' directory to the plugin classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Changed
 
+- Add JARs in the 'lib' directory to the plugin classpath ([#1343](https://github.com/JetBrains/intellij-plugin-verifier/pull/1343), [MP-7742](https://youtrack.jetbrains.com/issue/MP-7742))
+
 ### Fixed
 
 ## 1.395 - 2025-08-25

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -39,5 +39,10 @@ enum class ClasspathOrigin {
   /**
    * Declared in `product-info.json`
    */
-  PRODUCT_INFO
+  PRODUCT_INFO,
+
+  /**
+   * Available in the artifact - usually in the 'lib' directory
+   */
+  PLUGIN_ARTIFACT
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/Classpath.kt
@@ -26,6 +26,26 @@ class Classpath private constructor(val entries: List<ClasspathEntry> = emptyLis
     }
   }
 
+  fun mergeWith(other: Classpath): Classpath {
+    if (other.entries.isEmpty()) return this
+    if (this.entries.isEmpty()) return other
+
+    val pathToEntry = mutableMapOf<Path, ClasspathEntry>()
+
+    for (cpEntry in this.entries + other.entries) {
+      val path = cpEntry.path
+      val existingCpEntry = pathToEntry[path]
+      if (existingCpEntry == null) {
+        pathToEntry[path] = cpEntry
+      } else if (existingCpEntry.origin == IMPLICIT && cpEntry.origin != IMPLICIT) {
+        pathToEntry[path] = cpEntry
+      }
+    }
+
+    return Classpath(pathToEntry.values.toList())
+  }
+
+
   override fun toString(): String = entries.joinToString(separator = ":", prefix = "[", postfix = "]")
 }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/LibDirJarsClasspathProvider.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/LibDirJarsClasspathProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.utils.exists
+import com.jetbrains.plugin.structure.base.utils.listJars
+import java.nio.file.Path
+
+private const val MODULES_DIR = "modules"
+
+/**
+ * Return all JAR files available in the 'lib' directory of the plugin artifact path.
+ */
+class LibDirJarsClasspathProvider {
+  fun getClasspath(path: Path): Classpath {
+    val libDir = path.resolve(LIB_DIRECTORY)
+    if (!libDir.exists()) {
+      return Classpath.EMPTY
+    }
+    val jarPaths = libDir.listJars()
+    return Classpath.of(jarPaths, ClasspathOrigin.PLUGIN_ARTIFACT)
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -834,6 +834,7 @@ class DependenciesTest {
 
     val expectedClassPath = """
       plugins/java-coverage/lib/java-coverage.jar
+      plugins/java-coverage/lib/jacoco.jar
       plugins/testng/lib/testng-plugin.jar
       plugins/java/lib/java-impl.jar
       plugins/java/lib/java-frontback.jar
@@ -841,6 +842,11 @@ class DependenciesTest {
       plugins/java/lib/modules/intellij.java.featuresTrainer.jar
       plugins/java/lib/modules/intellij.java.vcs.jar
       plugins/java/lib/modules/intellij.java.structuralSearch.jar
+      plugins/java/lib/maven-resolver-transport-http.jar
+      plugins/java/lib/maven-resolver-transport-file.jar
+      plugins/java/lib/netty-codec-protobuf.jar
+      plugins/java/lib/jps-builders.jar
+      plugins/java/lib/maven-resolver-connector-basic.jar
       plugins/copyright/lib/copyright.jar
       lib/product.jar
       lib/testFramework.jar
@@ -892,6 +898,15 @@ class DependenciesTest {
       lib/modules/intellij.platform.ide.newUiOnboarding.jar
       lib/modules/intellij.libraries.microba.jar
       lib/modules/intellij.execution.process.mediator.common.jar
+      lib/app.jar
+      lib/lib-client.jar
+      lib/groovy.jar
+      lib/protobuf.jar
+      lib/lib.jar
+      lib/opentelemetry.jar
+      lib/jsch-agent.jar
+      lib/util-8.jar
+      lib/util.jar
       plugins/platform-images/lib/platform-images.jar
       plugins/featuresTrainer/lib/featuresTrainer.jar
       plugins/vcs-git/lib/vcs-git.jar
@@ -902,14 +917,16 @@ class DependenciesTest {
       plugins/markdown/lib/modules/intellij.markdown.compose.preview.jar
       plugins/platform-langInjection/lib/platform-langInjection.jar
       plugins/xpath/lib/xpath.jar
-      plugins/Kotlin/lib/kotlin-plugin-shared.jar
-      plugins/Kotlin/lib/kotlin-plugin.jar
       plugins/json/lib/json.jar
       plugins/yaml/lib/yaml-editing.jar
       plugins/yaml/lib/yaml.jar
       plugins/toml/lib/toml.jar
       plugins/grazie/lib/grazie.jar
       plugins/properties/lib/properties.jar
+      plugins/Kotlin/lib/kotlin-plugin-shared.jar
+      plugins/Kotlin/lib/kotlin-plugin.jar
+      plugins/Kotlin/lib/kotlin-gradle-tooling.jar
+      plugins/Kotlin/lib/kotlinc.kotlin-compiler-common.jar
       plugins/junit/lib/junit.jar
     """.trimIndent().split("\\s".toRegex()).toSet()
 


### PR DESCRIPTION
Add all JARs in the 'lib' directory of the plugin to the `classpath`.

This will add additional JARs on top of the JARs that contain content module. Duplicate JARs in the classpath are consolidated with a single origin - explicit JARs have precedence over implicit ones.

See [MP-7742](https://youtrack.jetbrains.com/issue/MP-7742) Plugin Verifier: Scala JARs are not discovered in transitive dependencies