### PR TITLE
Add RustRover to IntelliJPlatformProduct enum with improved error messaging

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IntelliJPlatformProduct.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IntelliJPlatformProduct.kt
@@ -36,7 +36,8 @@ enum class IntelliJPlatformProduct(
   JETBRAINS_CLIENT("JBC", "JetBrains Client", "JetBrainsClient"),
   GATEWAY("GW", "Gateway", "Gateway"),
   FLEET("FL", "Fleet", "Fleet"),
-  AQUA("QA", "Aqua", "Aqua");
+  AQUA("QA", "Aqua", "Aqua"),
+  RUST_ROVER("RR", "RustRover", "RustRover");
 
   companion object {
     fun fromProductCode(productCode: String): IntelliJPlatformProduct? =

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/CorePluginManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/CorePluginManager.kt
@@ -16,12 +16,11 @@ import com.jetbrains.plugin.structure.jar.PluginDescriptorResult
 import com.jetbrains.plugin.structure.jar.PluginJar
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
 import java.nio.file.Path
 
 private val LOG: Logger = LoggerFactory.getLogger(CorePluginManager::class.java)
 
-private val LIB_DIRECTORY = "lib"
+private const val LIB_DIRECTORY = "lib"
 
 private const val CORE_IDE_PLUGIN_ID = "com.intellij"
 
@@ -58,7 +57,7 @@ internal class CorePluginManager(private val pluginLoader: LayoutComponentLoader
     loadingResults: LoadingResults
   ) {
     if (loadingResults.successfulPlugins.isEmpty()) {
-      val libDir = "$idePath${File.separator}$LIB_DIRECTORY"
+      val libDir = idePath.resolve(LIB_DIRECTORY)
       val searchedFor = ideVersion.descriptorPaths.joinToString(", ")
       val knownProduct = IntelliJPlatformProduct.fromIdeVersion(ideVersion)
       val productHint = if (knownProduct == null) {
@@ -94,7 +93,7 @@ internal class CorePluginManager(private val pluginLoader: LayoutComponentLoader
    */
   private val IdeVersion.descriptorPaths: Array<String>
     get() {
-      operator fun String.div(fileName: String) = "$this${File.separator}$fileName"
+      operator fun String.div(fileName: String) = "$this/$fileName"
       return arrayOf(
         META_INF / "${platformPrefix}Plugin.xml",
         META_INF / PLUGIN_XML,

--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/CorePluginManager.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/layout/CorePluginManager.kt
@@ -47,18 +47,31 @@ internal class CorePluginManager(private val pluginLoader: LayoutComponentLoader
     val loadedPlugins = corePluginJarPaths.mapNotNull(loadPlugin)
     val loadingResults = LoadingResults(loadedPlugins)
     logFailures(LOG, loadingResults.failures, idePath)
-    assertCorePluginsPresent(idePath, loadingResults)
+    assertCorePluginsPresent(idePath, ideVersion, loadingResults)
 
     return loadingResults.successfulPlugins
   }
 
   private fun assertCorePluginsPresent(
     idePath: Path,
+    ideVersion: IdeVersion,
     loadingResults: LoadingResults
   ) {
     if (loadingResults.successfulPlugins.isEmpty()) {
+      val libDir = "$idePath${File.separator}$LIB_DIRECTORY"
+      val searchedFor = ideVersion.descriptorPaths.joinToString(", ")
+      val knownProduct = IntelliJPlatformProduct.fromIdeVersion(ideVersion)
+      val productHint = if (knownProduct == null) {
+        " The product code '${ideVersion.productCode}' is not known to ${IntelliJPlatformProduct::class.java.simpleName};" +
+          " add an entry there if this IDE should be supported."
+      } else {
+        ""
+      }
       throw InvalidIdeException(
-        idePath, "The 'Core' plugin (ID: 'com.intellij') is expected in the $idePath${File.separator}$LIB_DIRECTORY")
+        idePath,
+        "The 'Core' plugin (ID: 'com.intellij') was not found in $libDir." +
+          " Searched JARs for descriptors: $searchedFor.$productHint"
+      )
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/ProductInfoBasedIdeManagerTest.kt
@@ -3,6 +3,7 @@ package com.jetbrains.plugin.structure.ide
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
 import ch.qos.logback.core.spi.AppenderAttachable
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.ide.layout.LayoutComponents
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfo
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginImpl
@@ -115,6 +116,65 @@ class ProductInfoBasedIdeManagerTest {
     riderModule!!
     assertTrue(ideCore.pluginId == riderModule.pluginId)
   }
+
+  @Test
+  fun `reports actionable error when product code is unknown`() {
+    val ideRoot = temporaryFolder.newFolder("unknown-product").toPath()
+    buildDirectory(ideRoot) {
+      file("build.txt", "ZZ-261.0.0")
+      file("product-info.json", unknownProductInfoJson)
+      dir("lib") {
+        zip("app-client.jar") {
+          dir("META-INF") {
+            // Descriptor named for the unknown 'ZZ' product. CorePluginManager falls back
+            // to the IDEA prefix and searches for META-INF/ideaPlugin.xml + META-INF/plugin.xml,
+            // neither of which matches, so loading must fail.
+            file("ZzPlugin.xml", corePluginXml)
+          }
+        }
+      }
+      dir("modules") {
+        zip("module-descriptors.jar") {}
+      }
+    }
+
+    val ideManager = ProductInfoBasedIdeManager()
+    val ide = ideManager.createIde(ideRoot)
+    val exception = assertThrows(InvalidIdeException::class.java) { ide.bundledPlugins }
+
+    val message = exception.message ?: ""
+    assertTrue("message should mention the lib dir: $message", message.contains("lib"))
+    assertTrue("message should list searched descriptors: $message", message.contains("ideaPlugin.xml"))
+    assertTrue("message should list searched descriptors: $message", message.contains("plugin.xml"))
+    assertTrue("message should name the unknown product code: $message", message.contains("'ZZ'"))
+    assertTrue("message should point at IntelliJPlatformProduct: $message", message.contains("IntelliJPlatformProduct"))
+  }
+
+  private val unknownProductInfoJson = """
+    {
+      "name": "Unknown",
+      "version": "2026.1",
+      "versionSuffix": "EAP",
+      "buildNumber": "261.0.0",
+      "productCode": "ZZ",
+      "dataDirectoryName": "Unknown2026.1",
+      "svgIconPath": "bin/unknown.svg",
+      "productVendor": "JetBrains",
+      "launch": [],
+      "customProperties": [],
+      "bundledPlugins": [],
+      "modules": [],
+      "fileExtensions": [],
+      "layout": []
+    }
+  """.trimIndent()
+
+  private val corePluginXml = """
+    <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+      <id>com.intellij</id>
+      <name>IDEA CORE</name>
+    </idea-plugin>
+  """.trimIndent()
 
   @Test
   fun `create IDE manager with missing version suffix`() {


### PR DESCRIPTION
Fix for [MP-8079](https://youtrack.jetbrains.com/issue/MP-8079) extracted-ide is invalid: The 'Core' plugin (ID: 'com.intellij') is expected

Rust Rover was missing from an enum that is used to discover core plugins. I have added the enum and made the error message more informative, so in the future we have a more actionable stacktrace.