### PR TITLE
Fix optional dependency tracking on product-info code path

### DIFF
--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolver.kt
@@ -5,7 +5,6 @@
 package com.jetbrains.plugin.structure.ide.classes.resolver
 
 import com.jetbrains.plugin.structure.base.BinaryClassName
-import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.classes.resolvers.*
 import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode.FULL
 import com.jetbrains.plugin.structure.ide.*
@@ -228,13 +227,12 @@ class ProductInfoClassResolver private constructor(
     fun of(ide: Ide, readMode: ReadMode = FULL): ProductInfoClassResolver = of(ide, IdeResolverConfiguration(readMode))
 
     @Throws(InvalidIdeException::class)
-    private fun assertProductInfoPresent(idePath: Path) {
-      if (!idePath.containsProductInfoJson()) {
-        throw InvalidIdeException(idePath, "The '$PRODUCT_INFO_JSON' file is not available.")
-      }
+    private fun requireProductInfoJson(idePath: Path): Path {
+      return resolveProductInfoJsonPath(idePath)
+        ?: throw InvalidIdeException(idePath, "The '$PRODUCT_INFO_JSON' file is not available.")
     }
 
-    fun supports(idePath: Path): Boolean = idePath.containsProductInfoJson()
+    fun supports(idePath: Path): Boolean = resolveProductInfoJsonPath(idePath) != null
       && isAtLeastVersion(idePath, "242")
 
     private fun isAtLeastVersion(idePath: Path, expectedVersion: String): Boolean {
@@ -248,21 +246,14 @@ class ProductInfoClassResolver private constructor(
     @Throws(InvalidIdeException::class)
     private fun parseProductInfo(ide: Ide): ProductInfo {
       val idePath = ide.idePath
-      assertProductInfoPresent(idePath)
+      val productInfoJson = requireProductInfoJson(idePath)
       val productInfoParser = ProductInfoParser()
       try {
-        return productInfoParser.parse(idePath.productInfoJson)
+        return productInfoParser.parse(productInfoJson)
       } catch (e: ProductInfoParseException) {
         throw InvalidIdeException(idePath, e)
       }
     }
-
-    private fun Path.containsProductInfoJson(): Boolean = resolve(PRODUCT_INFO_JSON).exists()
-
-    private val Path.productInfoJson: Path
-      get() {
-        return resolve(PRODUCT_INFO_JSON)
-      }
   }
 
   private class LayoutComponentResolver(

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManager.kt
@@ -20,9 +20,21 @@ import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
 import java.io.IOException
 import java.nio.file.Path
 
-internal const val PRODUCT_INFO_JSON = "product-info.json"
-internal const val MACOS_RESOURCES_DIRECTORY = "Resources"
+private const val PRODUCT_INFO_JSON = "product-info.json"
+private const val MACOS_RESOURCES_DIRECTORY = "Resources"
 internal val VERSION_FROM_PRODUCT_INFO: IdeVersion? = null
+
+/**
+ * Resolves the `product-info.json` path for an IDE, checking both the root directory
+ * (Linux/Windows) and `Resources/` subdirectory (macOS).
+ */
+fun resolveProductInfoJsonPath(idePath: Path): Path? {
+  val locations = listOf(
+    idePath.resolve(PRODUCT_INFO_JSON),
+    idePath.resolve(MACOS_RESOURCES_DIRECTORY).resolve(PRODUCT_INFO_JSON)
+  )
+  return locations.firstOrNull { it.exists() }
+}
 
 class ProductInfoBasedIdeManager(
   missingLayoutFileMode: MissingLayoutFileMode = SKIP_AND_WARN,
@@ -38,9 +50,9 @@ class ProductInfoBasedIdeManager(
   override fun createIde(idePath: Path): Ide = createIde(idePath, VERSION_FROM_PRODUCT_INFO)
 
   override fun createIde(idePath: Path, version: IdeVersion?): Ide {
-    assertProductInfoPresent(idePath)
+    val productInfoJson = assertProductInfoPresent(idePath)
     try {
-      val productInfo = productInfoParser.parse(idePath.productInfoJson!!)
+      val productInfo = productInfoParser.parse(productInfoJson)
       val ideVersion = version ?: createIdeVersion(productInfo)
       return createIde(idePath, ideVersion, productInfo)
     } catch (e: ProductInfoParseException) {
@@ -92,21 +104,13 @@ class ProductInfoBasedIdeManager(
   private fun LayoutComponents.asSource(idePath: Path, ideVersion: IdeVersion) =
     ProductInfoLayoutComponentsPluginCollectionSource(idePath, ideVersion, this)
 
-  private val Path.productInfoJson: Path?
-    get() {
-      val locations = listOf<Path>(
-        resolve(PRODUCT_INFO_JSON),
-        resolve(MACOS_RESOURCES_DIRECTORY).resolve(PRODUCT_INFO_JSON)
-      )
-      return locations.firstOrNull { it.exists() }
-    }
-
   @Throws(InvalidIdeException::class)
   private fun assertProductInfoPresent(idePath: Path): Path {
-    return idePath.productInfoJson ?: throw InvalidIdeException(idePath, "The '$PRODUCT_INFO_JSON' file is not available.")
+    return resolveProductInfoJsonPath(idePath)
+      ?: throw InvalidIdeException(idePath, "The '$PRODUCT_INFO_JSON' file is not available.")
   }
 
-  fun supports(idePath: Path): Boolean = idePath.productInfoJson != null
+  fun supports(idePath: Path): Boolean = resolveProductInfoJsonPath(idePath) != null
     && isAtLeastVersion(idePath, "242")
 
   private fun isAtLeastVersion(idePath: Path, expectedVersion: String): Boolean {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTree.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTree.kt
@@ -141,6 +141,7 @@ class DependencyTree(private val pluginProvider: PluginProvider, private val ide
             // TODO log if a dependency might be provided by another plugin with different plugin
             debugLog(nestedIndent, i + 1, "Resolved cached dependency '{}'", dep.id)
           } else if (dep in missingDependencies) {
+            context.notifyMissingDependency(plugin, dep)
             debugLog(nestedIndent, i + 1, "Skipping dependency '{}' as it is already marked missing", dep.id)
           } else {
             when (val dependencyPlugin = resolve(dep)) {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/ProductInfoClassResolverTest.kt
@@ -134,6 +134,20 @@ class ProductInfoClassResolverTest {
   }
 
   @Test
+  fun `resolver supports macOS IDE with product-info in Resources directory`() {
+    val macIdeRoot = temporaryFolder.newFolder("idea-macos").toPath()
+    val resourcesDir = macIdeRoot.resolve("Resources")
+    Files.createDirectories(resourcesDir)
+    copyResource("/ide/productInfo/product-info_mini.json", resourcesDir.resolve("product-info.json"))
+    macIdeRoot.resolve("build.txt").writeText(IDEA_ULTIMATE_2024_2)
+
+    assertTrue(
+      "ProductInfoClassResolver should support macOS IDE layout with Resources/product-info.json",
+      ProductInfoClassResolver.supports(macIdeRoot)
+    )
+  }
+
+  @Test
   fun `resolver does not parse ProductInfo-aware IDE`() {
     val ideRoot = temporaryFolder.newFolder("idea-${UUID.randomUUID()}").toPath()
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
@@ -6,7 +6,9 @@ package com.jetbrains.pluginverifier.dependencies.resolution
 
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.classes.resolvers.CompositeResolver
+import com.jetbrains.plugin.structure.ide.ProductInfoAware
 import com.jetbrains.plugin.structure.ide.classes.IdeResolverCreator
+import com.jetbrains.plugin.structure.ide.classes.resolver.ProductInfoClassResolver
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfoParser
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
@@ -284,6 +286,142 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
       }
     }
   }
+
+  @Test
+  fun `optional dependency missing from product-info IDE is tracked in missingDependencies`() {
+    val ideVersionString = "261.22158.291"
+
+    val ideRoot = buildDirectory(temporaryFolder.newFolder("goland-${UUID.randomUUID()}").toPath()) {
+      dir("lib") {
+        file("app.jar", createEmptyZipByteArray())
+        file("idea_rt.jar", createEmptyZipByteArray())
+      }
+      file("build.txt", "GO-$ideVersionString")
+      file("product-info.json", productInfoJsonGO261)
+    }
+
+    val productInfoParser = ProductInfoParser()
+    val jdkDescriptorProvider = DefaultJdkDescriptorProvider()
+
+    val productInfo = productInfoParser.parse(ByteArrayInputStream(productInfoJsonGO261.toByteArray()), "Unit Test")
+    // GoLand-like IDE: has com.intellij core and com.intellij.tasks (which also depends on com.intellij.java),
+    // but does NOT have com.intellij.java itself.
+    // This reproduces the bug where DFS resolves com.intellij.tasks first, encounters com.intellij.java as missing
+    // for com.intellij.tasks, and then when the hermit plugin's own com.intellij.java dependency is processed,
+    // it was already in the shared missingDependencies set and the notification was skipped for the hermit plugin.
+    val optionalJavaDependencyForTasks = PluginDependencyImpl("com.intellij.java", true, false)
+    val bundledPlugins = listOf(
+      MockIdePlugin("com.intellij", pluginName = "IDEA Core", pluginVersion = ideVersionString,
+        pluginAliases = setOf("com.intellij.modules.platform"),
+        dependencies = listOf(
+          // com.intellij declares a dependency on com.intellij.tasks
+          PluginDependencyImpl("com.intellij.tasks", true, false)
+        )),
+      MockIdePlugin("com.intellij.tasks", pluginName = "Tasks", pluginVersion = ideVersionString,
+        dependencies = listOf(
+          // com.intellij.tasks depends on com.intellij.java (optional) — this gets resolved first in DFS
+          optionalJavaDependencyForTasks
+        ))
+    )
+    val ide = MockProductInfoAwareIde(ideRoot, productInfo, bundledPlugins)
+    val ideResolver = IdeResolverCreator.createIdeResolver(ide)
+    val jdkResult = jdkDescriptorProvider.getJdkDescriptor(ide, defaultJdkPath = null)
+    assertTrue(jdkResult is JdkDescriptorProvider.Result.Found)
+    jdkResult as JdkDescriptorProvider.Result.Found
+
+    val ideDescriptor = IdeDescriptor(ide, ideResolver, jdkResult.jdkDescriptor, ideFileLock = null)
+
+    // Verify we're on the product-info path
+    assertTrue(
+      "ideResolver should be ProductInfoClassResolver but was ${ideResolver::class.simpleName}",
+      ideResolver is ProductInfoClassResolver
+    )
+    assertTrue(
+      "ide should be ProductInfoAware",
+      ide is com.jetbrains.plugin.structure.ide.ProductInfoAware
+    )
+
+    // Plugin with mandatory platform dep + optional Java dep (like hermit-ij-plugin)
+    val optionalJavaDependency = PluginDependencyImpl("com.intellij.java", true, false)
+    val hermitLikePlugin = MockIdePlugin(
+      pluginId = "org.example.hermit",
+      pluginVersion = "1.0",
+      dependencies = listOf(platformModuleDependency, optionalJavaDependency)
+    )
+
+    val emptyDependencyFinder = RuleBasedDependencyFinder.create(ide)
+    val resolverProvider =
+      DefaultClassResolverProvider(emptyDependencyFinder, ideDescriptor, packageFilter, archiveManager = archiveManager)
+
+    val classResolver = resolverProvider.provide(hermitLikePlugin.getDetails())
+    with(classResolver.dependenciesGraph) {
+      // The optional com.intellij.java should be in missingDependencies
+      val allMissingDeps = missingDependencies.values.flatten()
+      val javaMissing = allMissingDeps.find { it.dependency.id == "com.intellij.java" }
+      assertTrue(
+        "com.intellij.java should be in missingDependencies on product-info path, but missingDependencies=$missingDependencies",
+        javaMissing != null
+      )
+      assertTrue(
+        "com.intellij.java should be marked as optional",
+        javaMissing!!.dependency.isOptional
+      )
+
+      // Verify getDirectMissingDependencies also works (this is what analyzeMissingClassesCausedByMissingOptionalDependencies uses)
+      val directMissing = getDirectMissingDependencies()
+      val javaDirectMissing = directMissing.find { it.dependency.id == "com.intellij.java" }
+      assertTrue(
+        "com.intellij.java should be in getDirectMissingDependencies(), but got: $directMissing, verifiedPlugin=$verifiedPlugin, missingDependencies keys=${missingDependencies.keys}",
+        javaDirectMissing != null
+      )
+    }
+  }
+
+  @Language("JSON")
+  private val productInfoJsonGO261 = """
+    {
+      "name": "GoLand",
+      "version": "2026.1",
+      "buildNumber": "261.22158.291",
+      "productCode": "GO",
+      "envVarBaseName": "GOLAND",
+      "dataDirectoryName": "GoLand2026.1",
+      "svgIconPath": "../bin/goland.svg",
+      "productVendor": "JetBrains",
+      "launch": [
+        {
+          "os": "Linux",
+          "arch": "amd64",
+          "launcherPath": "bin/goland",
+          "javaExecutablePath": "jbr/bin/java",
+          "vmOptionsFilePath": "bin/goland64.vmoptions",
+          "bootClassPathJarNames": [
+            "app.jar",
+            "idea_rt.jar"
+          ]
+        }
+      ],
+      "bundledPlugins": [],
+      "modules": [],
+      "layout": [
+        {
+          "name": "com.intellij",
+          "kind": "plugin",
+          "classPath": [
+            "lib/app.jar",
+            "lib/idea_rt.jar"
+          ]
+        },
+        {
+          "name": "com.intellij.tasks",
+          "kind": "plugin",
+          "classPath": [
+            "lib/app.jar"
+          ]
+        }
+      ]
+    }
+  """.trimIndent()
 
   private fun createEmptyZipByteArray(): ByteArray {
     val buffer = ByteArrayOutputStream()


### PR DESCRIPTION
For IDEs with `product-info.json`, `DefaultClassResolverProvider` resolves dependencies via `DependencyTree`. When `DependencyTree.getDependencyGraph` walks dependencies depth-first, a shared `missingDependencies` set tracks unresolvable deps. If a transitive dependency (e.g. `com.intellij.tasks`) encounters a missing optional dep (e.g. `com.intellij.java`) first, the root plugin's own reference to that same dep was silently skipped: it was already in the set but `notifyMissingDependency` was never called for the root plugin. This caused `getDirectMissingDependencies()` to return empty, so `analyzeMissingClassesCausedByMissingOptionalDependencies` never fired and the `ClassNotFoundProblem`s were reported as real compatibility errors.

I was trying to update the Hermit IntelliJ plugin to build against 261 (cashapp/hermit-ij-plugin#127) but was unable to get it to pass `verifyPlugin` checks against GoLand in CI ([failing build](https://github.com/cashapp/hermit-ij-plugin/actions/runs/24542807972/job/71753747727?pr=127)). The product-info code path (`DependencyTree`) is only used for IDEs version 242+. GoLand 251 has `product-info.json` but fewer bundled plugins with transitive optional deps on `com.intellij.java`, so the DFS ordering didn't trigger the bug. In 261, GoLand bundles `com.intellij.tasks` (which also optionally depends on `com.intellij.java`), and the DFS resolves that transitive dep first, poisoning the shared `missingDependencies` set before the root plugin's own optional dep is processed.

This PR fixes these two related but separate bugs in separate commits:

**Commit 1**: Extract `resolveProductInfoJsonPath()` from `ProductInfoBasedIdeManager` and use it in `ProductInfoClassResolver`. Previously `ProductInfoClassResolver.supports()` only checked for `product-info.json` at the IDE root, missing the macOS `Resources/` layout. This made the bug invisible on macOS (it silently fell back to the legacy code path and `verifyPlugin` passed locally but not in linux CI).

**Commit 2**: Call `notifyMissingDependency` in `DependencyTree` even when the dep is already in the shared set, so every plugin that depends on it gets recorded. Includes a regression test with a GoLand-like IDE setup from the Hermit PR that fails without the fix.


