### PR TITLE
Use proper namespace for content modules (IJPL-245093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Changed
 
+- Use proper namespace to allow declaring content modules in different namespaces in the same plugin ([IJPL-245093](https://youtrack.jetbrains.com/issue/IJPL-245093))
+
 ### Fixed
 
 ## 1.404 - 2026-05-18

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginModuleResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginModuleResolver.kt
@@ -11,23 +11,23 @@ import com.jetbrains.plugin.structure.intellij.beans.PluginBean
  */
 internal class PluginModuleResolver {
   fun resolvePluginModules(pluginBean: PluginBean): List<Module> {
-    val modules = pluginBean.pluginContent.flatMap { it.modules }
-    //for now, it's supposed that all modules in a plugin have the same namespace
-    val namespace = pluginBean.pluginContent.asSequence().mapNotNull { it.namespace }.firstOrNull()
-    //if the namespace isn't specified explicitly, a synthetic namespace is used in dependencies between private modules of the plugin
-    val actualNamespace = namespace ?: "${pluginBean.id}_\$implicit"
-    return modules.filter { it.moduleName != null }
-      .map {
-        val name = it.moduleName!!
-        val loadingRule = ModuleLoadingRule.create(it.loadingRule)
-        if (it.value.isNullOrBlank()) {
-          val configFile = "../${name.replace("/", ".")}.xml"
-          Module.FileBasedModule(name, namespace, actualNamespace, loadingRule, configFile)
-        } else {
-          val cDataContent = it.value!!
-          Module.InlineModule(name, namespace, actualNamespace, loadingRule, cDataContent)
+    return pluginBean.pluginContent.flatMap { contentBean ->
+      val namespace = contentBean.namespace
+      //if the namespace isn't specified explicitly, a synthetic namespace is used in dependencies between private modules of the plugin
+      val actualNamespace = namespace ?: "${pluginBean.id}_\$implicit"
+      contentBean.modules
+        .mapNotNull {
+          val name = it.moduleName ?: return@mapNotNull null
+          val loadingRule = ModuleLoadingRule.create(it.loadingRule)
+          if (it.value.isNullOrBlank()) {
+            val configFile = "../${name.replace("/", ".")}.xml"
+            Module.FileBasedModule(name, namespace, actualNamespace, loadingRule, configFile)
+          } else {
+            val cDataContent = it.value!!
+            Module.InlineModule(name, namespace, actualNamespace, loadingRule, cDataContent)
+          }
         }
-      }
+    }
   }
 
   fun supports(pluginBean: PluginBean): Boolean = pluginBean.pluginContent != null

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginParsingTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginParsingTest.kt
@@ -213,6 +213,46 @@ class PluginParsingTest(fileSystemType: FileSystemType) : IdePluginManagerTest(f
   }
 
   @Test
+  fun `multiple namespaces are supported`() {
+    val plugin = createPlugin {
+      dir("plugin") {
+        dir("lib") {
+          zip("plugin.jar") {
+            dir("META-INF") {
+              file("plugin.xml") { """
+                <idea-plugin>
+                  <id>someId</id>
+                  <content namespace="my_namespace1">
+                    <module name="module.1"/>
+                  </content>
+                  <content namespace="my_namespace2">
+                    <module name="module.2"/>
+                  </content>
+                </idea-plugin>  
+              """.trimIndent()
+              }
+            }
+            file("module.1.xml") {
+              """<idea-plugin/>"""
+            }
+            file("module.2.xml") {
+              """<idea-plugin/>"""
+            }
+          }
+        }
+      }
+    }
+    assertEquals(2, plugin.contentModules.size)
+    assertEquals("my_namespace1", plugin.contentModules[0].namespace)
+    assertEquals("my_namespace1", plugin.contentModules[0].actualNamespace)
+    assertEquals("my_namespace2", plugin.contentModules[1].namespace)
+    assertEquals("my_namespace2", plugin.contentModules[1].actualNamespace)
+    assertEquals(2, plugin.modulesDescriptors.size)
+    assertEquals("module.1", plugin.modulesDescriptors[0].name)
+    assertEquals("module.2", plugin.modulesDescriptors[1].name)
+  }
+
+  @Test
   fun `implicit namespace for private modules`() {
     val plugin = createPlugin {
       dir("plugin") {


### PR DESCRIPTION
Going forward from 262.6228.4, multiple `<content>` elements allow different namespaces in a single `plugin.xml`.

```xml
<idea-plugin>
    <id>someId</id>
    <content namespace="my_namespace1">
        <module name="module.1"/>
    </content>
    <content namespace="my_namespace2">
        <module name="module.2"/>
    </content>
</idea-plugin> 
```

As a side-effect, a single `plugin.xml` can contain multiple `<content>` elements, not just one.

It is now allowed to register the same module in different namespaces in different plugins, see [IJPL-244112](https://youtrack.jetbrains.com/issue/IJPL-244112) and [IJPL-245093](https://youtrack.jetbrains.com/issue/IJPL-245093).