### PR TITLE
Do not report OverrideOnly violations on static and companion calls

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassNode.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassNode.kt
@@ -20,6 +20,9 @@ class KtClassNode(private val classNode: ClassNode, private val metadata: Kotlin
   val isEnumClass: Boolean
     get() = cls.kind == ClassKind.ENUM_CLASS
 
+  val isObject: Boolean
+    get() = cls.kind == ClassKind.OBJECT || cls.kind == ClassKind.COMPANION_OBJECT
+
   fun isInternalField(fieldName: String): Boolean {
     return cls.properties.any { it.name == fieldName && it.visibility == Visibility.INTERNAL }
   }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/NonOverridableMethodUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/NonOverridableMethodUsageFilter.kt
@@ -1,0 +1,37 @@
+package com.jetbrains.pluginverifier.usages.overrideOnly
+
+import com.jetbrains.plugin.structure.classes.utils.KtClassResolver
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import org.objectweb.asm.tree.AbstractInsnNode
+
+/**
+ * Allows invocations whose target cannot be overridden, mirroring the IntelliJ Platform
+ * inspection's `target.isOverridable()` guard.
+ *
+ * Covers two shapes:
+ *  - Static methods (JVM `ACC_STATIC`). For Kotlin this matches `@JvmStatic` accessors.
+ *  - Instance methods whose declaring class is a Kotlin `object` or `companion object`.
+ *    Those compile to non-static methods on a singleton holder, so the static flag alone
+ *    does not catch them, but the singleton cannot be subclassed and the
+ *    `@ApiStatus.OverrideOnly` annotation cannot be enforced at the call site.
+ */
+class NonOverridableMethodUsageFilter : ApiUsageFilter {
+  private val ktClassResolver = KtClassResolver()
+
+  override fun allow(
+    invokedMethod: Method,
+    invocationInstruction: AbstractInsnNode,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean = invokedMethod.isStatic || invokedMethod.containingClassFile.isKotlinObject
+
+  private val ClassFile.isKotlinObject: Boolean
+    get() {
+      val asmNode = (this as? ClassFileAsm)?.asmNode ?: return false
+      return ktClassResolver[asmNode]?.isObject == true
+    }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
@@ -28,6 +28,7 @@ private val LOG: Logger = LoggerFactory.getLogger(OverrideOnlyMethodUsageProcess
 private const val overrideOnlyAnnotationName = "org/jetbrains/annotations/ApiStatus\$OverrideOnly"
 
 private val overrideOnlyUsageFilter = CompositeApiUsageFilter(
+  NonOverridableMethodUsageFilter(),
   SameModuleUsageFilter(overrideOnlyAnnotationName),
   CallOfSuperConstructorOverrideOnlyAllowedUsageFilter(),
   DelegateCallOnOverrideOnlyUsageFilter().withBridgeMethodSupport(),

--- a/intellij-plugin-verifier/verifier-test/additional-after-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/additional-after-idea/build.gradle.kts
@@ -3,3 +3,7 @@ version = "1.0"
 dependencies {
   implementation(project(":verifier-test:after-idea"))
 }
+
+// Fixture sources use bare `@ApiStatus.*` annotations on package declarations, which
+// the javadoc tool reads as unknown tags. These modules are not consumed for docs.
+tasks.javadoc { enabled = false }

--- a/intellij-plugin-verifier/verifier-test/additional-before-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/additional-before-idea/build.gradle.kts
@@ -3,3 +3,7 @@ version = "1.0"
 dependencies {
   implementation(project(":verifier-test:before-idea"))
 }
+
+// Fixture sources use bare `@ApiStatus.*` annotations on package declarations, which
+// the javadoc tool reads as unknown tags. These modules are not consumed for docs.
+tasks.javadoc { enabled = false }

--- a/intellij-plugin-verifier/verifier-test/after-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/after-idea/build.gradle.kts
@@ -2,3 +2,7 @@ version = "1.0"
 dependencies {
   implementation(project(":verifier-core"))
 }
+
+// Fixture sources use bare `@ApiStatus.*` annotations on package declarations, which
+// the javadoc tool reads as unknown tags. These modules are not consumed for docs.
+tasks.javadoc { enabled = false }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/overrideOnly/OverrideOnlyMethodOwner.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/overrideOnly/OverrideOnlyMethodOwner.java
@@ -6,4 +6,10 @@ public class OverrideOnlyMethodOwner {
   @ApiStatus.OverrideOnly
   public void overrideOnlyMethod() {
   }
+
+  // Annotation is contradictory: a static method cannot be overridden.
+  // Callers must not be flagged.
+  @ApiStatus.OverrideOnly
+  public static void staticOverrideOnlyMethod() {
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/overrideOnly/OverrideOnlyKotlinObjects.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/overrideOnly/OverrideOnlyKotlinObjects.kt
@@ -1,0 +1,45 @@
+package overrideOnly
+
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Kotlin top-level `object`. Methods cannot be overridden by callers, so a
+ * `@OverrideOnly` annotation on them is contradictory and callers must not be flagged.
+ */
+object OverrideOnlyKotlinObject {
+  @ApiStatus.OverrideOnly
+  fun overrideOnlyMethod() {
+  }
+}
+
+/**
+ * Kotlin class with a `companion object` carrying a `@OverrideOnly` method. The
+ * companion object compiles to a singleton holder whose methods are not overridable
+ * by callers, so callers must not be flagged.
+ */
+class OverrideOnlyKotlinCompanionHolder {
+  companion object {
+    @ApiStatus.OverrideOnly
+    fun overrideOnlyMethod() {
+    }
+  }
+}
+
+/**
+ * `@OverrideOnly` interface that exposes a factory method on its `companion object`.
+ *
+ * `isSatisfied` is a regular instance method on the interface and calling it from
+ * outside the implementor remains a violation. The companion factory `create` must
+ * not be flagged: its containing class is
+ * `OverrideOnlyKotlinInterfaceWithCompanion$Companion`, not the interface itself,
+ * so it picks up the annotation only via the enclosing-class lookup, and callers
+ * cannot override a singleton's methods.
+ */
+@ApiStatus.OverrideOnly
+interface OverrideOnlyKotlinInterfaceWithCompanion {
+  fun isSatisfied(): Boolean
+
+  companion object {
+    fun create(): OverrideOnlyKotlinInterfaceWithCompanion = throw NotImplementedError()
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/before-idea/build.gradle.kts
@@ -2,3 +2,7 @@ version = "1.0"
 dependencies {
   implementation(project(":verifier-core"))
 }
+
+// Fixture sources use bare `@ApiStatus.*` annotations on package declarations, which
+// the javadoc tool reads as unknown tags. These modules are not consumed for docs.
+tasks.javadoc { enabled = false }

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/overrideOnly/OverrideOnlyMethodOwner.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/overrideOnly/OverrideOnlyMethodOwner.java
@@ -6,4 +6,10 @@ public class OverrideOnlyMethodOwner {
   @ApiStatus.OverrideOnly
   public void overrideOnlyMethod() {
   }
+
+  // Annotation is contradictory: a static method cannot be overridden.
+  // Callers must not be flagged.
+  @ApiStatus.OverrideOnly
+  public static void staticOverrideOnlyMethod() {
+  }
 }

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/overrideOnly/OverrideOnlyKotlinObjects.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/overrideOnly/OverrideOnlyKotlinObjects.kt
@@ -1,0 +1,45 @@
+package overrideOnly
+
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Kotlin top-level `object`. Methods cannot be overridden by callers, so a
+ * `@OverrideOnly` annotation on them is contradictory and callers must not be flagged.
+ */
+object OverrideOnlyKotlinObject {
+  @ApiStatus.OverrideOnly
+  fun overrideOnlyMethod() {
+  }
+}
+
+/**
+ * Kotlin class with a `companion object` carrying a `@OverrideOnly` method. The
+ * companion object compiles to a singleton holder whose methods are not overridable
+ * by callers, so callers must not be flagged.
+ */
+class OverrideOnlyKotlinCompanionHolder {
+  companion object {
+    @ApiStatus.OverrideOnly
+    fun overrideOnlyMethod() {
+    }
+  }
+}
+
+/**
+ * `@OverrideOnly` interface that exposes a factory method on its `companion object`.
+ *
+ * `isSatisfied` is a regular instance method on the interface and calling it from
+ * outside the implementor remains a violation. The companion factory `create` must
+ * not be flagged: its containing class is
+ * `OverrideOnlyKotlinInterfaceWithCompanion$Companion`, not the interface itself,
+ * so it picks up the annotation only via the enclosing-class lookup, and callers
+ * cannot override a singleton's methods.
+ */
+@ApiStatus.OverrideOnly
+interface OverrideOnlyKotlinInterfaceWithCompanion {
+  fun isSatisfied(): Boolean
+
+  companion object {
+    fun create(): OverrideOnlyKotlinInterfaceWithCompanion = throw NotImplementedError()
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/OverrideOnlyMethodUsages.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/OverrideOnlyMethodUsages.java
@@ -1,6 +1,9 @@
 package mock.plugin.overrideOnly;
 
 import overrideOnly.AllOverrideOnlyMethodsOwner;
+import overrideOnly.OverrideOnlyKotlinCompanionHolder;
+import overrideOnly.OverrideOnlyKotlinInterfaceWithCompanion;
+import overrideOnly.OverrideOnlyKotlinObject;
 import overrideOnly.OverrideOnlyMethodOwner;
 
 import java.util.function.Consumer;
@@ -21,6 +24,27 @@ public class OverrideOnlyMethodUsages {
     Override-only method overrideOnly.AllOverrideOnlyMethodsOwner.overrideOnlyMethod() is invoked in mock.plugin.overrideOnly.OverrideOnlyMethodUsages.usages(OverrideOnlyMethodOwner, AllOverrideOnlyMethodsOwner) : void. This method is marked with @org.jetbrains.annotations.ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
     */
     owner2.overrideOnlyMethod();
+
+    // Calls to a static @OverrideOnly target must not be flagged: static dispatch
+    // cannot be overridden, so the annotation has no enforceable meaning here.
+    OverrideOnlyMethodOwner.staticOverrideOnlyMethod();
+
+    // Methods on a Kotlin `object` or `companion object` are not overridable by
+    // callers, so @OverrideOnly is unenforceable and these calls must not be flagged.
+    OverrideOnlyKotlinObject.INSTANCE.overrideOnlyMethod();
+    OverrideOnlyKotlinCompanionHolder.Companion.overrideOnlyMethod();
+
+    // Real-world case: an @OverrideOnly interface with a companion-object factory.
+    // The factory call must not be flagged even though the interface carries the
+    // annotation: the companion is a singleton, so its methods are not overridable.
+    OverrideOnlyKotlinInterfaceWithCompanion instance = OverrideOnlyKotlinInterfaceWithCompanion.Companion.create();
+
+    /*expected(OVERRIDE_ONLY)
+    Invocation of override-only method overrideOnly.OverrideOnlyKotlinInterfaceWithCompanion.isSatisfied()
+
+    Override-only method overrideOnly.OverrideOnlyKotlinInterfaceWithCompanion.isSatisfied() is invoked in mock.plugin.overrideOnly.OverrideOnlyMethodUsages.usages(OverrideOnlyMethodOwner, AllOverrideOnlyMethodsOwner) : void. This method is marked with @org.jetbrains.annotations.ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.
+    */
+    instance.isSatisfied();
   }
 
   public static void methodReferences() {


### PR DESCRIPTION
Implement https://youtrack.jetbrains.com/issue/MP-7233/ by checking if the target method is not static and not a companion object

Also disabled the Javadoc tasks on the verifier test projects because it was preventing Gradle from running the tests through the IDE