### PR TITLE
Strict mode on classpath construction for JARs in `lib/modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Changed
 
+- Arbitrary JARs in `lib/modules` do not automatically become part of the `classpath` in `IdePlugin`. Any such JAR must belong to a plugin content module that is explicitly declared in the `plugin.xml` ([#1479](https://github.com/JetBrains/intellij-plugin-verifier/pull/1479))  
+
 ### Fixed
 
 ## 1.402 - 2026-04-01

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BasePluginTest.kt
@@ -59,7 +59,7 @@ abstract class BasePluginTest {
     <id>$pluginId</id>
     <name>$pluginName</name>
     <version>$pluginVersion</version>
-    ""<vendor email="vendor.com" url="url">$vendor</vendor>""
+    <vendor email="vendor.com" url="url">$vendor</vendor>
     <description>$description</description>
     <change-notes>these change-notes are looooooooooong enough</change-notes>
     <idea-version since-build="$sinceBuild" until-build="$untilBuild"/>

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ContentModuleFixture.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ContentModuleFixture.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.intellij.plugin.ModuleLoadingRule
+
+object ContentModuleFixture {
+  fun content(build: ContentDsl.() -> Unit): String {
+    val dsl = ContentDsl()
+    dsl.build()
+    return dsl.toXml()
+  }
+
+  class ContentDsl {
+    private val modules = mutableListOf<PluginContentModuleDsl>()
+
+    fun module(name: String) {
+      modules += PluginContentModuleDsl(name, ModuleLoadingRule.OPTIONAL)
+    }
+
+    fun embeddedModule(name: String) {
+      modules += PluginContentModuleDsl(name, ModuleLoadingRule.EMBEDDED)
+    }
+
+    internal fun toXml(): String =
+      buildString {
+        append("<content>\n")
+        modules.forEach { module ->
+          append("<module name=\"")
+          append(module.name)
+          append("\"")
+          if (module.loadingRule == ModuleLoadingRule.EMBEDDED) {
+            append(" loading=\"embedded\"")
+          }
+          append(" />\n")
+        }
+        append("</content>")
+      }
+  }
+
+  private data class PluginContentModuleDsl(val name: String, val loadingRule: ModuleLoadingRule)
+
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ContentModuleFixtureTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ContentModuleFixtureTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tests
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ContentModuleFixtureTest {
+  @Test
+  fun `content DSL renders regular and embedded modules`() {
+    val content = ContentModuleFixture.content {
+      module("intellij.json.frontend.split")
+      embeddedModule("intellij.json")
+      module("intellij.json.backend")
+    }
+
+    assertEquals(
+      """
+      <content>
+      <module name="intellij.json.frontend.split" />
+      <module name="intellij.json" loading="embedded" />
+      <module name="intellij.json.backend" />
+      </content>
+      """.trimIndent(),
+      content
+    )
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -18,6 +18,7 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.pluginverifier.createPluginResolver
 import com.jetbrains.pluginverifier.resolution.BundledPluginClassResolverProvider
+import com.jetbrains.pluginverifier.tests.ContentModuleFixture.content
 import com.jetbrains.pluginverifier.tests.mocks.classBytes
 import com.jetbrains.pluginverifier.tests.mocks.descriptor
 import net.bytebuddy.ByteBuddy
@@ -159,7 +160,12 @@ class PluginClasspathTest : BasePluginTest() {
   }
 
   @Test
-  fun `lib-module and a main JAR are discovered`() {
+  fun `lib-module and a main JAR classpath is composed with content modules in the main plugin descriptor`() {
+    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON")+
+      content {
+        module("intellij.json.split")
+      }
+
     val result = buildPluginInDirectory {
       dir("lib") {
         dir("modules") {
@@ -168,7 +174,7 @@ class PluginClasspathTest : BasePluginTest() {
           }
         }
         zip("json.jar") {
-          descriptor(ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON"))
+          descriptor(pluginXml)
           file("intellij.json.xml", "<idea-plugin />")
         }
       }
@@ -178,6 +184,73 @@ class PluginClasspathTest : BasePluginTest() {
         assertEquals(2, size)
         assertTrue(containsFileName("json.jar"))
         assertTrue(containsFileName("intellij.json.split.jar"))
+      }
+    }
+  }
+
+  @Test
+  fun `classpath is deduced from the content modules in the main plugin descriptor and actual JARs in lib slash modules directory`() {
+    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON")+
+      content {
+        module("intellij.json.frontend.split")
+        embeddedModule("intellij.json")
+        module("intellij.json.backend")
+        module("intellij.json.backend.regexp")
+        embeddedModule("intellij.json.syntax")
+      }
+
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        dir("modules") {
+          zip("intellij.json.backend.jar") {
+            file("intellij.json.backend.xml", "<idea-plugin />")
+          }
+          zip("intellij.json.backend.regexp.jar") {
+            file("intellij.json.backend.regexp.xml", "<idea-plugin />")
+          }
+          zip("intellij.json.frontend.split.jar") {
+            file("intellij.json.frontend.split.xml", "<idea-plugin />")
+          }
+        }
+        zip("json.jar") {
+          descriptor(pluginXml)
+          file("intellij.json.xml", "<idea-plugin />")
+          file("intellij.json.syntax.xml", "<idea-plugin />")
+        }
+      }
+    }
+    assertSuccess(result) {
+      with(plugin.classpath) {
+        assertEquals(4, size)
+        assertTrue(containsFileName("json.jar"))
+        assertTrue(containsFileName("intellij.json.backend.jar"))
+        assertTrue(containsFileName("intellij.json.frontend.split.jar"))
+        assertTrue(containsFileName("intellij.json.backend.regexp.jar"))
+      }
+    }
+  }
+
+  @Test
+  fun `lib-module does not belong to the classpath if not declared in the main plugin descriptor`() {
+    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON")
+
+    val result = buildPluginInDirectory {
+      dir("lib") {
+        dir("modules") {
+          zip("intellij.json.split.jar") {
+            file("intellij.json.split.xml", "<idea-plugin />")
+          }
+        }
+        zip("json.jar") {
+          descriptor(pluginXml)
+          file("intellij.json.xml", "<idea-plugin />")
+        }
+      }
+    }
+    assertSuccess(result) {
+      with(plugin.classpath) {
+        assertEquals(1, size)
+        assertTrue(containsFileName("json.jar"))
       }
     }
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/PluginClasspathTest.kt
@@ -161,7 +161,7 @@ class PluginClasspathTest : BasePluginTest() {
 
   @Test
   fun `lib-module and a main JAR classpath is composed with content modules in the main plugin descriptor`() {
-    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON")+
+    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON") +
       content {
         module("intellij.json.split")
       }
@@ -190,7 +190,7 @@ class PluginClasspathTest : BasePluginTest() {
 
   @Test
   fun `classpath is deduced from the content modules in the main plugin descriptor and actual JARs in lib slash modules directory`() {
-    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON")+
+    val pluginXml = ideaPlugin(pluginId = "com.intellij.modules.json", pluginName = "JSON") +
       content {
         module("intellij.json.frontend.split")
         embeddedModule("intellij.json")


### PR DESCRIPTION
Be more strict when constructing `IdePlugin` elements in `classpath` property for JARs in `lib/modules`.

Each entry in this classpath must be declared in the main `plugin.xml` in the corresponding `<module>` in the `<content>` element, as per Plugin Model v2 spec. 

This means that random JARs in `lib/modules` do not automatically become a part of the `classpath`.