### PR TITLE
Propagate companion annotations to @JvmStatic methods and fields (IJPL-245371)

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -18,6 +18,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
+import org.objectweb.asm.Type
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -45,10 +46,88 @@ class AnnotationResolver(val annotation: FullyQualifiedClassName) {
   private fun resolveDirectAnnotation(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? =
     AnnotatedDirectly(classFileMember, annotation).takeIf { classFileMember.isDirectlyAnnotatedWith(annotation) }
 
-  private fun resolveInNonClassFile(classFileMember: ClassFileMember, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? =
-    resolve(classFileMember.containingClassFile, classResolver, resolutionStack)?.let {
+  private fun resolveInNonClassFile(classFileMember: ClassFileMember, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? {
+    val annotationFromCompanion = resolveInCompanion(classFileMember, classResolver)
+    if (annotationFromCompanion != null) {
+      return annotationFromCompanion
+    }
+    return resolve(classFileMember.containingClassFile, classResolver, resolutionStack)?.let {
       AnnotatedViaContainingClass(classFileMember.containingClassFile, classFileMember, annotation)
     }
+  }
+
+  /**
+   * consider the following class:
+   * ```kotlin
+   * class Foo {
+   *   @Internal
+   *   companion object {
+   *     @JvmStatic
+   *     fun bar()
+   *   }
+   * }
+   * ```
+   * We want to propagate `@Internal` annotation to `bar`,
+   * even if `bar` is represented by a separate static method outside `Foo$Companion` nested class in the bytecode
+   */
+  private fun resolveInCompanion(classFileMember: ClassFileMember, classResolver: Resolver): MemberAnnotation? {
+    if (classFileMember !is Field && classFileMember !is Method) {
+      return null
+    }
+    val isStaticMember = when (classFileMember) {
+      is Field -> classFileMember.isStatic
+      is Method -> classFileMember.isStatic
+      else -> false
+    }
+    if (!isStaticMember) return null
+
+    val containingClass = classFileMember.containingClassFile
+    val companionClass = classResolver.resolveClassOrNull("${containingClass.name}\$Companion")
+      ?.takeIf { it.enclosingClassName == containingClass.name }
+      ?: return null
+
+    if (classFileMember is Field && classFileMember.referencesCompanionInstanceAsField(companionClass)) {
+      return companionClass.directAnnotationViaCompanion(classFileMember)
+    }
+
+    if (classFileMember is Method) {
+      val companionMethod = companionClass.methods.firstOrNull {
+        it.matchesJvmStaticCompanionMember(classFileMember, companionClass.name)
+      } ?: return null
+      return companionClass.directAnnotationViaCompanion(classFileMember)
+        ?: companionMethod.directAnnotationViaCompanion(classFileMember)
+    }
+
+    return null
+  }
+
+  private fun ClassFileMember.directAnnotationViaCompanion(classFileMember: ClassFileMember): MemberAnnotation? =
+    AnnotatedViaContainingClass(this, classFileMember, annotation)
+      .takeIf { isDirectlyAnnotatedWith(annotation) }
+
+  private fun Field.referencesCompanionInstanceAsField(companionClass: ClassFile): Boolean {
+    if (!isFinal) {
+      return false
+    }
+    val type = Type.getType(descriptor)
+    return type.sort == Type.OBJECT && type.internalName == companionClass.name
+  }
+
+  private fun Method.matchesJvmStaticCompanionMember(
+    containingClassMethod: Method,
+    companionClassName: String
+  ): Boolean =
+    name == containingClassMethod.name
+      && (descriptor == containingClassMethod.descriptor
+      || descriptor == containingClassMethod.companionDefaultMethodDescriptor(companionClassName))
+
+  private fun Method.companionDefaultMethodDescriptor(companionClassName: String): String? {
+    if (!name.endsWith("\$default")) {
+      return null
+    }
+    val type = Type.getMethodType(descriptor)
+    return Type.getMethodDescriptor(type.returnType, Type.getObjectType(companionClassName), *type.argumentTypes)
+  }
 
   private fun resolveInEnclosingClassName(classFileMember: ClassFile, classResolver: Resolver, resolutionStack: ResolutionStack): MemberAnnotation? {
     val enclosingClassName = classFileMember.enclosingClassName

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageTest.kt
@@ -2,6 +2,7 @@ package com.jetbrains.pluginverifier.usages.experimental
 
 import com.jetbrains.plugin.structure.classes.resolvers.EMPTY_RESOLVER
 import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.plugin.structure.classes.resolvers.FixedClassesResolver
 import com.jetbrains.pluginverifier.usages.util.MemberAnnotation
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
 import org.junit.Assert.*
@@ -9,6 +10,7 @@ import org.junit.Test
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.InsnNode
 import org.objectweb.asm.tree.MethodNode
 
@@ -38,6 +40,62 @@ class ExperimentalApiUsageTest {
 
     assertEquals(expectedAnnotation.annotationName, annotation.annotationName)
     assertEquals(expectedAnnotation.member, annotation.member)
+  }
+
+  @Test
+  fun `Companion field is detected as experimental when companion object is annotated`() {
+    val resolver = FixedClassesResolver.create(
+      listOf(mockClassNodeWithCompanionField, mockExperimentalCompanionClassNode),
+      origin
+    )
+    val classFile = ClassFileAsm(mockClassNodeWithCompanionField, origin)
+    val companionField = classFile.fields.find { it.name == "Companion" }
+    assertNotNull(companionField)
+    companionField!!
+
+    assertTrue(companionField.isExperimentalApi(resolver))
+  }
+
+  @Test
+  fun `JvmStatic method is detected as experimental when companion object is annotated`() {
+    val resolver = FixedClassesResolver.create(
+      listOf(mockClassNodeWithJvmStaticMethod, mockExperimentalCompanionClassNode),
+      origin
+    )
+    val classFile = ClassFileAsm(mockClassNodeWithJvmStaticMethod, origin)
+    val jvmStaticMethod = classFile.methods.find { it.name == JVM_STATIC_METHOD_NAME }
+    assertNotNull(jvmStaticMethod)
+    jvmStaticMethod!!
+
+    assertTrue(jvmStaticMethod.isExperimentalApi(resolver))
+  }
+
+  @Test
+  fun `JvmStatic method is detected as experimental when companion method is annotated`() {
+    val resolver = FixedClassesResolver.create(
+      listOf(mockClassNodeWithJvmStaticMethod, mockCompanionClassNodeWithExperimentalMethod),
+      origin
+    )
+    val classFile = ClassFileAsm(mockClassNodeWithJvmStaticMethod, origin)
+    val jvmStaticMethod = classFile.methods.find { it.name == JVM_STATIC_METHOD_NAME }
+    assertNotNull(jvmStaticMethod)
+    jvmStaticMethod!!
+
+    assertTrue(jvmStaticMethod.isExperimentalApi(resolver))
+  }
+
+  @Test
+  fun `JvmStatic default method is detected as experimental when companion object is annotated`() {
+    val resolver = FixedClassesResolver.create(
+      listOf(mockClassNodeWithJvmStaticDefaultMethod, mockExperimentalCompanionClassNodeWithDefaultMethod),
+      origin
+    )
+    val classFile = ClassFileAsm(mockClassNodeWithJvmStaticDefaultMethod, origin)
+    val jvmStaticDefaultMethod = classFile.methods.find { it.name == JVM_STATIC_DEFAULT_METHOD_NAME }
+    assertNotNull(jvmStaticDefaultMethod)
+    jvmStaticDefaultMethod!!
+
+    assertTrue(jvmStaticDefaultMethod.isExperimentalApi(resolver))
   }
 
   private val mockClassNode: ClassNode
@@ -71,6 +129,95 @@ class ExperimentalApiUsageTest {
       methods.add(experimentalApiMethod)
     }
 
+  private val mockClassNodeWithCompanionField: ClassNode
+    get() = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC
+      name = HOLDER_CLASS_NAME
+      superName = "java/lang/Object"
+
+      fields.add(
+        FieldNode(
+          Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC or Opcodes.ACC_FINAL,
+          "Companion",
+          "L$COMPANION_CLASS_NAME;",
+          null,
+          null
+        )
+      )
+    }
+
+  private val mockClassNodeWithJvmStaticMethod: ClassNode
+    get() = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC
+      name = HOLDER_CLASS_NAME
+      superName = "java/lang/Object"
+
+      methods.add(staticMethod(JVM_STATIC_METHOD_NAME, "()V"))
+    }
+
+  private val mockClassNodeWithJvmStaticDefaultMethod: ClassNode
+    get() = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC
+      name = HOLDER_CLASS_NAME
+      superName = "java/lang/Object"
+
+      methods.add(staticMethod(JVM_STATIC_DEFAULT_METHOD_NAME, "(ILjava/lang/Object;)V"))
+    }
+
+  private val mockExperimentalCompanionClassNode: ClassNode
+    get() = companionClassNode(
+      annotations = listOf(AnnotationNode("L$EXPERIMENTAL_API_ANNOTATION_NAME;")),
+      methods = listOf(instanceMethod(JVM_STATIC_METHOD_NAME, "()V"))
+    )
+
+  private val mockCompanionClassNodeWithExperimentalMethod: ClassNode
+    get() = companionClassNode(
+      methods = listOf(
+        instanceMethod(
+          JVM_STATIC_METHOD_NAME,
+          "()V",
+          annotations = listOf(AnnotationNode("L$EXPERIMENTAL_API_ANNOTATION_NAME;"))
+        )
+      )
+    )
+
+  private val mockExperimentalCompanionClassNodeWithDefaultMethod: ClassNode
+    get() = companionClassNode(
+      annotations = listOf(AnnotationNode("L$EXPERIMENTAL_API_ANNOTATION_NAME;")),
+      methods = listOf(staticMethod(JVM_STATIC_DEFAULT_METHOD_NAME, "(L$COMPANION_CLASS_NAME;ILjava/lang/Object;)V"))
+    )
+
+  private fun companionClassNode(
+    annotations: List<AnnotationNode> = emptyList(),
+    methods: List<MethodNode> = emptyList()
+  ): ClassNode = ClassNode(Opcodes.ASM9).apply {
+    version = Opcodes.V1_8
+    access = Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL
+    name = COMPANION_CLASS_NAME
+    superName = "java/lang/Object"
+    outerClass = HOLDER_CLASS_NAME
+    visibleAnnotations = annotations
+    this.methods.addAll(methods)
+  }
+
+  private fun staticMethod(name: String, descriptor: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, name, descriptor, null, null).apply {
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun instanceMethod(
+    name: String,
+    descriptor: String,
+    annotations: List<AnnotationNode> = emptyList()
+  ): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL, name, descriptor, null, null).apply {
+      visibleAnnotations = annotations
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
   private val origin = object : FileOrigin {
     override val parent = null
   }
@@ -78,4 +225,7 @@ class ExperimentalApiUsageTest {
 
 private const val EXPERIMENTAL_API_METHOD_NAME = "experimentalApiMethod"
 private const val EXPERIMENTAL_API_ANNOTATION_NAME = "org/jetbrains/annotations/ApiStatus\$Experimental"
-
+private const val HOLDER_CLASS_NAME = "com/jetbrains/Holder"
+private const val COMPANION_CLASS_NAME = "$HOLDER_CLASS_NAME\$Companion"
+private const val JVM_STATIC_METHOD_NAME = "jvmStaticMethod"
+private const val JVM_STATIC_DEFAULT_METHOD_NAME = "jvmStaticMethod\$default"


### PR DESCRIPTION
The following `foo` method must be marked as `@Internal` as well.

```kotlin
interface A {
  @Internal
  companion object {
    @JvmStatic fun foo() {}
  }
}
```

This applies for any annotation on the `companion object`. For example, `@Experimental` as well.

See [IJPL-245371](https://youtrack.jetbrains.com/issue/IJPL-245371).