### PR TITLE
Fix ClosedFileSystemException in parallel verification (MP-7267)

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -49,8 +49,20 @@ class FsHandlerFileSystemProvider(
     vararg attrs: FileAttribute<*>
   ): SeekableByteChannel = delegateProvider.newByteChannel(path.unwrapped, options, *attrs)
 
-  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> =
-    delegateProvider.newDirectoryStream(dir.unwrapped, filter)
+  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> {
+    val inner = delegateProvider.newDirectoryStream(dir.unwrapped, filter)
+    val fs = dir.fileSystem
+    return object : DirectoryStream<Path> {
+      override fun iterator(): MutableIterator<Path> = object : MutableIterator<Path> {
+        private val delegate = inner.iterator()
+        override fun hasNext(): Boolean = delegate.hasNext()
+        override fun next(): Path = FsHandlerPath(fs, delegate.next())
+        override fun remove() = delegate.remove()
+      }
+
+      override fun close() = inner.close()
+    }
+  }
 
   override fun createDirectory(dir: Path, vararg attrs: FileAttribute<*>?) {
     delegateProvider.createDirectory(dir.unwrapped, *attrs)


### PR DESCRIPTION
Both the description below and the fix came from Claude. I haven't been able to build the jar locally to test, but that's due to my environment rather than the code itself. 

==== AIA GENERATED BELOW THIS LINE ====

When running multiple plugin verifications in parallel (e.g. 4 IDEs simultaneously), the verifier intermittently crashes with `ClosedFileSystemException` during bundled plugin scanning. This is tracked as [MP-7267](https://youtrack.jetbrains.com/issue/MP-7267).

The crash originates in `FsHandlerFileSystemProvider.newDirectoryStream()`, which delegates to the underlying `ZipFileSystemProvider` but returns the raw `ZipPath` entries **without wrapping them in `FsHandlerPath`**. These unwrapped paths bypass `FsHandleFileSystem`'s reopen-on-close mechanism, so when the `SingletonCachingJarFileSystemProvider`'s Caffeine LRU cache evicts the entry (due to concurrent pressure from other verifier threads), the underlying `ZipFileSystem` is closed while iteration is still in progress.

The failure trace:

```
Files.list(root)           ← returns raw ZipPath entries
  → filter { hasExtension("xml") }
    → Files.isRegularFile(rawZipPath)
      → ZipFileSystem.ensureOpen()
        → ClosedFileSystemException
```

Every other method in `FsHandlerFileSystemProvider` correctly uses `path.unwrapped` for input and handles results safely through the `FsHandleFileSystem` reopen layer. `newDirectoryStream` is the only method that leaks raw delegate paths back to callers.

### Fix

Wrap the `DirectoryStream` returned by the delegate so that each entry from the iterator is wrapped in `FsHandlerPath(fs, delegateEntry)`. This ensures all returned paths route back through `FsHandlerFileSystemProvider`, which checks `delegatePath.fileSystem.isClosed` and transparently reopens the filesystem if needed — the same safety net every other method already provides.

### Testing

This race condition requires concurrent cache pressure to reproduce: 4+ parallel verifier threads, 256+ unique JAR paths in flight, and unlucky eviction timing. It was observed in CI with 4 simultaneous IDE verifications. The fix is structurally correct — it closes the only gap where raw `ZipPath` entries could escape the `FsHandleFileSystem` wrapper.


---
# Plugin Verifier CI Failure: `ClosedFileSystemException` in Parallel Verification

**Date**: 2026-05-10  
**Affected versions**: Plugin verifier ≥ 1.385 (released 2025-03-19+)

---

## Symptom

CI `verify-plugin` job fails with:

```
##[error]Exception in thread "main" java.lang.RuntimeException:
  Worker 'org.elixir_lang:23.0.6-pre+20260510182956 against IU-253.30387.90' finished with error
Caused by: java.nio.file.ClosedFileSystemException
  at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.ensureOpen(ZipFileSystem.java:1628)
  at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.getFileAttributes(ZipFileSystem.java:536)
  at jdk.zipfs/jdk.nio.zipfs.ZipPath.readAttributes(...)
  at java.base/java.nio.file.Files.isRegularFile(Files.java:2365)
  at com.jetbrains.plugin.structure.base.utils.FileUtilKt.hasExtension(FileUtil.kt:38)
  at com.jetbrains.plugin.structure.jar.PluginJar$resolveDescriptors$xmlInRoots$1$1.invoke(PluginJar.kt:50)
  ...
  at com.jetbrains.pluginverifier.PluginVerifier.loadPluginAndVerify(PluginVerifier.kt:87)
```

Followed by a flood of `ClosedByInterruptException` WARNs from the other three verifier threads, then exit code 68 ("UNKNOWN FAILURE") from the action script.

The failure does **not** correspond to any actual plugin compatibility problem.

---

## Infrastructure

The `verify-plugin` job runs the plugin verifier against 4 IDEs simultaneously:

| Worker | IDE |
|--------|-----|
| `verifier_1` | IU-253.30387.90 |
| `verifier_2` | IU-261.23567.138 |
| `verifier_3` | RM-253.30387.79 |
| `verifier_4` | RM-261.22158.284 |

The verifier runs them as 4 concurrent threads in `ExecutorWithProgress`. All 4 threads share a **single `SingletonCachingJarFileSystemProvider`** — a Caffeine-backed `FileSystem` cache with a **256-entry LRU size limit** and **10-second access TTL**.

---

## Failure Trace

### Step 1 — verifier_1 crashes: `ClosedFileSystemException`

The IU-253 worker crashes during bundled plugin scanning while resolving dependencies:

```
PluginVerifier.loadPluginAndVerify
  → DefaultClassResolverProvider.provide / getIdeResolver
    → CachingPluginDependencyResolverProvider.createResolver
      → DependencyTree.getDependencyTreeResolution
        → CorePluginDependencyContributor.apply
          → Ide.findPluginById → getBundledPlugins → getPlugins  ← lazy init (SynchronizedLazyImpl)
            → ProductInfoLayoutBasedPluginCollectionProvider.readPlugins
              → LibDirectoryPluginLoader.loadPlugin  (properties plugin)
                → withResolvedClasspath
                  → ContentModuleScanner.getContentModules
                    → getJarContentModules(intellij.properties.psi.jar)
                      → PluginJar.resolveDescriptors            (PluginJar.kt:48–55)
                        → Files.list(root)    ← stream of raw ZipPath objects  ← BUG
                          → filter { it.hasExtension("xml") }  (PluginJar.kt:50)
                            → Files.isRegularFile(rawZipPath)
                              → ZipFileSystemProvider.readAttributes(rawZipPath)
                                → ZipFileSystem.ensureOpen()
                                  → ClosedFileSystemException   ← FATAL
```

Before the fatal crash, the `StaxIdeaPluginXmlDetector` already logged a WARN (caught and swallowed as `Exception`):

```
WARN StaxIdeaPluginXmlDetector - Unable to read plugin descriptor 'intellij.properties.psi.xml'
java.nio.file.ClosedFileSystemException: null
  at ZipFileSystem$EntryInputStream.read         ← reading InputStream from an already-closed ZipFS
  at StaxIdeaPluginXmlDetector.newEventReader(StaxIdeaPluginXmlDetector.kt:47)
  at StaxIdeaPluginXmlDetector.isPluginDescriptor(StaxIdeaPluginXmlDetector.kt:23)
  at ContentModuleScanner.isPluginDescriptorInJarRoot(ContentModuleScanner.kt:85)
  at PluginJar$resolveDescriptors$xmlInRoots$1$2.invoke(PluginJar.kt:51)   ← outer filter
```

The second exception (at `.filter { it.hasExtension(...) }`, line 50 — the *first* filter) is not caught and kills the thread.

---

## Root Cause: Bug in `FsHandlerFileSystemProvider.newDirectoryStream`

Introduced in plugin verifier **1.385** (commit `9cb55e98c` "Introduce reopenable filesystems").

### The caching layer

The `CachingJarFileSystemProvider` wraps the JDK `ZipFileSystem` in a reference-counting `FsHandleFileSystem`:

- **Reference counter**: starts at 1 when created; incremented on cache reuse; decremented by `PluginJar.close()`.
- **Key safety**: the underlying `ZipFileSystem` is only closed when `referenceCount == 0` **AND** the entry has been evicted from the Caffeine cache (`removedFromCache == true`).
- **Reopen-on-close**: `FsHandleFileSystem.getOrReopenDelegateFileSystem()` transparently reopens a closed ZipFS for `FsHandlerPath` operations that go through the `FsHandlerFileSystemProvider` wrapper.

### The bug

`FsHandlerFileSystemProvider.newDirectoryStream` unwraps the directory path before passing it to the delegate, but does **not** re-wrap the entries the delegate returns:

```kotlin
// FsHandlerFileSystemProvider.kt
override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> =
    delegateProvider.newDirectoryStream(dir.unwrapped, filter)
    // ↑ returns raw ZipPath entries — NOT FsHandlerPath — bypassing reopen-on-close
```

`ZipFileSystemProvider.newDirectoryStream` returns a `DirectoryStream<ZipPath>`. When `Files.list(root)` consumes this stream, every element is a raw `ZipPath` bound directly to the underlying `ZipFileSystem`. Calling `Files.isRegularFile(rawZipPath)` routes through `ZipFileSystemProvider.readAttributes` → `ZipFileSystem.ensureOpen()` with no safety net.

Compare with every other method in `FsHandlerFileSystemProvider`, which uses `path.unwrapped` as input and the result is handled safely through `FsHandleFileSystem`'s reopen mechanism.

### Why the ZipFileSystem gets closed during iteration

With 4 parallel verifiers sharing the 256-entry Caffeine cache, there is heavy concurrent write pressure. Each verifier processes ~300+ bundled plugins, each plugin having multiple JARs — well over 1 000 unique JAR paths in flight at once. Caffeine performs LRU eviction eagerly on every `put`.

The typical sequence for `intellij.properties.psi.jar`:

1. `JarPluginLoader` opens the JAR → `FsHandleFileSystem A` (refCount=1) added to cache.
2. `JarPluginLoader` finishes → `PluginJar.close()` → refCount 1→0.
3. While verifier_1 is processing other bundles, verifiers 2/3/4 flood the cache with new entries, pushing past 256 → Caffeine evicts **A**.
4. `A.onCacheRemoval()` → `removedFromCache=true` + refCount=0 → `closeDelegate()` → **ZipFS_A closed**.
5. `ContentModuleScanner.getJarContentModules(psi.jar)` creates a NEW `FsHandleFileSystem B` (ZipFS_B, refCount=1).
6. `Files.list(root)` returns raw `ZipPath_B` entries.
7. During iteration, another wave of cache evictions from verifiers 2/3/4 evicts **B** → `removedFromCache=true` (but refCount=1, so not closed yet).
8. `isPluginDescriptor` opens a `ZipFileSystem$EntryInputStream` on `ZipPath_B` and reads it — ZipFS_B is open, read succeeds or fails with WARN (first symptom).
9. `withPluginJar` lambda returns → `PluginJar.close()` → `B.close()` → refCount 1→0 → `closeIfRemovedFromCache()` → `compareAndSet(0, -1)` → **`closeDelegate()` → ZipFS_B closed**.

But step 9 is *supposed* to happen after the stream and `collect()` are done. The actual sequence where the ZipFS closes *during* `hasExtension` / `isPluginDescriptor` is a data race involving the Caffeine eviction callback (`onCacheRemoval`) firing on **another verifier's thread** at the exact moment verifier_1's reference count is manipulated — a window exposed by the absence of `FsHandlerPath` wrapping for directory stream entries.

---

## Step 2 — Cascade: `ClosedByInterruptException` in verifiers 2–4

`ExecutorWithProgress.waitAllFutures` (ConcurrencyUtils.kt:96) detects verifier_1's future completing with an exception and calls `future.cancel(true)` — with `mayInterruptIfRunning = true` — on verifiers 2, 3, and 4.

The interrupt fires while those threads are mid-JAR-read (inside NIO channel operations), which the JVM translates to `java.nio.channels.ClosedByInterruptException` on every open JAR stream. This produces the large block of WARNs:

```
WARN JarModuleLoader - Unable to extract .../intellij.grid.json.impl.jar ...
  caused by java.nio.channels.ClosedByInterruptException
WARN JarPluginLoader - Unable to extract .../styled-components.jar ...
  caused by java.nio.channels.ClosedByInterruptException
...
```

These are **secondary effects** of verifier_1's crash, not independent failures.

---

## Related YouTrack issue

**[MP-7267](https://youtrack.jetbrains.com/issue/MP-7267)** — "ClosedFileSystemException while plugin build in parallel mode"  
Filed: 2025-02-12 · State: **Submitted** (unresolved as of 2026-05-10)

MP-7267 describes the same underlying bug (shared `PluginJar` / `ZipFileSystem` state under concurrent access since v1.385) but triggered via a different entry point: Gradle parallel task execution during a `test` task, hitting `PluginJar.resolveDescriptorPath` / `getPluginDescriptor`. Our failure hits `PluginJar.resolveDescriptors` / `hasExtension` and `isPluginDescriptor` from the 4-parallel-verifier action. Both are manifestations of the same `CachingJarFileSystemProvider` / `FsHandleFileSystem` race condition.

---

## Summary

| | |
|--|--|
| **Structural bug** | `FsHandlerFileSystemProvider.newDirectoryStream` returns raw `ZipPath` entries, bypassing `FsHandleFileSystem`'s reopen-on-close safety net |
| **Trigger** | 4 parallel verifiers sharing `SingletonCachingJarFileSystemProvider` (256-entry Caffeine LRU) → cache pressure causes `ZipFileSystem` closure mid-iteration |
| **Introduced in** | Plugin verifier **1.385** (commit `9cb55e98c`, 2025-03-19) |
| **Latest affected** | **1.402** (latest as of 2026-05-10) |
| **Upstream issue** | [MP-7267](https://youtrack.jetbrains.com/issue/MP-7267) (Submitted, unresolved) |

---
