### PR TITLE
Merge semantics for OverrideOnly in Java final class and Kotlin object

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/NonOverridableMethodUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/NonOverridableMethodUsageFilter.kt
@@ -1,10 +1,7 @@
 package com.jetbrains.pluginverifier.usages.overrideOnly
 
-import com.jetbrains.plugin.structure.classes.utils.KtClassResolver
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
-import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
@@ -14,24 +11,16 @@ import org.objectweb.asm.tree.AbstractInsnNode
  *
  * Covers two shapes:
  *  - Static methods (JVM `ACC_STATIC`). For Kotlin this matches `@JvmStatic` accessors.
- *  - Instance methods whose declaring class is a Kotlin `object` or `companion object`.
- *    Those compile to non-static methods on a singleton holder, so the static flag alone
- *    does not catch them, but the singleton cannot be subclassed and the
- *    `@ApiStatus.OverrideOnly` annotation cannot be enforced at the call site.
+ *  - Instance methods on a `final` class (JVM `ACC_FINAL`). The class cannot be
+ *    subclassed, so callers cannot override the method and `@ApiStatus.OverrideOnly`
+ *    is unenforceable. This covers both Kotlin `object`/`companion object` (which
+ *    compile to final classes) and hand-written Java final singletons.
  */
 class NonOverridableMethodUsageFilter : ApiUsageFilter {
-  private val ktClassResolver = KtClassResolver()
-
   override fun allow(
     invokedMethod: Method,
     invocationInstruction: AbstractInsnNode,
     callerMethod: Method,
     context: VerificationContext
-  ): Boolean = invokedMethod.isStatic || invokedMethod.containingClassFile.isKotlinObject
-
-  private val ClassFile.isKotlinObject: Boolean
-    get() {
-      val asmNode = (this as? ClassFileAsm)?.asmNode ?: return false
-      return ktClassResolver[asmNode]?.isObject == true
-    }
+  ): Boolean = invokedMethod.isStatic || invokedMethod.containingClassFile.isFinal
 }

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/overrideOnly/OverrideOnlyJavaSingleton.java
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/java/overrideOnly/OverrideOnlyJavaSingleton.java
@@ -1,0 +1,20 @@
+package overrideOnly;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Java equivalent of a Kotlin `object`: a {@code final} singleton exposed through a
+ * static {@code INSTANCE} field. The class cannot be subclassed, so callers cannot
+ * override {@link #overrideOnlyMethod()} and the {@code @OverrideOnly} annotation is
+ * just as unenforceable as it is on a Kotlin object. Callers must not be flagged.
+ */
+public final class OverrideOnlyJavaSingleton {
+  public static final OverrideOnlyJavaSingleton INSTANCE = new OverrideOnlyJavaSingleton();
+
+  private OverrideOnlyJavaSingleton() {
+  }
+
+  @ApiStatus.OverrideOnly
+  public void overrideOnlyMethod() {
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/overrideOnly/OverrideOnlyJavaSingleton.java
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/java/overrideOnly/OverrideOnlyJavaSingleton.java
@@ -1,0 +1,20 @@
+package overrideOnly;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Java equivalent of a Kotlin `object`: a {@code final} singleton exposed through a
+ * static {@code INSTANCE} field. The class cannot be subclassed, so callers cannot
+ * override {@link #overrideOnlyMethod()} and the {@code @OverrideOnly} annotation is
+ * just as unenforceable as it is on a Kotlin object. Callers must not be flagged.
+ */
+public final class OverrideOnlyJavaSingleton {
+  public static final OverrideOnlyJavaSingleton INSTANCE = new OverrideOnlyJavaSingleton();
+
+  private OverrideOnlyJavaSingleton() {
+  }
+
+  @ApiStatus.OverrideOnly
+  public void overrideOnlyMethod() {
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/OverrideOnlyMethodUsages.java
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/java/mock/plugin/overrideOnly/OverrideOnlyMethodUsages.java
@@ -1,6 +1,7 @@
 package mock.plugin.overrideOnly;
 
 import overrideOnly.AllOverrideOnlyMethodsOwner;
+import overrideOnly.OverrideOnlyJavaSingleton;
 import overrideOnly.OverrideOnlyKotlinCompanionHolder;
 import overrideOnly.OverrideOnlyKotlinInterfaceWithCompanion;
 import overrideOnly.OverrideOnlyKotlinObject;
@@ -33,6 +34,11 @@ public class OverrideOnlyMethodUsages {
     // callers, so @OverrideOnly is unenforceable and these calls must not be flagged.
     OverrideOnlyKotlinObject.INSTANCE.overrideOnlyMethod();
     OverrideOnlyKotlinCompanionHolder.Companion.overrideOnlyMethod();
+
+    // A hand-written Java singleton has the same shape as a Kotlin `object`: a final
+    // class reached through a static INSTANCE field, so the method cannot be overridden
+    // by callers and @OverrideOnly is unenforceable. This call must not be flagged.
+    OverrideOnlyJavaSingleton.INSTANCE.overrideOnlyMethod();
 
     // Real-world case: an @OverrideOnly interface with a companion-object factory.
     // The factory call must not be flagged even though the interface carries the


### PR DESCRIPTION
Follow up of #1489 

isStatic works in both languages' case, but isKotlinObject can be handled with a simple check for java final classes (that kotlin objects compile to, and they also can't be subclasses). So we can make it a bit more generic.