### PR TITLE
Fix NPE during ProductModuleV2 construction when missing classPath field

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/ProductInfo.kt
@@ -73,10 +73,19 @@ sealed class LayoutComponent(val kind: String) {
   }
 
   data class ProductModuleV2(
-    @JsonProperty("name") override val name: String,
-    @JsonProperty("classPath")
+    override val name: String,
     val classPaths: List<String>,
   ) : LayoutComponent("productModuleV2"), Classpathable {
+
+    companion object {
+      @JvmStatic
+      @JsonCreator
+      fun create(
+        @JsonProperty("name") name: String,
+        @JsonProperty("classPath") classPaths: List<String>?,
+      ): ProductModuleV2 = ProductModuleV2(name, classPaths ?: emptyList())
+    }
+
     override fun getClasspath() = classPaths.paths
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/platform/ProductInfoParserTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/platform/ProductInfoParserTest.kt
@@ -42,6 +42,37 @@ class ProductInfoParserTest {
   }
 
   @Test
+  fun `productModuleV2 with missing classPath field is deserialized as empty classpath`() {
+    val json = """
+      {
+        "name": "Gateway",
+        "version": "2026.1",
+        "versionSuffix": null,
+        "buildNumber": "261.1234.56",
+        "productCode": "GW",
+        "dataDirectoryName": "JetBrainsGateway2026.1",
+        "svgIconPath": "bin/gateway.svg",
+        "productVendor": "JetBrains",
+        "launch": [],
+        "bundledPlugins": [],
+        "modules": [],
+        "layout": [
+          {
+            "name": "intellij.gateway.backend.core",
+            "kind": "productModuleV2"
+          }
+        ]
+      }
+    """.trimIndent()
+
+    val productInfo = productInfoParser.parse(json.byteInputStream(), "test")
+
+    val productModules = productInfo.layout.filterIsInstance<LayoutComponent.ProductModuleV2>()
+    assertEquals(1, productModules.size)
+    assertEquals(emptyList<String>(), productModules.single().classPaths)
+  }
+
+  @Test
   fun `product-info JSON is serialized`() {
     val jackson = ObjectMapper()
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/MP-8060/ProductModuleV2-doesnt-handle-missing-classPath-field-in-Gateway-2026.1-product-info.json