### PR TITLE
Migrate JAXB to Jakarta namespace

### DIFF
--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ asm = "9.9.1"
 commons-compress = "1.28.0"
 evo-inflector = "1.3"
 jackson-dataformat-yaml = "2.14.2"
-jaxb = "2.3.1"
+jaxb = "4.0.2"
 jdom = "2.0.6.1"
 jimfs = "1.3.1"
 kotlinx-metadata = "0.9.0"
@@ -22,7 +22,7 @@ asm-util = { group = "org.ow2.asm", name = "asm-util", version.ref = "asm" }
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress" }
 evo-inflector = { group = "org.atteo", name = "evo-inflector", version.ref = "evo-inflector" }
 jackson-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jackson-dataformat-yaml" }
-jaxb-api = { group = "javax.xml.bind", name = "jaxb-api", version.ref = "jaxb" }
+jaxb-api = { group = "jakarta.xml.bind", name = "jakarta.xml.bind-api", version.ref = "jaxb" }
 jaxb-runtime = { group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb" }
 jdom = { group = "org.jdom", name = "jdom2", version.ref = "jdom" }
 jimfs = { group = "com.google.jimfs", name = "jimfs", version.ref = "jimfs" }

--- a/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/beans/ReSharperPluginBean.kt
+++ b/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/beans/ReSharperPluginBean.kt
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.dotnet.beans
 
-import javax.xml.bind.annotation.*
+import jakarta.xml.bind.annotation.*
 
 @XmlRootElement(name = "package")
 class NuspecDocumentBean {

--- a/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/beans/ReSharperPluginBeanExtractor.kt
+++ b/intellij-plugin-structure/structure-dotnet/src/main/kotlin/com/jetbrains/plugin/structure/dotnet/beans/ReSharperPluginBeanExtractor.kt
@@ -7,8 +7,8 @@ package com.jetbrains.plugin.structure.dotnet.beans
 import com.jetbrains.plugin.structure.xml.DefaultXMLDocumentBuilderProvider
 import org.xml.sax.SAXParseException
 import java.io.InputStream
-import javax.xml.bind.JAXBContext
-import javax.xml.bind.UnmarshalException
+import jakarta.xml.bind.JAXBContext
+import jakarta.xml.bind.UnmarshalException
 
 
 object ReSharperPluginBeanExtractor {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ContentModuleDependencyBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ContentModuleDependencyBean.java
@@ -6,7 +6,7 @@ package com.jetbrains.plugin.structure.intellij.beans;
 
 import org.jetbrains.annotations.Nullable;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class ContentModuleDependencyBean {
   @XmlAttribute(name = "name") public String moduleName;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/IdeaVersionBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/IdeaVersionBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class IdeaVersionBean {
   @XmlAttribute(name = "since-build") public String sinceBuild;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ModuleBean.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ModuleBean.kt
@@ -1,10 +1,10 @@
 package com.jetbrains.plugin.structure.intellij.beans
 
 import java.nio.file.Path
-import javax.xml.bind.annotation.XmlAttribute
-import javax.xml.bind.annotation.XmlElement
-import javax.xml.bind.annotation.XmlElementWrapper
-import javax.xml.bind.annotation.XmlRootElement
+import jakarta.xml.bind.annotation.XmlAttribute
+import jakarta.xml.bind.annotation.XmlElement
+import jakarta.xml.bind.annotation.XmlElementWrapper
+import jakarta.xml.bind.annotation.XmlRootElement
 
 private const val DEFAULT_NAME: String = "##default"
 private const val DEFAULT_PATH: String = "##default"

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginAliasBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginAliasBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class PluginAliasBean {
   @XmlAttribute(name = "value") String value;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginAliasItemAdapter.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginAliasItemAdapter.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 public class PluginAliasItemAdapter extends XmlAdapter<PluginAliasBean, String> {
   @Override

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
@@ -6,8 +6,8 @@ package com.jetbrains.plugin.structure.intellij.beans;
 
 import org.jdom2.Element;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginContentBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginContentBean.java
@@ -4,8 +4,8 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependenciesBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependenciesBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependenciesPluginBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependenciesPluginBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class PluginDependenciesPluginBean {
   @XmlAttribute(name = "id") public String dependencyId;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependencyBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginDependencyBean.java
@@ -4,8 +4,8 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * Plugin dependency mapped to {@code <depends>} element in <code>plugin.xml</code>.

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginHelpSetBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginHelpSetBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class PluginHelpSetBean {
   @XmlAttribute(name = "file") public String file;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginModuleBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginModuleBean.java
@@ -4,8 +4,8 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 public class PluginModuleBean {
   @XmlAttribute(name = "name") public String moduleName;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginVendorBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginVendorBean.java
@@ -5,8 +5,8 @@
 package com.jetbrains.plugin.structure.intellij.beans;
 
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlValue;
 
 public class PluginVendorBean {
   @XmlAttribute(name = "url") public String url = "";

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ProductDescriptorBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/ProductDescriptorBean.java
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import javax.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlAttribute;
 
 public class ProductDescriptorBean {
   @XmlAttribute(name = "code") public String code;

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/ModuleUnmarshaller.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/ModuleUnmarshaller.kt
@@ -4,9 +4,9 @@ import com.jetbrains.plugin.structure.base.utils.inputStream
 import com.jetbrains.plugin.structure.intellij.beans.ModuleBean
 import java.io.StringReader
 import java.nio.file.Path
-import javax.xml.bind.JAXBContext
-import javax.xml.bind.JAXBException
-import javax.xml.bind.Unmarshaller
+import jakarta.xml.bind.JAXBContext
+import jakarta.xml.bind.JAXBException
+import jakarta.xml.bind.Unmarshaller
 
 object ModuleUnmarshaller {
   private val jaxbContext by lazy {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/PluginBeanExtractor.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/extractor/PluginBeanExtractor.kt
@@ -7,8 +7,8 @@ package com.jetbrains.plugin.structure.intellij.extractor
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import org.jdom2.Document
 import org.jdom2.transform.JDOMSource
-import javax.xml.bind.JAXBContext
-import javax.xml.bind.JAXBException
+import jakarta.xml.bind.JAXBContext
+import jakarta.xml.bind.JAXBException
 
 object PluginBeanExtractor {
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/BundledModulesResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/platform/BundledModulesResolver.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
-import javax.xml.bind.JAXBException
+import jakarta.xml.bind.JAXBException
 import kotlin.streams.asSequence
 
 private val LOG: Logger = LoggerFactory.getLogger(BundledModulesResolver::class.java)

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/platform/ModuleBeanParsingTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/platform/ModuleBeanParsingTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.nio.file.Path
-import javax.xml.bind.UnmarshalException
+import jakarta.xml.bind.UnmarshalException
 
 class ModuleBeanParsingTest {
   @Test

--- a/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/beans/TeamcityPluginBean.kt
+++ b/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/beans/TeamcityPluginBean.kt
@@ -4,7 +4,7 @@
 
 package com.jetbrains.plugin.structure.teamcity.beans
 
-import javax.xml.bind.annotation.*
+import jakarta.xml.bind.annotation.*
 
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlRootElement(name = "teamcity-plugin")

--- a/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/beans/TeamcityPluginBeanExtractor.kt
+++ b/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/beans/TeamcityPluginBeanExtractor.kt
@@ -7,8 +7,8 @@ package com.jetbrains.plugin.structure.teamcity.beans
 import com.jetbrains.plugin.structure.xml.DefaultXMLDocumentBuilderProvider
 import org.xml.sax.SAXParseException
 import java.io.InputStream
-import javax.xml.bind.JAXBContext
-import javax.xml.bind.UnmarshalException
+import jakarta.xml.bind.JAXBContext
+import jakarta.xml.bind.UnmarshalException
 
 object TeamcityPluginBeanExtractor {
   private val jaxbContext = JAXBContext.newInstance(TeamcityPluginBean::class.java)


### PR DESCRIPTION
We need to migrate from Java EE to Jakarta in Marketplace because newer versions of Hibernate brings a new `org.glassfish.jaxb:jaxb-runtime` that is not backward compatible.

I suggest not rushing this and first evaluating how difficult it will be to migrate other clients to a newer runtime. Please add more people to review. 

I also recommend releasing the important upcoming changes first, and then handling the migration in a separate version to avoid getting stuck, since the full migration in Marketplace will take some time. Maybe we can release it as dev build?

To check how hard the migration might be the following commands might be usefull:
```
./gradlew dependencyInsight --dependency org.glassfish.jaxb:jaxb-runtime --configuration runtimeClasspath
```