### PR TITLE
Move description validation to the base validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 ### Changed
 
 - Use proper namespace to allow declaring content modules in different namespaces in the same plugin ([IJPL-245093](https://youtrack.jetbrains.com/issue/IJPL-245093))
+- `PropertyWithDefaultValue` class is now `com.jetbrains.plugin.structure.base.problems.PropertyWithDefaultValue`
+- `DescriptionNotStartingWithLatinCharacters` class is now `DescriptionNotStartingWithLatinCharacters`
 
 ### Fixed
 

--- a/intellij-plugin-structure/structure-base/build.gradle.kts
+++ b/intellij-plugin-structure/structure-base/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
   implementation(sharedLibs.xz)
   implementation(libs.trove4j)
 
+  implementation(sharedLibs.jsoup)
+
   //Provides English class capable of pluralizing english words.
   implementation(libs.evo.inflector)
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/InvalidDescriptorErrors.kt
@@ -42,7 +42,7 @@ class UnexpectedDescriptorElements(
 }
 
 class TooLongPropertyValue(
-  descriptorPath: String,
+  descriptorPath: String?,
   propertyName: String,
   propertyValueLength: Int,
   maxLength: Int
@@ -190,4 +190,42 @@ class InvalidUrl(url: String, descriptorPath: String? = null) : InvalidDescripto
 ) {
   override val level
     get() = Level.ERROR
+}
+
+class PropertyWithDefaultValue(
+  descriptorPath: String?,
+  property: DefaultProperty,
+  value: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "One of the parameters matches the default value. Please ensure that ${property.propertyName} " +
+          "is not equal to the default value '$value'."
+) {
+  enum class DefaultProperty(val propertyName: String) {
+    ID("<id>"),
+    NAME("<name>"),
+    VENDOR("<vendor>"),
+    VENDOR_URL("<vendor url>"),
+    VENDOR_EMAIL("<vendor email>"),
+    DESCRIPTION("<description>")
+  }
+
+  override val level
+    get() = Level.ERROR
+}
+
+class DescriptionNotStartingWithLatinCharacters : InvalidDescriptorProblem(
+  descriptorPath = "description",
+  detailedMessage = "The plugin description must start with Latin characters and have at least $MIN_DESCRIPTION_LENGTH characters."
+) {
+  override val level
+    get() = Level.WARNING
+}
+
+class HttpLinkInDescription(link: String) : InvalidDescriptorProblem(
+  descriptorPath = "description",
+  detailedMessage = "All the links in the plugin description must be HTTPS: $link."
+) {
+  override val level
+    get() = Level.UNACCEPTABLE_WARNING
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/Validator.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/problems/Validator.kt
@@ -1,9 +1,20 @@
 package com.jetbrains.plugin.structure.base.problems
 
+import org.jsoup.Jsoup
+
 val ALLOWED_NAME_SYMBOLS = Regex("[a-zA-Z0-9 .,+_\\-/:()#'&\\[\\]|]+")
+private const val MAX_DESCRIPTION_LENGTH = 65535
+private val DEFAULT_TEMPLATE_DESCRIPTIONS = setOf(
+  "Enter short description for your plugin here", "most HTML tags may be used", "example.com/my-framework"
+)
+const val MIN_DESCRIPTION_LENGTH = 40
+
+// \u2013 - `–` (short dash) ans \u2014 - `—` (long dash)
+@Suppress("RegExpSimplifiable")
+private val STARTS_WITH_LATIN_SYMBOLS_REGEX = Regex("^[\\w\\s\\p{Punct}\\u2013\\u2014]{$MIN_DESCRIPTION_LENGTH,}")
 
 fun validatePropertyLength(
-  descriptor: String,
+  descriptor: String?,
   propertyName: String,
   propertyValue: String,
   maxLength: Int,
@@ -26,3 +37,47 @@ fun validatePluginNameIsCorrect(descriptor: String, name: String): PluginProblem
   } else {
     null
   }
+
+fun validateDescriptionIsCorrect(propertyName: String, descriptorPath: String?, htmlDescription: String?, problems: MutableList<PluginProblem>) {
+  problems.addAll(validateDescriptionIsCorrect(propertyName, descriptorPath, htmlDescription))
+}
+
+fun validateDescriptionIsCorrect(propertyName: String, descriptorPath: String?, htmlDescription: String?): List<PluginProblem> {
+  val problems = mutableListOf<PluginProblem>()
+  if (htmlDescription.isNullOrBlank()) {
+    problems.add(PropertyNotSpecified(propertyName, descriptorPath))
+    return problems
+  }
+  validatePropertyLength(descriptorPath, propertyName, htmlDescription, MAX_DESCRIPTION_LENGTH, problems)
+
+  val html = Jsoup.parseBodyFragment(htmlDescription)
+  val textDescription = html.text()
+
+  if (DEFAULT_TEMPLATE_DESCRIPTIONS.any { textDescription.contains(it) }) {
+    problems.add(
+      PropertyWithDefaultValue(
+        descriptorPath,
+        PropertyWithDefaultValue.DefaultProperty.DESCRIPTION,
+        textDescription
+      )
+    )
+    return problems
+  }
+
+  val latinDescriptionPart = STARTS_WITH_LATIN_SYMBOLS_REGEX.find(textDescription)?.value
+  if (latinDescriptionPart == null) {
+    problems.add(DescriptionNotStartingWithLatinCharacters())
+  }
+  val links = html.select("[href],img[src]")
+  links.forEach { link ->
+    val href = link.attr("abs:href")
+    val src = link.attr("abs:src")
+    if (href.startsWith("http://")) {
+      problems.add(HttpLinkInDescription(href))
+    }
+    if (src.startsWith("http://")) {
+      problems.add(HttpLinkInDescription(src))
+    }
+  }
+  return problems
+}

--- a/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-fleet/src/main/kotlin/com/jetbrains/plugin/structure/fleet/FleetPluginDescriptor.kt
@@ -46,9 +46,12 @@ data class FleetPluginDescriptor(
     }
 
     val metaSpec = FleetDescriptorSpec.Meta
-    if (meta?.description.isNullOrBlank()) {
-      problems.add(PropertyNotSpecified(metaSpec.relativeFieldPath(metaSpec.DESCRIPTION_FIELD_NAME)))
-    }
+    validateDescriptionIsCorrect(
+      propertyName = metaSpec.relativeFieldPath(metaSpec.DESCRIPTION_FIELD_NAME),
+      descriptorPath = FleetDescriptorSpec.DESCRIPTOR_FILE_NAME,
+      htmlDescription = meta?.description,
+      problems = problems
+    )
 
     if (meta?.vendor.isNullOrBlank()) {
       problems.add(PropertyNotSpecified(metaSpec.relativeFieldPath(metaSpec.VENDOR_FIELD_NAME)))

--- a/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
+++ b/intellij-plugin-structure/structure-hub/src/main/kotlin/com/jetbrains/plugin/structure/hub/Validator.kt
@@ -60,12 +60,15 @@ internal fun validateHubPluginBean(manifest: HubPluginManifest): List<PluginProb
     problems.add(PropertyNotSpecified("author"))
   }
 
-  if (manifest.description.isNullOrBlank()) {
-    problems.add(PropertyNotSpecified("description"))
-  }
+  validateDescriptionIsCorrect(
+    propertyName = "description",
+    descriptorPath = DESCRIPTOR_NAME,
+    htmlDescription = manifest.description,
+    problems = problems
+  )
 
   val version = manifest.pluginVersion
-  if (version == null || version.isBlank()) {
+  if (version.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("version"))
   }
 

--- a/intellij-plugin-structure/structure-intellij/build.gradle.kts
+++ b/intellij-plugin-structure/structure-intellij/build.gradle.kts
@@ -2,7 +2,6 @@ dependencies {
   api(project(":structure-base"))
   api(libs.jdom)
 
-  implementation(sharedLibs.jsoup)
   implementation(libs.jaxb.api)
   implementation(libs.jaxb.runtime)
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
@@ -4,25 +4,11 @@
 
 package com.jetbrains.plugin.structure.intellij.plugin
 
-import com.jetbrains.plugin.structure.base.problems.MAX_NAME_LENGTH
-import com.jetbrains.plugin.structure.base.problems.NotBoolean
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
-import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
-import com.jetbrains.plugin.structure.base.problems.validatePluginNameIsCorrect
-import com.jetbrains.plugin.structure.intellij.beans.IdeaVersionBean
-import com.jetbrains.plugin.structure.intellij.beans.PluginBean
-import com.jetbrains.plugin.structure.intellij.beans.PluginDependencyBean
-import com.jetbrains.plugin.structure.intellij.beans.PluginVendorBean
-import com.jetbrains.plugin.structure.intellij.beans.ProductDescriptorBean
+import com.jetbrains.plugin.structure.base.problems.*
+import com.jetbrains.plugin.structure.intellij.beans.*
 import com.jetbrains.plugin.structure.intellij.problems.*
-import com.jetbrains.plugin.structure.intellij.verifiers.MAX_PROPERTY_LENGTH
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginIdVerifier
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginUntilBuildVerifier
-import com.jetbrains.plugin.structure.intellij.verifiers.ProductReleaseVersionVerifier
-import com.jetbrains.plugin.structure.intellij.verifiers.ReusedDescriptorVerifier
+import com.jetbrains.plugin.structure.intellij.verifiers.*
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import org.jsoup.Jsoup
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
@@ -32,12 +18,6 @@ private const val MAX_VERSION_LENGTH = 64
 private const val MAX_PRODUCT_CODE_LENGTH = 15
 
 private val DEFAULT_TEMPLATE_NAMES = setOf("Plugin display name here", "My Framework Support", "Template", "Demo")
-private val DEFAULT_TEMPLATE_DESCRIPTIONS = setOf(
-  "Enter short description for your plugin here", "most HTML tags may be used", "example.com/my-framework"
-)
-// \u2013 - `–` (short dash) ans \u2014 - `—` (long dash)
-@Suppress("RegExpSimplifiable")
-private val STARTS_WITH_LATIN_SYMBOLS_REGEX = Regex("^[\\w\\s\\p{Punct}\\u2013\\u2014]{$MIN_DESCRIPTION_LENGTH,}")
 
 private val RELEASE_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
 
@@ -116,34 +96,12 @@ class PluginBeanValidator {
   }
 
   private fun ValidationContext.validateDescription(htmlDescription: String?) {
-    if (htmlDescription.isNullOrEmpty()) {
-      registerProblem(PropertyNotSpecified("description", descriptorPath))
-      return
-    }
-    validatePropertyLength("description", htmlDescription, MAX_LONG_PROPERTY_LENGTH)
-
-    val html = Jsoup.parseBodyFragment(htmlDescription)
-    val textDescription = html.text()
-
-    if (DEFAULT_TEMPLATE_DESCRIPTIONS.any { textDescription.contains(it) }) {
-      registerProblem(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.DESCRIPTION, textDescription))
-      return
-    }
-
-    val latinDescriptionPart = STARTS_WITH_LATIN_SYMBOLS_REGEX.find(textDescription)?.value
-    if (latinDescriptionPart == null) {
-      registerProblem(DescriptionNotStartingWithLatinCharacters())
-    }
-    val links = html.select("[href],img[src]")
-    links.forEach { link ->
-      val href = link.attr("abs:href")
-      val src = link.attr("abs:src")
-      if (href.startsWith("http://")) {
-        registerProblem(HttpLinkInDescription(href))
-      }
-      if (src.startsWith("http://")) {
-        registerProblem(HttpLinkInDescription(src))
-      }
+    validateDescriptionIsCorrect(
+        propertyName = "description",
+        descriptorPath = descriptorPath,
+        htmlDescription = htmlDescription
+    ).forEach {
+      registerProblem(it)
     }
   }
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -9,28 +9,6 @@ import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.version.ProductReleaseVersion
 
-class PropertyWithDefaultValue(
-  descriptorPath: String,
-  property: DefaultProperty,
-  value: String
-) : InvalidDescriptorProblem(
-  descriptorPath = descriptorPath,
-  detailedMessage = "One of the parameters matches the default value. Please ensure that ${property.propertyName} " +
-                    "is not equal to the default value '$value'."
-) {
-  enum class DefaultProperty(val propertyName: String) {
-    ID("<id>"),
-    NAME("<name>"),
-    VENDOR("<vendor>"),
-    VENDOR_URL("<vendor url>"),
-    VENDOR_EMAIL("<vendor email>"),
-    DESCRIPTION("<description>")
-  }
-
-  override val level
-    get() = Level.ERROR
-}
-
 class InvalidDependencyId(descriptorPath: String, invalidPluginId: String) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
   detailedMessage = "The dependency ID is invalid. '${invalidPluginId.trim()}' cannot be empty and must not contain " +

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/UnacceptableWarnings.kt
@@ -6,24 +6,6 @@ import com.jetbrains.plugin.structure.base.problems.ProblemSolutionHint
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginContentDescriptor
 import com.jetbrains.plugin.structure.intellij.verifiers.ExposedModulesVerifier
 
-const val MIN_DESCRIPTION_LENGTH = 40
-
-class DescriptionNotStartingWithLatinCharacters : InvalidDescriptorProblem(
-  descriptorPath = "description",
-  detailedMessage = "The plugin description must start with Latin characters and have at least $MIN_DESCRIPTION_LENGTH characters."
-) {
-  override val level
-    get() = Level.UNACCEPTABLE_WARNING
-}
-
-class HttpLinkInDescription(link: String) : InvalidDescriptorProblem(
-  descriptorPath = "description",
-  detailedMessage = "All the links in the plugin description must be HTTPS: $link."
-) {
-  override val level
-    get() = Level.UNACCEPTABLE_WARNING
-}
-
 class ServiceExtensionPointPreloadNotSupported(
   private val serviceType: IdePluginContentDescriptor.ServiceType
 ) : PluginProblem() {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -1,9 +1,9 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
-import com.jetbrains.plugin.structure.intellij.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
 
 val DEFAULT_ILLEGAL_PREFIXES = listOf("com.example", "net.example", "org.example", "edu.example", "com.intellij", "org.jetbrains")

--- a/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
+++ b/intellij-plugin-structure/structure-intellij/src/main/resources/com/jetbrains/plugin/structure/intellij/problems/remapping/plugin-problems.json
@@ -6,12 +6,14 @@
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber": "unacceptable-warning",
     "com.jetbrains.plugin.structure.intellij.problems.ReleaseVersionWrongFormat": "warning",
-    "com.jetbrains.plugin.structure.base.problems.InvalidPluginName": "ignore"
+    "com.jetbrains.plugin.structure.base.problems.InvalidPluginName": "ignore",
+    "com.jetbrains.plugin.structure.base.problems.DescriptionNotStartingWithLatinCharacters": "unacceptable-warning"
   },
   "new-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "error",
     "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId": "error",
-    "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "error"
+    "com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName": "error",
+    "com.jetbrains.plugin.structure.base.problems.DescriptionNotStartingWithLatinCharacters": "error"
   },
   "jetbrains-plugin": {
     "com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix": "ignore",

--- a/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/Validator.kt
+++ b/intellij-plugin-structure/structure-teamcity/src/main/kotlin/com/jetbrains/plugin/structure/teamcity/Validator.kt
@@ -7,6 +7,7 @@ package com.jetbrains.plugin.structure.teamcity
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.MAX_NAME_LENGTH
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.problems.validateDescriptionIsCorrect
 import com.jetbrains.plugin.structure.base.problems.validatePluginNameIsCorrect
 import com.jetbrains.plugin.structure.base.problems.validatePropertyLength
 import com.jetbrains.plugin.structure.teamcity.TeamcityPluginManager.Companion.DESCRIPTOR_NAME
@@ -47,9 +48,13 @@ internal fun validateTeamcityPluginBean(bean: TeamcityPluginBean): List<PluginPr
   if (bean.info?.version.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("version"))
   }
-  if (bean.info?.description.isNullOrBlank()) {
-    problems.add(PropertyNotSpecified("description"))
-  }
+  validateDescriptionIsCorrect(
+      propertyName = "description",
+      descriptorPath = DESCRIPTOR_NAME,
+      htmlDescription = bean.info?.description,
+      problems = problems
+  )
+
   if (bean.info?.vendor?.name.isNullOrBlank()) {
     problems.add(PropertyNotSpecified("vendor name"))
   }

--- a/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
+++ b/intellij-plugin-structure/structure-toolbox/src/main/kotlin/com/jetbrains/plugin/structure/toolbox/ToolboxPluginDescriptor.kt
@@ -45,9 +45,12 @@ data class ToolboxPluginDescriptor(
       problems.add(PropertyNotSpecified("version"))
     }
 
-    if (meta?.description.isNullOrBlank()) {
-      problems.add(PropertyNotSpecified("meta.description"))
-    }
+    validateDescriptionIsCorrect(
+      propertyName = "meta.description",
+      descriptorPath = ToolboxPluginManager.DESCRIPTOR_NAME,
+      htmlDescription = meta?.description,
+      problems = problems
+    )
 
     if (meta?.vendor.isNullOrBlank()) {
       problems.add(PropertyNotSpecified("meta.vendor"))

--- a/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
+++ b/intellij-plugin-structure/structure-youtrack/src/main/kotlin/com/jetbrains/plugin/structure/youtrack/Validator.kt
@@ -18,9 +18,12 @@ fun validateYouTrackManifest(manifest: YouTrackAppManifest): List<PluginProblem>
 
   validateTitle(manifest.title, problems)
 
-  if (manifest.description.isNullOrBlank()) {
-    problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION))
-  }
+  validateDescriptionIsCorrect(
+    propertyName = YouTrackAppFields.Manifest.DESCRIPTION,
+    descriptorPath = DESCRIPTOR_NAME,
+    htmlDescription = manifest.description,
+    problems = problems
+  )
 
   if (manifest.version.isNullOrBlank()) {
     problems.add(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.VERSION))

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetInvalidPluginsTest.kt
@@ -95,9 +95,9 @@ class FleetInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManage
 
   @Test
   fun `description is not specified`() {
-    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description")) { it.copy(meta = it.meta?.copy(description = null)) }
-    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description")) { it.copy(meta = it.meta?.copy(description = "")) }
-    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description")) { it.copy(meta = it.meta?.copy(description = "\n")) }
+    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = null)) }
+    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = "")) }
+    checkInvalidPlugin(PropertyNotSpecified("compatibleShipVersionRange.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = "\n")) }
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/fleet/mock/FleetPluginMockTest.kt
@@ -123,7 +123,7 @@ class FleetPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTes
     assertEquals("fleet.language.css", plugin.pluginId)
     assertEquals("CSS", plugin.pluginName)
     assertEquals("JetBrains", plugin.vendor)
-    assertEquals("CSS language support", plugin.description)
+    assertEquals("CSS language support long enough description", plugin.description)
     assertEquals("1.0.0-SNAPSHOT", plugin.pluginVersion)
     assertEquals(setOf("AIR", "AINEXT"), plugin.supportedProducts)
     assertEquals(FleetShipVersionRange("1.1000.1", "1.1001.10"), plugin.compatibleShipVersionRange)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubMockPluginBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubMockPluginBuilder.kt
@@ -1,12 +1,13 @@
 package com.jetbrains.plugin.structure.hub.mock
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.jetbrains.plugin.structure.teamcity.recipe.randomAlphanumeric
 
 data class HubPluginJsonBuilder(
     var key: String? = "key",
     var name: String? = "name",
     var version: String? = "version",
-    var description: String? = "description",
+    var description: String? = randomAlphanumeric(40),
     var author: String? = "A B a@gmail.com",
     var homeUrl: String? = "www.google.com",
     var iconUrl: String? = null,

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/hub/mock/HubPluginMockTest.kt
@@ -18,7 +18,7 @@ class HubPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTest<
     version = "1.1.1"
     author = "Michael Jackson <mj@gmail.com>"
     homeUrl = "https://github.com/mariyadavydova/youtrack-cats-widget"
-    description = "Funny cats and dogs for your Dashboard!"
+    description = "Funny cats and dogs for your Hub Dashboard!"
     iconUrl = "images/cat_purr.png"
     dependencies = mapOf("Hub" to ">=2018.2")
     products = mapOf("Hub" to "^2018.2", "YouTrack" to "^2018.2")
@@ -60,7 +60,7 @@ class HubPluginMockTest(fileSystemType: FileSystemType) : BasePluginManagerTest<
     assertEquals("https://github.com/mariyadavydova/youtrack-cats-widget", plugin.url)
     assertEquals("Michael Jackson", plugin.vendor)
     assertEquals("mj@gmail.com", plugin.vendorEmail)
-    assertEquals("Funny cats and dogs for your Dashboard!", plugin.description)
+    assertEquals("Funny cats and dogs for your Hub Dashboard!", plugin.description)
     assertEquals(iconTestContent, String(plugin.icons.single().content))
     assertEquals(mapOf("Hub" to ">=2018.2"), plugin.dependencies)
     assertEquals(mapOf("Hub" to "^2018.2", "YouTrack" to "^2018.2"), plugin.products)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/problems/JsonUrlProblemLevelRemappingManagerTest.kt
@@ -30,7 +30,7 @@ class JsonUrlProblemLevelRemappingManagerTest {
     Assert.assertNotNull(newPluginProblemSet)
     newPluginProblemSet?.let {
       val errors = it.findProblemsByLevel(StandardLevel(PluginProblem.Level.ERROR))
-      assertThat(errors.size, `is`(3))
+      assertThat(errors.size, `is`(4))
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -2,6 +2,8 @@ package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
+import com.jetbrains.plugin.structure.base.problems.DescriptionNotStartingWithLatinCharacters
+import com.jetbrains.plugin.structure.base.problems.HttpLinkInDescription
 import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
 import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
 import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
@@ -10,6 +12,7 @@ import com.jetbrains.plugin.structure.base.problems.NotNumber
 import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.problems.PropertyWithDefaultValue
 import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
 import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
 import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
@@ -516,7 +519,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
 
   @Test
   fun `short latin description`() {
-    `test plugin xml unacceptable warnings`(
+    `test plugin xml warnings`(
       perfectXmlBuilder.modify {
         description = "<description>Too short latin description bla-bla-bla</description>"
       },
@@ -528,7 +531,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
   fun `non latin description`() {
     val desc = getRandomNonLatinSentence(5, minWordLength = 8)
     assertTrue(desc.length > 40)
-    `test plugin xml unacceptable warnings`(
+    `test plugin xml warnings`(
       perfectXmlBuilder.modify {
         description = "<description>$desc</description>"
       },
@@ -541,7 +544,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
     val nonLatinDesc = getRandomNonLatinSentence(5, minWordLength = 8)
     val desc = "$nonLatinDesc, Latin description"
     assertTrue(desc.length > 40)
-    `test plugin xml unacceptable warnings`(
+    `test plugin xml warnings`(
       perfectXmlBuilder.modify {
         description = "<description>$desc</description>"
       },
@@ -554,7 +557,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
     val nonLatinDesc = getRandomNonLatinSentence(5)
     val desc = "$nonLatinDesc $LONG_LATIN_DESCRIPTION"
     assertTrue(desc.length > 40)
-    `test plugin xml unacceptable warnings`(
+    `test plugin xml warnings`(
       perfectXmlBuilder.modify {
         description = "<description>$desc</description>"
       },
@@ -642,7 +645,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
 
   @Test
   fun `html description`() {
-    `test plugin xml unacceptable warnings`(
+    `test plugin xml warnings`(
       perfectXmlBuilder.modify {
         description = """<description><![CDATA[
           <a href=\"https://github.com/myamazinguserprofile/myamazingproject\">short text</a>

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityPluginXmlBuilder.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityPluginXmlBuilder.kt
@@ -1,12 +1,14 @@
 package com.jetbrains.plugin.structure.teamcity.mock
 
+import com.jetbrains.plugin.structure.teamcity.recipe.randomAlphanumeric
+
 data class TeamcityPluginXmlBuilder(
   var teamcityPluginTagOpen: String = "<teamcity-plugin>",
   var teamcityPluginTagClose: String = "</teamcity-plugin>",
   var name: String = "<name>name</name>",
   var displayName: String = "<display-name>Display name</display-name>",
   var version: String = "<version>0.1.1</version>",
-  var description: String = "<description>Some short description</description>",
+  var description: String = "<description>${randomAlphanumeric(40)}</description>",
   var downloadUrl: String = "",
   var email: String = "",
   var deployment: String = "",

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxInvalidPluginsTest.kt
@@ -11,6 +11,8 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginManagerTest<ToolboxPlugin, ToolboxPluginManager>(fileSystemType) {
+  private val LONG_LATIN_DESCRIPTION = "Latin description, 1234 &amp; ;,.!-–— () long enough"
+
   override fun createManager(extractDirectory: Path) = ToolboxPluginManager.createManager(extractDirectory)
 
   @Test(expected = IllegalArgumentException::class)
@@ -93,10 +95,11 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `description is not specified`() {
-    checkInvalidPlugin(PropertyNotSpecified("meta.description")) { it.copy(meta = it.meta?.copy(description = null)) }
-    checkInvalidPlugin(PropertyNotSpecified("meta.description")) { it.copy(meta = it.meta?.copy(description = "")) }
-    checkInvalidPlugin(PropertyNotSpecified("meta.description")) { it.copy(meta = it.meta?.copy(description = "\n")) }
-    checkValidPlugin { it.copy(meta = it.meta?.copy(description = "herring herring herring")) }
+    checkInvalidPlugin(PropertyNotSpecified("meta.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = null)) }
+    checkInvalidPlugin(PropertyNotSpecified("meta.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = "")) }
+    checkInvalidPlugin(PropertyNotSpecified("meta.description", "extension.json")) { it.copy(meta = it.meta?.copy(description = "\n")) }
+    checkValidWithWarningsPlugin(listOf(DescriptionNotStartingWithLatinCharacters())) { it.copy(meta = it.meta?.copy(description = "herring herring herring")) }
+    checkValidPlugin { it.copy(meta = it.meta?.copy(description = LONG_LATIN_DESCRIPTION)) }
   }
 
   @Test
@@ -173,5 +176,12 @@ class ToolboxInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMana
   private fun checkValidPlugin(descriptorUpdater: (ToolboxPluginDescriptor) -> ToolboxPluginDescriptor) {
     val descriptor = descriptorUpdater(ToolboxPluginDescriptor.parse(getMockPluginJsonContent("extension")))
     Assert.assertEquals(emptyList<PluginProblem>(), descriptor.validate())
+  }
+
+  private fun checkValidWithWarningsPlugin(expectedWarnings: List<PluginProblem>, descriptorUpdater: (ToolboxPluginDescriptor) -> ToolboxPluginDescriptor) {
+    val descriptor = descriptorUpdater(ToolboxPluginDescriptor.parse(getMockPluginJsonContent("extension")))
+    val problems = descriptor.validate()
+    Assert.assertTrue(problems.all { it.level == PluginProblem.Level.WARNING })
+    Assert.assertEquals(expectedWarnings, descriptor.validate())
   }
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxPluginMockTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/toolbox/mock/ToolboxPluginMockTest.kt
@@ -125,7 +125,7 @@ class ToolboxPluginMockTest(fileSystemType: FileSystemType) :
         assertEquals("chunga.changa", plugin.pluginId)
         assertEquals("Chunga Changa", plugin.pluginName)
         assertEquals("JetBrains", plugin.vendor)
-        assertEquals("Chunga Changa language support", plugin.description)
+        assertEquals("Chunga Changa language support plugin description", plugin.description)
         assertEquals("0.1", plugin.pluginVersion)
         assertEquals(ToolboxVersionRange("1.1.1", "1.1.1"), plugin.compatibleVersionRange)
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackInvalidPluginTest.kt
@@ -102,8 +102,8 @@ class YouTrackInvalidPluginTest(fileSystemType: FileSystemType) : BasePluginMana
 
   @Test
   fun `invalid app description`() {
-    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION)) { it.copy(description = null) }
-    checkInvalidPlugin(ManifestPropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION)) { it.copy(description = "") }
+    checkInvalidPlugin(PropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION, "manifest.json")) { it.copy(description = null) }
+    checkInvalidPlugin(PropertyNotSpecified(YouTrackAppFields.Manifest.DESCRIPTION, "manifest.json")) { it.copy(description = "") }
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackMockPluginTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/youtrack/mock/YouTrackMockPluginTest.kt
@@ -30,7 +30,7 @@ class YouTrackMockPluginTest(fileSystemType: FileSystemType) : BasePluginManager
 
     assertEquals("template-app", plugin.pluginId)
     assertEquals("Template App", plugin.pluginName)
-    assertEquals("App description", plugin.description)
+    assertEquals("Template app toolbox plugin long description", plugin.description)
     assertEquals("1.0.0", plugin.pluginVersion)
     assertEquals("https://example.com", plugin.url)
     assertEquals("2022.2.0", plugin.sinceVersion)

--- a/intellij-plugin-structure/tests/src/test/resources/fleet/extension.json
+++ b/intellij-plugin-structure/tests/src/test/resources/fleet/extension.json
@@ -5,7 +5,7 @@
   "meta": {
     "frontend-only": "true",
     "readableName": "CSS",
-    "description": "CSS language support",
+    "description": "CSS language support long enough description",
     "vendor": "JetBrains",
     "visible": "false",
     "supportedProducts": "AIR,AINEXT"

--- a/intellij-plugin-structure/tests/src/test/resources/toolbox/extension.json
+++ b/intellij-plugin-structure/tests/src/test/resources/toolbox/extension.json
@@ -3,7 +3,7 @@
   "version": "0.1",
   "meta": {
     "readableName": "Chunga Changa",
-    "description": "Chunga Changa language support",
+    "description": "Chunga Changa language support plugin description",
     "vendor": "JetBrains"
   },
   "apiVersion": "1.1.1"

--- a/intellij-plugin-structure/tests/src/test/resources/youtrack/manifest.json
+++ b/intellij-plugin-structure/tests/src/test/resources/youtrack/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "template-app",
   "title": "Template App",
-  "description": "App description",
+  "description": "Template app toolbox plugin long description",
   "version": "1.0.0",
   "url": "https://example.com",
   "icon": "icon.svg",

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/ExistingPluginValidationTest.kt
@@ -3,6 +3,8 @@ package com.jetbrains.pluginverifier.tests
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationResult
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.problems.DescriptionNotStartingWithLatinCharacters
+import com.jetbrains.plugin.structure.base.problems.HttpLinkInDescription
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PluginProblem.Level.ERROR
 import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
@@ -585,7 +587,65 @@ class ExistingPluginValidationTest : BasePluginTest() {
         assertNoProblems((result as PluginCreationSuccess).warnings)
     }
 
-  private fun pluginOf(header: String): ContentBuilder.() -> Unit = {
+    @Test
+    fun `new plugin has short description`() {
+        val ideaPlugin = ideaPlugin(description = "Too short latin description")
+        val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = false)
+        val result = buildPluginWithResult(problemResolver) {
+            dir("META-INF") {
+                file("plugin.xml") {
+                    """
+            <idea-plugin>
+              $ideaPlugin
+            </idea-plugin>
+          """
+                }
+            }
+        }
+        result.assertContains<DescriptionNotStartingWithLatinCharacters>("Invalid plugin descriptor 'description'. The plugin description must start with Latin characters and have at least 40 characters.")
+    }
+
+    @Test
+    fun `existing plugin has short description`() {
+        val ideaPlugin = ideaPlugin(description = "Too short latin description")
+        val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = true)
+        val result = buildPluginWithResult(problemResolver) {
+            dir("META-INF") {
+                file("plugin.xml") {
+                    """
+            <idea-plugin>
+              $ideaPlugin
+            </idea-plugin>
+          """
+                }
+            }
+        }
+        result as PluginCreationSuccess
+        assertEquals(1, result.unacceptableWarnings.size)
+        result.assertContains<DescriptionNotStartingWithLatinCharacters>("Invalid plugin descriptor 'description'. The plugin description must start with Latin characters and have at least 40 characters.")
+    }
+
+    @Test
+    fun `jetbrains plugin has short description`() {
+        val ideaPlugin = ideaPlugin(description = "Too short latin description")
+        val problemResolver = getIntelliJPluginCreationResolver(isExistingPlugin = true)
+        val result = buildPluginWithResult(problemResolver) {
+            dir("META-INF") {
+                file("plugin.xml") {
+                    """
+            <idea-plugin>
+              $ideaPlugin
+            </idea-plugin>
+          """
+                }
+            }
+        }
+        result as PluginCreationSuccess
+        assertEquals(1, result.unacceptableWarnings.size)
+        result.assertContains<DescriptionNotStartingWithLatinCharacters>("Invalid plugin descriptor 'description'. The plugin description must start with Latin characters and have at least 40 characters.")
+    }
+
+    private fun pluginOf(header: String): ContentBuilder.() -> Unit = {
     dir("META-INF") {
       file("plugin.xml") {
         """


### PR DESCRIPTION
Move description validation to the base.

- `PropertyWithDefaultValue` class is now `com.jetbrains.plugin.structure.base.problems.PropertyWithDefaultValue`
- `DescriptionNotStartingWithLatinCharacters` class is now `DescriptionNotStartingWithLatinCharacters`