### PR TITLE
Add logs for dependency downloads and plugin cache usage (MP-8047)

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -22,6 +22,7 @@ import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
 import com.jetbrains.pluginverifier.reporting.DirectoryBasedPluginVerificationReportage
 import com.jetbrains.pluginverifier.reporting.LoggingPluginVerificationReportageAggregator
 import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 import com.jetbrains.pluginverifier.repository.cleanup.DiskSpaceSetting
 import com.jetbrains.pluginverifier.repository.cleanup.SpaceAmount
 import com.jetbrains.pluginverifier.repository.cleanup.SpaceUnit
@@ -126,13 +127,17 @@ object PluginVerifierMain {
       DefaultPluginDetailsProvider(pluginArchiveManager).use { pluginDetailsProvider ->
         val reportageAggregator = LoggingPluginVerificationReportageAggregator()
         DirectoryBasedPluginVerificationReportage(reportageAggregator) { outputOptions.getTargetReportDirectory(it) }.use { reportage ->
+          var pluginDetailsCacheStatistics: CacheStatistics? = null
           measurePluginVerification {
             val detailsCacheSize = System.getProperty("plugin.verifier.plugin.details.cache.size")?.toIntOrNull() ?: 32
-            val taskResult = SizeLimitedPluginDetailsCache(
+            val pluginDetailsCache = SizeLimitedPluginDetailsCache(
               detailsCacheSize,
               pluginFilesBank,
               pluginDetailsProvider
-            ).use { pluginDetailsCache ->
+            )
+            // Capture stats reference before close() so the post-run summary can read it.
+            pluginDetailsCacheStatistics = pluginDetailsCache.statistics
+            pluginDetailsCache.use {
               runner.getParametersBuilder(
                 pluginRepository,
                 pluginDetailsCache,
@@ -146,11 +151,11 @@ object PluginVerifierMain {
                   .execute(reportage, pluginDetailsCache)
               }
             }
-            taskResult
           }.run {
             val taskResultsPrinter = taskResult.createTaskResultsPrinter(pluginRepository)
             taskResultsPrinter.printResults(taskResult, outputOptions)
             reportage.reportDownloadStatistics(outputOptions, pluginFilesBank)
+            pluginDetailsCacheStatistics?.let { reportage.reportCacheStatistics("PluginDetailsCache", it) }
             reportageAggregator.handleAggregatedReportage()
             reportage.reportVerificationDuration(this)
           }
@@ -188,6 +193,13 @@ object PluginVerifierMain {
         totalSpaceUsed.to(SpaceUnit.BYTE).toLong()
       )
     }
+  }
+
+  private fun PluginVerificationReportage.reportCacheStatistics(
+    cacheName: String,
+    statistics: CacheStatistics
+  ) {
+    logVerificationStage("$cacheName statistics: ${statistics.presentableSummary()}")
   }
 
   private fun PluginVerificationReportage.reportVerificationDuration(measuredResult: MeasuredResult) {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/PluginVerifierMain.kt
@@ -199,7 +199,7 @@ object PluginVerifierMain {
     cacheName: String,
     statistics: CacheStatistics
   ) {
-    logVerificationStage("$cacheName statistics: ${statistics.presentableSummary()}")
+    logVerificationStage("$cacheName statistics: ${statistics.presentableSummary}")
   }
 
   private fun PluginVerificationReportage.reportVerificationDuration(measuredResult: MeasuredResult) {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
@@ -5,6 +5,8 @@
 package com.jetbrains.pluginverifier.dependencies.resolution
 
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * [DependencyFinder] that subsequently delegates the search
@@ -14,20 +16,46 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
  * the [DependencyFinder.Result.NotFound] is returned.
  */
 class CompositeDependencyFinder(private val dependencyFinders: List<DependencyFinder>) : DependencyFinder {
+  private companion object {
+    private val LOG: Logger = LoggerFactory.getLogger(CompositeDependencyFinder::class.java)
+  }
+
   override val presentableName
     get() = dependencyFinders.joinToString { it.presentableName }
 
   override fun findPluginDependency(dependencyId: String, isModule: Boolean): DependencyFinder.Result {
-    return dependencyFinders.asSequence()
-      .map { it.findPluginDependency(dependencyId, isModule) }
-      .firstOrNull { it !is DependencyFinder.Result.NotFound }
-      ?: DependencyFinder.Result.NotFound("Dependency '$dependencyId'${if (isModule) " (module)" else ""} is not resolved. It was searched in the following locations: $presentableName")
+    val kind = if (isModule) "module" else "plugin"
+    val label = "'$dependencyId'"
+    return resolve(kind, label) { it.findPluginDependency(dependencyId, isModule) }
+      ?: notFound("Dependency '$dependencyId'${if (isModule) " (module)" else ""} is not resolved. It was searched in the following locations: $presentableName", kind, label)
   }
 
   override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result {
-    return dependencyFinders.asSequence()
-      .map { it.findPluginDependency(dependency) }
-      .firstOrNull { it !is DependencyFinder.Result.NotFound }
-      ?: DependencyFinder.Result.NotFound("Dependency '$dependency' is not resolved. It was searched in the following locations: $presentableName")
+    val kind = if (dependency.isModule) "module" else "plugin"
+    val label = "'$dependency'"
+    return resolve(kind, label) { it.findPluginDependency(dependency) }
+      ?: notFound("Dependency '$dependency' is not resolved. It was searched in the following locations: $presentableName", kind, label)
+  }
+
+  private inline fun resolve(
+    kind: String,
+    label: String,
+    findIn: (DependencyFinder) -> DependencyFinder.Result
+  ): DependencyFinder.Result? {
+    for (finder in dependencyFinders) {
+      val result = findIn(finder)
+      if (result !is DependencyFinder.Result.NotFound) {
+        LOG.debug("Dependency {} {} resolved by {}", kind, label, finder.presentableName)
+        return result
+      } else {
+        LOG.debug("Dependency {} {} not found in {}: {}", kind, label, finder.presentableName, result.reason)
+      }
+    }
+    return null
+  }
+
+  private fun notFound(reason: String, kind: String, label: String): DependencyFinder.Result.NotFound {
+    LOG.info("Dependency {} {} could not be resolved by any finder ({})", kind, label, presentableName)
+    return DependencyFinder.Result.NotFound(reason)
   }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/CompositeDependencyFinder.kt
@@ -8,6 +8,8 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+private val LOG: Logger = LoggerFactory.getLogger(CompositeDependencyFinder::class.java)
+
 /**
  * [DependencyFinder] that subsequently delegates the search
  * to the [dependencyFinders] until the dependency is resolved.
@@ -16,10 +18,6 @@ import org.slf4j.LoggerFactory
  * the [DependencyFinder.Result.NotFound] is returned.
  */
 class CompositeDependencyFinder(private val dependencyFinders: List<DependencyFinder>) : DependencyFinder {
-  private companion object {
-    private val LOG: Logger = LoggerFactory.getLogger(CompositeDependencyFinder::class.java)
-  }
-
   override val presentableName
     get() = dependencyFinders.joinToString { it.presentableName }
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
@@ -9,6 +9,8 @@ import com.jetbrains.pluginverifier.misc.retry
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.repositories.dependency.DependencyPluginRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * [DependencyFinder] that searches for the dependency in the [PluginRepository].
@@ -21,6 +23,10 @@ class RepositoryDependencyFinder(
   private val pluginDetailsCache: PluginDetailsCache
 ) : DependencyFinder {
 
+  private companion object {
+    private val LOG: Logger = LoggerFactory.getLogger(RepositoryDependencyFinder::class.java)
+  }
+
   private val pluginRepository = DependencyPluginRepository(pluginRepository)
 
   override val presentableName
@@ -31,22 +37,45 @@ class RepositoryDependencyFinder(
       if (dependencyId.isBlank()) {
         return@retry DependencyFinder.Result.NotFound("Invalid empty dependency ID")
       }
-      if (isModule) {
-        convertResult(pluginVersionSelector.selectPluginByModuleId(dependencyId, pluginRepository))
+      val kind = if (isModule) "module" else "plugin"
+      LOG.debug("Resolving dependency {} '{}' against {}", kind, dependencyId, pluginRepository)
+      val selectResult = if (isModule) {
+        pluginVersionSelector.selectPluginByModuleId(dependencyId, pluginRepository)
       } else {
-        convertResult(pluginVersionSelector.selectPluginVersion(dependencyId, pluginRepository))
+        pluginVersionSelector.selectPluginVersion(dependencyId, pluginRepository)
       }
+      convertResult(dependencyId, kind, selectResult)
     }
 
   override fun findPluginDependency(dependency: PluginDependency): DependencyFinder.Result =
     findPluginDependency(dependency.id, dependency.isModule)
 
-  private fun convertResult(selectResult: PluginVersionSelector.Result): DependencyFinder.Result =
+  private fun convertResult(
+    dependencyId: String,
+    kind: String,
+    selectResult: PluginVersionSelector.Result
+  ): DependencyFinder.Result =
     when (selectResult) {
       is PluginVersionSelector.Result.Selected -> {
+        LOG.info(
+          "Resolved dependency {} '{}' to {} against {}",
+          kind,
+          dependencyId,
+          selectResult.pluginInfo,
+          pluginRepository
+        )
         val cacheEntryResult = pluginDetailsCache.getPluginDetailsCacheEntry(selectResult.pluginInfo)
         DependencyFinder.Result.DetailsProvided(cacheEntryResult)
       }
-      is PluginVersionSelector.Result.NotFound -> DependencyFinder.Result.NotFound(selectResult.reason)
+      is PluginVersionSelector.Result.NotFound -> {
+        LOG.debug(
+          "Dependency {} '{}' not found in {}: {}",
+          kind,
+          dependencyId,
+          pluginRepository,
+          selectResult.reason
+        )
+        DependencyFinder.Result.NotFound(selectResult.reason)
+      }
     }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
@@ -12,6 +12,8 @@ import com.jetbrains.pluginverifier.repository.repositories.dependency.Dependenc
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+private val LOG: Logger = LoggerFactory.getLogger(RepositoryDependencyFinder::class.java)
+
 /**
  * [DependencyFinder] that searches for the dependency in the [PluginRepository].
  * The [pluginVersionSelector] is used to select a specific version of the plugin
@@ -22,10 +24,6 @@ class RepositoryDependencyFinder(
   private val pluginVersionSelector: PluginVersionSelector,
   private val pluginDetailsCache: PluginDetailsCache
 ) : DependencyFinder {
-
-  private companion object {
-    private val LOG: Logger = LoggerFactory.getLogger(RepositoryDependencyFinder::class.java)
-  }
 
   private val pluginRepository = DependencyPluginRepository(pluginRepository)
 

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/IdeFilesBank.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/ide/IdeFilesBank.kt
@@ -97,7 +97,7 @@ private class IdeDownloadProvider(
   val ideRepository: IdeRepository
 ) : ResourceProvider<IdeVersion, Path> {
 
-  private val downloadProvider = DownloadProvider(bankDirectory, IdeDownloader()) { it.version.asString() }
+  private val downloadProvider = DownloadProvider(bankDirectory, IdeDownloader(), "IDE") { it.version.asString() }
 
   override fun provide(key: IdeVersion): ProvideResult<Path> {
     val availableIde = try {

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginDetailsCache.kt
@@ -2,6 +2,7 @@ package com.jetbrains.pluginverifier.plugin
 
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntry
 import com.jetbrains.pluginverifier.repository.cleanup.SizeWeight
 import java.io.Closeable
@@ -18,6 +19,11 @@ interface PluginDetailsCache : Closeable {
    * Provides the [PluginDetails] of the given [pluginInfo] wrapped in a [Result].
    */
   fun getPluginDetailsCacheEntry(pluginInfo: PluginInfo): Result
+
+  /**
+   * Aggregate hit/miss/eviction statistics for this cache.
+   */
+  val statistics: CacheStatistics
 
   /**
    * Represents possible results of the [getPluginDetailsCacheEntry].

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginFilesBank.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/PluginFilesBank.kt
@@ -49,7 +49,7 @@ class PluginFilesBank(
       val urlProvider: (PluginInfo) -> URL? = { (it as? Downloadable)?.downloadUrl }
       val urlDownloader = UrlDownloader(urlProvider)
 
-      val downloadProvider = DownloadProvider(pluginsDir, urlDownloader) { key ->
+      val downloadProvider = DownloadProvider(pluginsDir, urlDownloader, "Plugin") { key ->
         when (key) {
           is UpdateInfo -> getFileNameForMarketplacePlugin(key)
           else -> (key.pluginId + "-" + key.version).replaceInvalidFileNameCharacters()

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/plugin/SizeLimitedPluginDetailsCache.kt
@@ -6,6 +6,7 @@ package com.jetbrains.pluginverifier.plugin
 
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.WithIdePlugin
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntry
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntryResult
 import com.jetbrains.pluginverifier.repository.cache.createSizeLimitedResourceCache
@@ -35,6 +36,9 @@ class SizeLimitedPluginDetailsCache(
     { it.close() },
     "PluginDetailsCache"
   )
+
+  override val statistics: CacheStatistics
+    get() = internalCache.statistics
 
   /**
    * Provides the [PluginDetails] of the given [pluginInfo] wrapped in a [Result].

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/CacheStatistics.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/CacheStatistics.kt
@@ -45,27 +45,29 @@ class CacheStatistics {
     }
   }
 
-  fun hits(): Long = hitCount.get()
-  fun misses(): Long = missCount.get()
-  fun failures(): Long = failureCount.get()
-  fun evictions(): Long = evictionCount.get()
+  val hits: Long get() = hitCount.get()
+  val misses: Long get() = missCount.get()
+  val failures: Long get() = failureCount.get()
+  val evictions: Long get() = evictionCount.get()
 
-  fun total(): Long = hits() + misses() + failures()
+  val total: Long get() = hits + misses + failures
 
   /**
    * Hit rate as a fraction in `[0.0, 1.0]`. Returns `0.0` if the cache has not been accessed yet.
    */
-  fun hitRate(): Double {
-    val totalLookups = hits() + misses() + failures()
-    return if (totalLookups == 0L) 0.0 else hits().toDouble() / totalLookups
-  }
+  val hitRate: Double
+    get() {
+      val totalLookups = hits + misses + failures
+      return if (totalLookups == 0L) 0.0 else hits.toDouble() / totalLookups
+    }
 
   /**
    * One-line, human-readable summary suitable for `info`-level logging.
    */
-  fun presentableSummary(): String {
-    val total = total()
-    val hitRatePercent = if (total == 0L) "n/a" else "%.1f%%".format(hitRate() * 100.0)
-    return "hits=${hits()}, misses=${misses()}, failures=${failures()}, evictions=${evictions()}, total=$total, hit-rate=$hitRatePercent"
-  }
+  val presentableSummary: String
+    get() {
+      val total = total
+      val hitRatePercent = if (total == 0L) "n/a" else "%.1f%%".format(hitRate * 100.0)
+      return "hits=$hits, misses=$misses, failures=$failures, evictions=$evictions, total=$total, hit-rate=$hitRatePercent"
+    }
 }

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/CacheStatistics.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/CacheStatistics.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.repository.cache
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Aggregate hit/miss statistics for a single cache.
+ *
+ * A `hit` is a lookup that was served entirely from already-cached state.
+ * A `miss` is a lookup that had to invoke the underlying [com.jetbrains.pluginverifier.repository.provider.ResourceProvider]
+ * (or wait for another thread doing the same).
+ * A `failure` is a lookup that ended in a `NotFound`/`Failed` outcome — the cache did not retain anything.
+ * An `eviction` is a previously-stored resource that was removed by the eviction policy.
+ *
+ * All counters are updated atomically and may be read concurrently.
+ */
+class CacheStatistics {
+  private val hitCount = AtomicLong()
+  private val missCount = AtomicLong()
+  private val failureCount = AtomicLong()
+  private val evictionCount = AtomicLong()
+
+  fun recordHit() {
+    hitCount.incrementAndGet()
+  }
+
+  fun recordMiss() {
+    missCount.incrementAndGet()
+  }
+
+  fun recordFailure() {
+    failureCount.incrementAndGet()
+  }
+
+  fun recordEviction() {
+    evictionCount.incrementAndGet()
+  }
+
+  fun recordEvictions(count: Int) {
+    if (count > 0) {
+      evictionCount.addAndGet(count.toLong())
+    }
+  }
+
+  fun hits(): Long = hitCount.get()
+  fun misses(): Long = missCount.get()
+  fun failures(): Long = failureCount.get()
+  fun evictions(): Long = evictionCount.get()
+
+  fun total(): Long = hits() + misses() + failures()
+
+  /**
+   * Hit rate as a fraction in `[0.0, 1.0]`. Returns `0.0` if the cache has not been accessed yet.
+   */
+  fun hitRate(): Double {
+    val totalLookups = hits() + misses() + failures()
+    return if (totalLookups == 0L) 0.0 else hits().toDouble() / totalLookups
+  }
+
+  /**
+   * One-line, human-readable summary suitable for `info`-level logging.
+   */
+  fun presentableSummary(): String {
+    val total = total()
+    val hitRatePercent = if (total == 0L) "n/a" else "%.1f%%".format(hitRate() * 100.0)
+    return "hits=${hits()}, misses=${misses()}, failures=${failures()}, evictions=${evictions()}, total=$total, hit-rate=$hitRatePercent"
+  }
+}

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/ResourceCache.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/cache/ResourceCache.kt
@@ -99,6 +99,12 @@ class ResourceCache<R : Any, in K : Any, W : ResourceWeight<W>>(
   )
 
   /**
+   * Aggregate cache hit/miss statistics. Updated by the underlying [resourceRepository].
+   */
+  val statistics: CacheStatistics
+    get() = resourceRepository.statistics
+
+  /**
    * A flag indicating whether _this_ cache is already closed.
    */
   private val isClosed = AtomicBoolean(false)

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/downloader/DownloadProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/downloader/DownloadProvider.kt
@@ -10,23 +10,32 @@ import com.jetbrains.pluginverifier.repository.cleanup.fileSize
 import com.jetbrains.pluginverifier.repository.provider.ProvideResult
 import com.jetbrains.pluginverifier.repository.provider.ResourceProvider
 import org.apache.commons.io.FileUtils
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 
 /**
  * [ResourceProvider] responsible for downloading files and directories
  * using provided [downloader] and saving them to the [destinationDirectory]
  * using the [fileNameWithoutExtensionMapper].
+ *
+ * The [presentableName] is used as a label in log messages so callers can tell apart
+ * downloads coming from different download providers (e.g. plugin vs. IDE downloads).
  */
 class DownloadProvider<in K : Any>(
   private val destinationDirectory: Path,
   private val downloader: Downloader<K>,
+  private val presentableName: String = "Downloads",
   private val fileNameWithoutExtensionMapper: (K) -> String
 ) : ResourceProvider<K, Path> {
   private companion object {
     const val DOWNLOADS_DIRECTORY = ".downloads"
   }
+
+  private val logger: Logger = LoggerFactory.getLogger(DownloadProvider::class.java.name + "." + presentableName)
 
   private val downloadDirectory = destinationDirectory.resolve(DOWNLOADS_DIRECTORY)
 
@@ -40,21 +49,52 @@ class DownloadProvider<in K : Any>(
   @Throws(InterruptedException::class)
   override fun provide(key: K): ProvideResult<Path> {
     val downloadEvent = downloadStatistics.downloadStarted()
+    val startNanos = System.nanoTime()
+    logger.debug("Download started: {}", key)
     val tempDirectory = createTempDirectoryForDownload(key)
     try {
       return with(downloader.download(key, tempDirectory)) {
         when (this) {
           is DownloadResult.Downloaded -> {
-            downloadEvent.downloadEnded(downloadedFileOrDirectory.fileSize)
+            val size = downloadedFileOrDirectory.fileSize
+            downloadEvent.downloadEnded(size)
+            logger.info(
+              "Download finished: {} ({}, {})",
+              key,
+              size.presentableAmount(),
+              formatElapsed(startNanos)
+            )
             saveDownloadedFileToFinalDestination(key, downloadedFileOrDirectory, extension, isDirectory)
           }
-          is DownloadResult.NotFound -> ProvideResult.NotFound(reason)
-          is DownloadResult.FailedToDownload -> ProvideResult.Failed(reason, error)
+          is DownloadResult.NotFound -> {
+            logger.info(
+              "Download not found: {} ({}). Reason: {}",
+              key,
+              formatElapsed(startNanos),
+              reason
+            )
+            ProvideResult.NotFound(reason)
+          }
+          is DownloadResult.FailedToDownload -> {
+            logger.warn(
+              "Download failed: {} ({}). Reason: {}",
+              key,
+              formatElapsed(startNanos),
+              reason,
+              error
+            )
+            ProvideResult.Failed(reason, error)
+          }
         }
       }
     } finally {
       tempDirectory.deleteLogged()
     }
+  }
+
+  private fun formatElapsed(startNanos: Long): String {
+    val nanos = System.nanoTime() - startNanos
+    return Duration.ofNanos(nanos).formatDuration()
   }
 
   private val nameGenerationLocks = Striped.lock(getConcurrencyLevel().coerceAtLeast(1))

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/resources/ResourceRepositoryImpl.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/resources/ResourceRepositoryImpl.kt
@@ -243,7 +243,7 @@ class ResourceRepositoryImpl<R : Any, K : Any, W : ResourceWeight<W>>(
         }
         value.statistic.access(now)
         statistics.recordHit()
-        logger.debugMaybe { "$presentableName hit: $key (cached, lockId=$lockId)" }
+        logger.debugMaybe { "$presentableName hit: the resource $key is available and a lock is registered $lock (cached, lockId=$lockId)" }
         return ResourceRepositoryResult.Found(lock)
       }
       val fetchTask: Fetching<R>

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/resources/ResourceRepositoryImpl.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/resources/ResourceRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.jetbrains.plugin.structure.base.utils.checkIfInterrupted
 import com.jetbrains.plugin.structure.base.utils.closeOnException
 import com.jetbrains.plugin.structure.base.utils.pluralize
 import com.jetbrains.plugin.structure.base.utils.rethrowIfInterrupted
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 import com.jetbrains.pluginverifier.repository.cleanup.UsageStatistic
 import com.jetbrains.pluginverifier.repository.provider.ProvideResult
 import com.jetbrains.pluginverifier.repository.provider.ResourceProvider
@@ -44,6 +45,8 @@ class ResourceRepositoryImpl<R : Any, K : Any, W : ResourceWeight<W>>(
   private val presentableName: String = "ResourceRepository"
 ) : ResourceRepository<R, K, W> {
   private val logger: Logger = LoggerFactory.getLogger(presentableName)
+
+  val statistics: CacheStatistics = CacheStatistics()
 
   private val nextLockId = AtomicLong()
 
@@ -239,19 +242,22 @@ class ResourceRepositoryImpl<R : Any, K : Any, W : ResourceWeight<W>>(
           continue
         }
         value.statistic.access(now)
-        logger.debugMaybe { "get($key): the resource is available and a lock is registered $lock" }
+        statistics.recordHit()
+        logger.debugMaybe { "$presentableName hit: $key (cached, lockId=$lockId)" }
         return ResourceRepositoryResult.Found(lock)
       }
       val fetchTask: Fetching<R>
       val runInCurrentThread: Boolean
       if (value is Fetching<*>) {
-        logger.debugMaybe { "get($key): waiting for another thread to finish fetching the resource" }
+        statistics.recordMiss()
+        logger.debugMaybe { "$presentableName miss: $key (waiting for another thread to finish fetching)" }
         @Suppress("UNCHECKED_CAST")
         fetchTask = value as Fetching<R>
         runInCurrentThread = false
       } else {
         assert(value === null)
-        logger.debugMaybe { "get($key): fetching the resource in the current thread" }
+        statistics.recordMiss()
+        logger.debugMaybe { "$presentableName miss: $key (fetching in the current thread)" }
         val newTask = Fetching {
           fetchResource(key)
         }
@@ -300,6 +306,7 @@ class ResourceRepositoryImpl<R : Any, K : Any, W : ResourceWeight<W>>(
       } else {
         // remove unsuccessful task from the storage
         storage.remove(key, fetchTask)
+        statistics.recordFailure()
         return when (provideResult) {
           is ProvideResult.NotFound<R> -> ResourceRepositoryResult.NotFound(provideResult.reason)
           is ProvideResult.Failed<R> -> ResourceRepositoryResult.Failed(provideResult.reason, provideResult.error)
@@ -405,9 +412,10 @@ class ResourceRepositoryImpl<R : Any, K : Any, W : ResourceWeight<W>>(
 
       if (resourcesForEviction.isNotEmpty()) {
         val disposedTotalWeight = resourcesForEviction.map { it.resourceInfo.weight }.reduce { acc, weight -> acc + weight }
+        statistics.recordEvictions(resourcesForEviction.size)
         logger.debugMaybe {
-          "It's time to evict unused resources. " +
-            "Total weight: $totalWeight. " +
+          "$presentableName eviction: " +
+            "Total weight before eviction: $totalWeight. " +
             "${resourcesForEviction.size} " + "resource".pluralize(resourcesForEviction.size) +
             " will be evicted with total weight $disposedTotalWeight"
         }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockPluginDetailsCache.kt
@@ -2,8 +2,11 @@ package com.jetbrains.pluginverifier.tests.mocks
 
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 
 class MockPluginDetailsCache : PluginDetailsCache {
+  override val statistics: CacheStatistics = CacheStatistics()
+
   override fun getPluginDetailsCacheEntry(pluginInfo: PluginInfo): PluginDetailsCache.Result {
     return PluginDetailsCache.Result.FileNotFound("Mock cache does not provide any files")
   }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockSinglePluginDetailsCache.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/mocks/MockSinglePluginDetailsCache.kt
@@ -7,12 +7,15 @@ package com.jetbrains.pluginverifier.tests.mocks
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.plugin.PluginDetailsProvider
 import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
 import com.jetbrains.pluginverifier.repository.cache.ResourceCacheEntry
 
 class MockSinglePluginDetailsCache(
   private val supportedPluginId: String,
   private val pluginDetailsProvider: PluginDetailsProvider
 ) : PluginDetailsCache {
+  override val statistics: CacheStatistics = CacheStatistics()
+
   override fun getPluginDetailsCacheEntry(pluginInfo: PluginInfo): PluginDetailsCache.Result {
     return if (supportedPluginId != pluginInfo.pluginId) {
       fail(pluginInfo)


### PR DESCRIPTION
- Improve logging on dependency searches
- Trace cache hits when resolving dependencies to investigate duplicate downloads and other corner-cases

See [MP-8047](https://youtrack.jetbrains.com/issue/MP-8047/Improve-logging-around-downloads-and-cache-usage)