### PR TITLE
Clarify missing product info layout element semantics

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIde.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIde.kt
@@ -5,7 +5,6 @@
 package com.jetbrains.plugin.structure.ide
 
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
-import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import org.jetbrains.annotations.ApiStatus
 import java.nio.file.Path
@@ -27,18 +26,14 @@ class ProductInfoBasedIde private constructor(
 
   override fun getVersion() = version
 
-  override fun getBundledPlugins(): List<IdePlugin> = plugins
+  override fun getBundledPlugins() = plugins
 
-  override fun hasBundledPlugin(pluginId: String): Boolean {
-    return productInfo.layout.any { it.name == pluginId }
-  }
+  override fun hasBundledPlugin(pluginId: String) = productInfo.layout.any { it.name == pluginId }
 
   override fun getIdePath() = idePath
 
   @ApiStatus.Internal
-  fun isPluginCollectionLoaded(): Boolean {
-    return _plugins.isInitialized()
-  }
+  fun isPluginCollectionLoaded() = _plugins.isInitialized()
 
   fun <T> getPluginCollectionSource(resourceType: Class<T>): PluginCollectionSource<Path, T>? {
     @Suppress("UNCHECKED_CAST")

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIde.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/ProductInfoBasedIde.kt
@@ -4,8 +4,6 @@
 
 package com.jetbrains.plugin.structure.ide
 
-import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
-import com.jetbrains.plugin.structure.ide.layout.LayoutComponentsAware
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
@@ -17,7 +15,7 @@ class ProductInfoBasedIde private constructor(
   private val version: IdeVersion,
   override val productInfo: ProductInfo,
   private val pluginCollectionProviders: Map<PluginCollectionSource<Path, *>, PluginCollectionProvider<Path>>
-) : Ide(), ProductInfoAware, LayoutComponentsAware {
+) : Ide(), ProductInfoAware {
 
   private val _plugins = lazy {
     pluginCollectionProviders.flatMap { (source, provider) ->
@@ -26,10 +24,6 @@ class ProductInfoBasedIde private constructor(
   }
 
   private val plugins by _plugins
-
-  override val layoutComponents: LayoutComponents
-    get() = getPluginCollectionSource(LayoutComponents::class.java)?.resource
-      ?: LayoutComponents.of(idePath, productInfo)
 
   override fun getVersion() = version
 

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
@@ -9,24 +9,27 @@ enum class MissingLayoutFileMode {
    * Do not perform any validation of the layout component classpath.
    *
    * The IDE will be created anyway, but its structure might be incomplete or semantically incorrect.
-    */
+   */
   IGNORE,
 
   /**
    * When any classpath element is missing, it will be skipped while all other valid classpath elements remain in use.
    * Additionally, warn about missing classpath elements in the log.
    */
-  SKIP_MISSING_ELEMENTS,
+  SKIP_MISSING_CLASSPATH_ELEMENTS,
+
   /**
    * When any classpath element is missing, skip all classpath elements in the layout component.
    * Don't log anything.
    */
   SKIP_SILENTLY,
+
   /**
    * When any classpath element is missing, skip all classpath elements in the layout component.
    * Warn about missing classpath elements in the log.
    */
   SKIP_AND_WARN,
+
   /**
    * When any classpath element is missing, throw an exception.
    *

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
@@ -6,7 +6,7 @@ package com.jetbrains.plugin.structure.ide.layout
 
 enum class MissingLayoutFileMode {
   /**
-   * Do not perform any validation of layout component classpath.
+   * Do not perform any validation of the layout component classpath.
    *
    * The IDE will be created anyway, but its structure might be incomplete or semantically incorrect.
     */

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/MissingLayoutFileMode.kt
@@ -13,9 +13,10 @@ enum class MissingLayoutFileMode {
   IGNORE,
 
   /**
-   * When any classpath element is missing, skip it but retain the available classpath elements.
+   * When any classpath element is missing, it will be skipped while all other valid classpath elements remain in use.
+   * Additionally, warn about missing classpath elements in the log.
    */
-  SKIP_CLASSPATH,
+  SKIP_MISSING_ELEMENTS,
   /**
    * When any classpath element is missing, skip all classpath elements in the layout component.
    * Don't log anything.

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ValidatingLayoutComponentsProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ValidatingLayoutComponentsProvider.kt
@@ -32,7 +32,7 @@ class ValidatingLayoutComponentsProvider(private val missingLayoutFileMode: Miss
         if (missingLayoutFileMode == FAIL) {
           throw MissingClasspathFileInLayoutComponentException.of(idePath, validatedComponents.failedComponents)
         }
-        if (missingLayoutFileMode == SKIP_MISSING_ELEMENTS) {
+        if (missingLayoutFileMode == SKIP_MISSING_CLASSPATH_ELEMENTS) {
           acceptedComponents += validatedComponents.skipMissingClasspathElements()
         }
         logUnavailableClasspath(validatedComponents.failures)

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ValidatingLayoutComponentsProvider.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/resolver/ValidatingLayoutComponentsProvider.kt
@@ -4,13 +4,8 @@
 
 package com.jetbrains.plugin.structure.ide.resolver
 
-import com.jetbrains.plugin.structure.ide.layout.IdeRelativePath
-import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
-import com.jetbrains.plugin.structure.ide.layout.LayoutComponentsProvider
-import com.jetbrains.plugin.structure.ide.layout.MissingClasspathFileInLayoutComponentException
-import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode
+import com.jetbrains.plugin.structure.ide.layout.*
 import com.jetbrains.plugin.structure.ide.layout.MissingLayoutFileMode.*
-import com.jetbrains.plugin.structure.ide.layout.ResolvedLayoutComponent
 import com.jetbrains.plugin.structure.ide.problem.IdeProblem
 import com.jetbrains.plugin.structure.ide.problem.LayoutComponentHasNonExistentClasspath
 import com.jetbrains.plugin.structure.intellij.platform.LayoutComponent
@@ -37,7 +32,7 @@ class ValidatingLayoutComponentsProvider(private val missingLayoutFileMode: Miss
         if (missingLayoutFileMode == FAIL) {
           throw MissingClasspathFileInLayoutComponentException.of(idePath, validatedComponents.failedComponents)
         }
-        if (missingLayoutFileMode == SKIP_CLASSPATH) {
+        if (missingLayoutFileMode == SKIP_MISSING_ELEMENTS) {
           acceptedComponents += validatedComponents.skipMissingClasspathElements()
         }
         logUnavailableClasspath(validatedComponents.failures)

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
@@ -84,7 +84,7 @@ class LayoutComponentsProviderTest {
       val ideProblem = first()
       assertTrue(ideProblem is LayoutComponentHasNonExistentClasspath)
       ideProblem as LayoutComponentHasNonExistentClasspath
-      ideProblem.layoutComponentName == "com.jetbrains.somePlugin"
+      assertEquals("com.jetbrains.somePlugin", ideProblem.layoutComponentName)
       val expectedMissingClasspathElements = listOf("missingComponentOne.jar", "missingComponentTwo.jar").map {
         IdeRelativePath(idePath, Path.of(it))
       }

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
@@ -67,7 +67,7 @@ class LayoutComponentsProviderTest {
   @Test
   fun `product info with a single layout component that has one valid and two missing classpath elements will skip missing classpath elements`() {
     val (idePath, productInfo) = parseProductInfo(productInfoJsonWithMissingJarInClasspath)
-    val provider = ValidatingLayoutComponentsProvider(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val provider = ValidatingLayoutComponentsProvider(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
     val layoutComponents = provider.resolveLayoutComponents(productInfo, idePath)
 
     assertEquals(1, layoutComponents.toList().size)

--- a/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
+++ b/intellij-plugin-structure/structure-ide/src/test/kotlin/com/jetbrains/plugin/structure/ide/resolver/LayoutComponentsProviderTest.kt
@@ -67,7 +67,7 @@ class LayoutComponentsProviderTest {
   @Test
   fun `product info with a single layout component that has one valid and two missing classpath elements will skip missing classpath elements`() {
     val (idePath, productInfo) = parseProductInfo(productInfoJsonWithMissingJarInClasspath)
-    val provider = ValidatingLayoutComponentsProvider(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val provider = ValidatingLayoutComponentsProvider(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
     val layoutComponents = provider.resolveLayoutComponents(productInfo, idePath)
 
     assertEquals(1, layoutComponents.toList().size)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoIdeManagerLazyLoadingTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoIdeManagerLazyLoadingTest.kt
@@ -15,7 +15,7 @@ class ProductInfoIdeManagerLazyLoadingTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
       .createIde(ideRoot)
     assertTrue(ide is ProductInfoAware)
     ide as ProductInfoBasedIde

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoIdeManagerLazyLoadingTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoIdeManagerLazyLoadingTest.kt
@@ -15,7 +15,7 @@ class ProductInfoIdeManagerLazyLoadingTest {
     ideUrl!!
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
       .createIde(ideRoot)
     assertTrue(ide is ProductInfoAware)
     ide as ProductInfoBasedIde

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -671,7 +671,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
       .createIde(ideRoot)
     then(ide.bundledPlugins).hasSize(279)
 
@@ -725,7 +725,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
       .createIde(ideRoot)
 
     then(ide.bundledPlugins).hasSize(503)
@@ -782,7 +782,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
       .createIde(ideRoot)
 
     val coveragePlugin = ide.findPluginById("Coverage")
@@ -838,7 +838,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_CLASSPATH_ELEMENTS)
       .createIde(ideRoot)
 
     val coveragePlugin = ide.findPluginById("Coverage")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependenciesTest.kt
@@ -671,7 +671,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
       .createIde(ideRoot)
     then(ide.bundledPlugins).hasSize(279)
 
@@ -725,7 +725,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
       .createIde(ideRoot)
 
     then(ide.bundledPlugins).hasSize(503)
@@ -782,7 +782,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
       .createIde(ideRoot)
 
     val coveragePlugin = ide.findPluginById("Coverage")
@@ -838,7 +838,7 @@ class DependenciesTest {
     assertNotNull(ideUrl, "Dumped IDE not found in the resources [$ideResourceLocation]")
     val ideRoot = Paths.get(ideUrl.toURI())
 
-    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_CLASSPATH)
+    val ide = ProductInfoBasedIdeManager(MissingLayoutFileMode.SKIP_MISSING_ELEMENTS)
       .createIde(ideRoot)
 
     val coveragePlugin = ide.findPluginById("Coverage")


### PR DESCRIPTION
- Rename `SKIP_CLASSPATH` to `SKIP_MISSING_CLASSPATH_ELEMENTS`
- Remove `LayoutComponentsAware` interface from `ProductInfoBasedIde`. When necessary, this can be obtained from `getPluginCollectionSource()`.