### PR TITLE
Do not consider plugins with dependency on Java plugin as legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Fixed
 
+- Plugins with dependency only on the Java plugin aren't considered legacy ([MP-8104](https://youtrack.jetbrains.com/issue/MP-8104))
+
 ## 1.404 - 2026-05-18
 
 ### Fixed

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifier.kt
@@ -5,23 +5,11 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.intellij.plugin.*
+import com.jetbrains.plugin.structure.intellij.plugin.INTELLIJ_MODULE_PREFIX
 import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
 import com.jetbrains.plugin.structure.intellij.problems.NoDependencies
 import com.jetbrains.plugin.structure.intellij.problems.NoModuleDependencies
 import com.jetbrains.plugin.structure.intellij.verifiers.LegacyIntelliJIdeaPluginVerifier.VerificationResult.NotLegacyPlugin
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
-private val LOG: Logger = LoggerFactory.getLogger(LegacyIntelliJIdeaPluginVerifier::class.java)
-
-private const val PLATFORM_MODULE_ID = "com.intellij.modules.platform"
-private val ADDITIONAL_MODULES_AVAILABLE_IN_ALL_PRODUCTS = listOf(
-  "com.intellij.modules.platform",
-  "com.intellij.modules.lang",
-  "com.intellij.modules.xml",
-  "com.intellij.modules.vcs",
-  "com.intellij.modules.xdebugger"
-)
 
 /**
  * Verifies if a plugin is a legacy plugin compatible with IntelliJ IDEA only.
@@ -56,31 +44,10 @@ class LegacyIntelliJIdeaPluginVerifier {
       // Due to confusing semantics we might need to check old-style module declarations
       val oldSemanticsModuleDependencies = dependencies.filterIsInstance<PluginDependencyImpl>()
       val moduleCandidates = v1Dependencies + oldSemanticsModuleDependencies
-      if (dependsOnAnyModuleAvailableInAllProducts(moduleCandidates)) return NotLegacyPlugin
-      if (dependsOnAnyModuleWithComIntellijModulesPrefix(moduleCandidates)) return NotLegacyPlugin
+      if (moduleCandidates.any { it.id.startsWith(INTELLIJ_MODULE_PREFIX) }) return NotLegacyPlugin
 
       return VerificationResult.NoModuleDependencies
     }
-  }
-
-  private fun dependsOnAnyModuleWithComIntellijModulesPrefix(dependencies: List<PluginDependency>): Boolean {
-    return dependencies.any { it.id.startsWith(INTELLIJ_MODULE_PREFIX) }
-  }
-
-  private fun dependsOnAnyModuleAvailableInAllProducts(dependencies: List<PluginDependency>): Boolean {
-    if (dependencies.any { it.id == PLATFORM_MODULE_ID }) {
-      return true
-    } else {
-      LOG.debug("Undeclared dependency on module '{}'. " +
-                  "Plugin should declare this dependency to indicate dependence on shared functionality", PLATFORM_MODULE_ID)
-    }
-    if (dependencies.any { it.id in ADDITIONAL_MODULES_AVAILABLE_IN_ALL_PRODUCTS }) {
-      return true
-    } else {
-      LOG.debug("Undeclared dependency on any of the modules that are available in all Products. " +
-                  "This is not an issue if a dependency on the '{}' is declared explicitly.", PLATFORM_MODULE_ID)
-    }
-    return false
   }
 
   private fun IdePlugin.hasAnyV2Dependencies() = dependencies.any { it is PluginV2Dependency || it is ModuleV2Dependency }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifier.kt
@@ -44,7 +44,11 @@ class LegacyIntelliJIdeaPluginVerifier {
       // Due to confusing semantics we might need to check old-style module declarations
       val oldSemanticsModuleDependencies = dependencies.filterIsInstance<PluginDependencyImpl>()
       val moduleCandidates = v1Dependencies + oldSemanticsModuleDependencies
-      if (moduleCandidates.any { it.id.startsWith(INTELLIJ_MODULE_PREFIX) }) return NotLegacyPlugin
+
+      // the plugin system considers plugins with a dependency on any module or the Java plugin as not legacy
+      if (moduleCandidates.any { it.id.startsWith(INTELLIJ_MODULE_PREFIX) || it.id == "com.intellij.java" }) {
+        return NotLegacyPlugin
+      }
 
       return VerificationResult.NoModuleDependencies
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifierTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/verifiers/LegacyIntelliJIdeaPluginVerifierTest.kt
@@ -62,6 +62,14 @@ class LegacyIntelliJIdeaPluginVerifierTest : BaseExtensionPointTest<LegacyIntell
   }
 
   @Test
+  fun `dependency just on com_intellij_java`() {
+    val plugin = MockIdePlugin(dependencies = listOf(PluginV1Dependency.Mandatory("com.intellij.java")))
+    verifier.verify(plugin, PLUGIN_XML, problemRegistrar)
+
+    assertEquals(0, problems.size)
+  }
+
+  @Test
   fun `plugin with a single v2 dependency as a ModuleV2Dependency`() {
     val plugin = MockIdePlugin(
       pluginId = "com.intellij.classic.ui",


### PR DESCRIPTION
See [MP-8104](https://youtrack.jetbrains.com/issue/MP-8104).

See also [com.intellij.ide.plugins.PluginCompatibilityUtils](https://github.com/JetBrains/intellij-community/blob/0094ca972cb3ff53399e1b20d45448afaf1c437a/platform/core-impl/src/com/intellij/ide/plugins/PluginCompatibilityUtils.kt#L17).