### PR TITLE
Fix closed filesystem exception

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import java.net.URI
 import java.nio.channels.SeekableByteChannel
 import java.nio.file.AccessMode
+import java.nio.file.ClosedFileSystemException
 import java.nio.file.CopyOption
 import java.nio.file.DirectoryStream
 import java.nio.file.FileStore
@@ -47,10 +48,27 @@ class FsHandlerFileSystemProvider(
     path: Path,
     options: Set<OpenOption>,
     vararg attrs: FileAttribute<*>
-  ): SeekableByteChannel = delegateProvider.newByteChannel(path.unwrapped, options, *attrs)
+  ): SeekableByteChannel = retryOnClosedFs(path) { p ->
+    delegateProvider.newByteChannel(p, options, *attrs)
+  }
 
-  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> =
-    delegateProvider.newDirectoryStream(dir.unwrapped, filter)
+  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> {
+    val inner = delegateProvider.newDirectoryStream(dir.unwrapped, filter)
+    // Only wrap entries when the caller actually came through the FsHandlerPath layer.
+    // For a raw delegate path, dir.fileSystem is the underlying ZipFileSystem, which would
+    // produce FsHandlerPath instances that bypass the reopen mechanism anyway.
+    val fs = (dir as? FsHandlerPath)?.fileSystem ?: return inner
+    return object : DirectoryStream<Path> {
+      override fun iterator(): MutableIterator<Path> = object : MutableIterator<Path> {
+        private val delegate = inner.iterator()
+        override fun hasNext(): Boolean = delegate.hasNext()
+        override fun next(): Path = FsHandlerPath(fs, delegate.next())
+        override fun remove() = delegate.remove()
+      }
+
+      override fun close() = inner.close()
+    }
+  }
 
   override fun createDirectory(dir: Path, vararg attrs: FileAttribute<*>?) {
     delegateProvider.createDirectory(dir.unwrapped, *attrs)
@@ -92,13 +110,17 @@ class FsHandlerFileSystemProvider(
     path: Path,
     type: Class<A>,
     vararg options: LinkOption
-  ): A = delegateProvider.readAttributes(path.unwrapped, type, *options)
+  ): A = retryOnClosedFs(path) { p ->
+    delegateProvider.readAttributes(p, type, *options)
+  }
 
   override fun readAttributes(
     path: Path,
     attributes: String,
     vararg options: LinkOption
-  ): Map<String, Any> = delegateProvider.readAttributes(path.unwrapped, attributes, *options)
+  ): Map<String, Any> = retryOnClosedFs(path) { p ->
+    delegateProvider.readAttributes(p, attributes, *options)
+  }
 
   override fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption): Unit =
     delegateProvider.setAttribute(path.unwrapped, attribute, value, *options)
@@ -119,4 +141,11 @@ class FsHandlerFileSystemProvider(
     } else {
       this
     }
+
+  // Handles the race where the delegate FS is closed between `unwrapped`'s isClosed check and the NIO call.
+  private inline fun <T> retryOnClosedFs(path: Path, op: (Path) -> T): T = try {
+    op(path.unwrapped)
+  } catch (_: ClosedFileSystemException) {
+    op(path.unwrapped)
+  }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -8,15 +8,32 @@ import com.jetbrains.plugin.structure.base.fs.isClosed
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isFile
 import com.jetbrains.plugin.structure.base.utils.writeText
+import com.jetbrains.plugin.structure.fs.FsHandlerFileSystemProvider
+import com.jetbrains.plugin.structure.fs.FsHandlerPath
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.AccessMode
+import java.nio.file.ClosedFileSystemException
+import java.nio.file.CopyOption
+import java.nio.file.DirectoryStream
+import java.nio.file.FileStore
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.OpenOption
 import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileAttribute
+import java.nio.file.attribute.FileAttributeView
+import java.nio.file.spi.FileSystemProvider
+import java.util.concurrent.atomic.AtomicInteger
 
 class CachingJarFileSystemProviderTest {
 
@@ -206,4 +223,92 @@ class CachingJarFileSystemProviderTest {
   private fun FileSystem.hasSameDelegate(fs: FileSystem): Boolean {
     return (this as? FsHandleFileSystem)?.hasSameDelegate(fs) == true
   }
+
+  // Regression: MP-7468. newDirectoryStream used to return raw ZipPath entries, so any
+  // downstream Files.* call on them bypassed FsHandleFileSystem's reopen-on-close safety net.
+  @Test
+  fun `newDirectoryStream entries are FsHandlerPath and recover after a delegate close`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+    val fs = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val root = fs.getPath("/")
+
+    val entries = Files.newDirectoryStream(root).use { it.toList() }
+    assertTrue("expected at least one entry in the JAR root", entries.isNotEmpty())
+    entries.forEach { assertTrue("entry $it is not wrapped: ${it::class}", it is FsHandlerPath) }
+
+    // Simulate Caffeine evicting the cached ZipFileSystem after entries were collected.
+    fs.initialDelegateFileSystem.close()
+
+    val hello = entries.first { it.fileName.toString() == "hello.txt" }
+    // Routes through FsHandlerFileSystemProvider.readAttributes -> unwrapped -> reopen.
+    assertTrue(Files.isRegularFile(hello))
+  }
+
+  // Regression: MP-7468. Targets the TOCTOU window in `unwrapped` — the FS is open at the
+  // isClosed() check but closes (from another thread / Caffeine eviction) before the NIO
+  // call lands. The stub simulates exactly that race by throwing ClosedFileSystemException
+  // on the first invocation without actually closing the FS, so only the catch-and-retry
+  // can recover.
+  @Test
+  fun `read operations retry once on transient ClosedFileSystemException`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+    val fs = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val helloPath = fs.getPath("hello.txt")
+
+    val realDelegateProvider = fs.initialDelegateFileSystem.provider()
+    val flaky = ThrowsOnceClosedFsProvider(realDelegateProvider)
+    val handler = FsHandlerFileSystemProvider(flaky, NoopJarFileSystemProvider)
+
+    val attrs = handler.readAttributes(helloPath, BasicFileAttributes::class.java)
+    assertTrue(attrs.isRegularFile)
+    assertEquals(2, flaky.readAttributesCalls.get())
+
+    val content = handler.newByteChannel(helloPath, emptySet()).use { channel ->
+      val buf = ByteBuffer.allocate(attrs.size().toInt())
+      while (buf.hasRemaining() && channel.read(buf) >= 0) { /* read until EOF */ }
+      String(buf.array(), 0, buf.position(), Charsets.UTF_8)
+    }
+    assertEquals("Hello World", content)
+    assertEquals(2, flaky.newByteChannelCalls.get())
+  }
+}
+
+private object NoopJarFileSystemProvider : JarFileSystemProvider {
+  override fun getFileSystem(jarPath: Path): FileSystem = throw UnsupportedOperationException()
+}
+
+// FileSystemProvider stub that throws ClosedFileSystemException on the first call to
+// newByteChannel / readAttributes(Class) and then delegates. Other methods are not exercised
+// by the tests and intentionally throw.
+private class ThrowsOnceClosedFsProvider(private val delegate: FileSystemProvider) : FileSystemProvider() {
+  val newByteChannelCalls = AtomicInteger(0)
+  val readAttributesCalls = AtomicInteger(0)
+
+  override fun getScheme(): String = delegate.scheme
+
+  override fun newByteChannel(path: Path, options: Set<OpenOption>, vararg attrs: FileAttribute<*>): SeekableByteChannel {
+    if (newByteChannelCalls.getAndIncrement() == 0) throw ClosedFileSystemException()
+    return delegate.newByteChannel(path, options, *attrs)
+  }
+
+  override fun <A : BasicFileAttributes> readAttributes(path: Path, type: Class<A>, vararg options: LinkOption): A {
+    if (readAttributesCalls.getAndIncrement() == 0) throw ClosedFileSystemException()
+    return delegate.readAttributes(path, type, *options)
+  }
+
+  override fun newFileSystem(uri: URI, env: Map<String, *>): FileSystem = throw UnsupportedOperationException()
+  override fun getFileSystem(uri: URI): FileSystem = throw UnsupportedOperationException()
+  override fun getPath(uri: URI): Path = throw UnsupportedOperationException()
+  override fun newDirectoryStream(dir: Path, filter: DirectoryStream.Filter<in Path>): DirectoryStream<Path> = throw UnsupportedOperationException()
+  override fun createDirectory(dir: Path, vararg attrs: FileAttribute<*>?) = throw UnsupportedOperationException()
+  override fun delete(path: Path) = throw UnsupportedOperationException()
+  override fun copy(source: Path, target: Path, vararg options: CopyOption) = throw UnsupportedOperationException()
+  override fun move(source: Path, target: Path, vararg options: CopyOption) = throw UnsupportedOperationException()
+  override fun isSameFile(path: Path, path2: Path): Boolean = throw UnsupportedOperationException()
+  override fun isHidden(path: Path): Boolean = throw UnsupportedOperationException()
+  override fun getFileStore(path: Path): FileStore = throw UnsupportedOperationException()
+  override fun checkAccess(path: Path, vararg modes: AccessMode) = throw UnsupportedOperationException()
+  override fun <V : FileAttributeView?> getFileAttributeView(path: Path, type: Class<V>, vararg options: LinkOption): V = throw UnsupportedOperationException()
+  override fun readAttributes(path: Path, attributes: String, vararg options: LinkOption): Map<String, Any> = throw UnsupportedOperationException()
+  override fun setAttribute(path: Path, attribute: String, value: Any, vararg options: LinkOption) = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Attempts to fix https://youtrack.jetbrains.com/issue/MP-7468/Plugin-Verifier-ClosedFileSystemException-when-verifying-large-number-of-plugins

This is an exception due to a race condition where an underlying resource is closed on one thread, so reproduction is non-trivial. This includes two related changes, one from https://github.com/JetBrains/intellij-plugin-verifier/pull/1487 @sh41 and one from me. 