### PR TITLE
Introduce limit on the FsHandler unwrapping attempts

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/fs/FsHandlerFileSystemProvider.kt
@@ -23,6 +23,8 @@ import java.nio.file.attribute.FileAttribute
 import java.nio.file.attribute.FileAttributeView
 import java.nio.file.spi.FileSystemProvider
 
+private const val MAX_REOPEN_ATTEMPTS = 3
+
 class FsHandlerFileSystemProvider(
   val delegateProvider: FileSystemProvider,
   private val delegateJarFileSystemProvider: JarFileSystemProvider
@@ -131,15 +133,21 @@ class FsHandlerFileSystemProvider(
 
   private fun FsHandlerPath.reopen() = fileSystem.getPath(delegatePath.toString())
 
+  // Bounds reopen retries so an evicted FsHandleFileSystem (referenceCount < 0,
+  // can no longer reopen) surfaces as ClosedFileSystemException instead of StackOverflowError.
   private val Path.unwrapped: Path
-    get() = if (this is FsHandlerPath) {
-      if (delegatePath.fileSystem.isClosed) {
-        reopen().unwrapped
-      } else {
-        delegatePath
+    get() {
+      if (this !is FsHandlerPath) return this
+      var current: FsHandlerPath = this
+      repeat(MAX_REOPEN_ATTEMPTS) {
+        if (!current.delegatePath.fileSystem.isClosed) {
+          return current.delegatePath
+        }
+        val reopened = current.reopen()
+        if (reopened !is FsHandlerPath) return reopened
+        current = reopened
       }
-    } else {
-      this
+      throw ClosedFileSystemException()
     }
 
   // Handles the race where the delegate FS is closed between `unwrapped`'s isClosed check and the NIO call.

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -16,7 +16,9 @@ import org.slf4j.LoggerFactory
 import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 
 private val LOG: Logger = LoggerFactory.getLogger(CachingJarFileSystemProvider::class.java)
@@ -33,6 +35,8 @@ class CachingJarFileSystemProvider(
 
   private val delegateJarFileSystemProvider = UriJarFileSystemProvider { it.toUri().withSuperScheme(JAR_SCHEME) }
 
+  private val delegateRefCounts = ConcurrentHashMap<String, AtomicInteger>()
+
   private val fsCache = Caffeine.newBuilder()
     .maximumSize(MAX_OPEN_JAR_FILE_SYSTEMS)
     .expireAfterAccess(retentionTimeInSeconds, TimeUnit.SECONDS)
@@ -46,10 +50,31 @@ class CachingJarFileSystemProvider(
   val eventLog = EventLog()
 
   private fun createFileSystem(jarPath: Path, jarUri: URI): FsHandleFileSystem {
+    val key = jarUri.toString()
     val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
       LOG.debug("Creating a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.estimatedSize())
     }
-    return FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath)
+    delegateRefCounts.computeIfAbsent(key) { AtomicInteger(0) }.incrementAndGet()
+    return FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath) { delegate ->
+      releaseDelegate(key, delegate)
+    }
+  }
+
+  private fun releaseDelegate(key: String, delegate: FileSystem) {
+    synchronized(key.intern()) {
+      val count = delegateRefCounts[key]
+      if (count != null && count.decrementAndGet() == 0) {
+        delegateRefCounts.remove(key)
+        try {
+          if (delegate.isOpen) delegate.close()
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          LOG.info("Cannot close delegate due to an interruption for [{}]", delegate)
+        } catch (e: Exception) {
+          LOG.error("Unable to close delegate [{}]", delegate, e)
+        }
+      }
+    }
   }
 
   override fun getFileSystem(jarPath: Path): FileSystem {
@@ -73,7 +98,10 @@ class CachingJarFileSystemProvider(
           val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
             LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
           }
-          fs = FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath)
+          delegateRefCounts.computeIfAbsent(key) { AtomicInteger(0) }.incrementAndGet()
+          fs = FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath) { delegate ->
+            releaseDelegate(key, delegate)
+          }
           fsCache.put(key, fs)
           logRecreatedFs(key)
         }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -36,7 +36,8 @@ private val LOG: Logger = LoggerFactory.getLogger(FsHandleFileSystem::class.java
 class FsHandleFileSystem(
   val initialDelegateFileSystem: FileSystem,
   private val provider: JarFileSystemProvider,
-  private val path: Path
+  private val path: Path,
+  private val onDelegateRelease: ((FileSystem) -> Unit)? = null
 ) : FileSystem() {
 
   // 0 for cached but idle, '-1' for removed from cache and permanently closed
@@ -127,6 +128,10 @@ class FsHandleFileSystem(
 
   fun closeDelegate() {
     val fs = synchronized(this) { _delegateFileSystem }
+    if (onDelegateRelease != null) {
+      onDelegateRelease.invoke(fs)
+      return
+    }
     try {
       if (fs.isOpen) fs.close()
     } catch (_: InterruptedException) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModule.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModule.kt
@@ -2,4 +2,4 @@ package com.jetbrains.plugin.structure.intellij.plugin.module
 
 import java.nio.file.Path
 
-data class ContentModule(val id: String, val artifactPath: Path, val descriptorPath: Path)
+data class ContentModule(val id: String, val artifactPath: Path)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -51,7 +51,7 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
     } else {
       descriptorPath.getModuleName()
     }
-    return ContentModule(moduleName, jarPath, descriptorPath)
+    return ContentModule(moduleName, jarPath)
   }
 
   private inline fun <T> withPluginJar(jarPath: Path, action: (PluginJar) -> T): T? {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -264,6 +264,32 @@ class CachingJarFileSystemProviderTest {
     assertTrue(Files.isRegularFile(hello))
   }
 
+  // Regression: MP-8146. The JVM caches ZipFileSystems globally, so two FsHandleFileSystem
+  // wrappers created for the same JAR at different times share the same underlying Z ZipFileSystem.
+  // A Z-level ref-count must gate Z.close() so that Z stays open until every wrapper
+  // that holds it has been evicted.
+  @Test
+  fun `shared delegate Z stays open until the last wrapper is evicted`() {
+    val provider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+
+    // h1 and h2 are distinct wrapper instances that share the same underlying ZipFileSystem Z.
+    val h1 = provider.getFileSystem(jarPath) as FsHandleFileSystem
+    val z = h1.initialDelegateFileSystem
+
+    // Close h1's client reference so referenceCount drops to 0 (idle in cache).
+    h1.close()
+    assertFalse(h1.isOpen)
+    // Z must still be open — it is still tracked by the Z-level ref-count.
+    assertTrue("Z must not close while h1 is still registered in the cache", z.isOpen)
+
+    // Simulate Caffeine evicting h1. This fires onCacheRemoval → closeDelegate → releaseDelegate.
+    // Z has no other holders, so it should now close.
+    h1.onCacheRemoval()
+    assertFalse("Z must close after the last wrapper is evicted", z.isOpen)
+
+    provider.close()
+  }
+
   // Regression: MP-7468. Targets the TOCTOU window in `unwrapped` — the FS is open at the
   // isClosed() check but closes (from another thread / Caffeine eviction) before the NIO
   // call lands. The stub simulates exactly that race by throwing ClosedFileSystemException

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -220,6 +220,26 @@ class CachingJarFileSystemProviderTest {
     assertTrue(anotherFs2.hasSameDelegate(yetAnotherFs2))
   }
 
+  @Test
+  fun `path used after cache eviction surfaces as ClosedFileSystemException, not StackOverflowError`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+    val fs = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val helloTxtPath: Path = fs.getPath("hello.txt")
+
+    // Simulate Caffeine evicting the handle while a Path to it is still held: this drops
+    // referenceCount to -1, after which getOrReopenDelegateFileSystem refuses to reopen.
+    fs.close()
+    fs.onCacheRemoval()
+    assertTrue(fs.isClosed)
+
+    try {
+      Files.readAttributes(helloTxtPath, BasicFileAttributes::class.java)
+      fail("Expected ClosedFileSystemException")
+    } catch (_: ClosedFileSystemException) {
+      // expected — before the depth bound this looped in `unwrapped` until StackOverflowError.
+    }
+  }
+
   private fun FileSystem.hasSameDelegate(fs: FileSystem): Boolean {
     return (this as? FsHandleFileSystem)?.hasSameDelegate(fs) == true
   }


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/MP-8146/StackOverflowError-on-FsHandlerFileSystemProvider.getUnwrapped-in-plugin-verifier

As the comment on the ticket says, first I had a "quick fix" for the issue (bounding recursion), but given that this is due to a race condition this unfortunately resulted in a lot of failures (~50% of runs) even when increasing the bound. So I spent some more time fixing the underlying problem:

`UriJarFileSystemProvider.getFileSystem()` calls into the JVM's `FileSystems.newFileSystem` / existing FS lookup. The JVM `ZipFileSystem` is globally cached by URI inside the JDK — so calling getFileSystem() for the same JAR multiple times returns the exact same Z object, while the assumption was that these are independent objects that can be closed independently. Added ref counting to these as well to track their usage.