### PR TITLE
Improve Filesystem handle delegate race corner-cases

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -116,26 +116,54 @@ class CachingJarFileSystemProvider(
     val jarUri = jarPath.toJarFileUri()
     val key = jarUri.toString()
 
-    synchronized(key.intern()) {
-      var fs = fsCache.getIfPresent(key)
-      if (fs != null) {
-        if (fs.increment(expectedClients)) {
-          logReusedFs(key)
-        } else {
+    // Retry because increment() must run outside the per-key lock: while it is running,
+    // Caffeine may evict the cached handle or another thread may replace it. In that case
+    // undo the acquired references, re-read the cache, and try again against the current entry.
+    while (true) {
+      val cachedFs = synchronized(key.intern()) {
+        fsCache.getIfPresent(key)
+      }
+
+      if (cachedFs != null) {
+        // increment() may reopen the delegate and call back into replaceDelegate(), which also
+        // takes the per-key lock. Keep it outside that lock to avoid key -> fs / fs -> key inversion.
+        if (cachedFs.increment(expectedClients)) {
+          synchronized(key.intern()) {
+            if (fsCache.getIfPresent(key) === cachedFs) {
+              logReusedFs(key)
+              return cachedFs
+            }
+          }
+          repeat(expectedClients) {
+            cachedFs.close()
+          }
+          continue
+        }
+      }
+
+      val resolvedFs = synchronized(key.intern()) {
+        val currentFs = fsCache.getIfPresent(key)
+        if (currentFs !== cachedFs) {
+          null
+        } else if (currentFs != null) {
           val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
             LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
           }
           retainDelegate(jarFs)
-          fs = fsHandleFileSystem(key, jarFs, jarPath)
+          val fs = fsHandleFileSystem(key, jarFs, jarPath)
           fsCache.put(key, fs)
           logRecreatedFs(key)
+          fs
+        } else {
+          val fs = createFileSystem(jarPath, jarUri)
+          fsCache.put(key, fs)
+          logCreatedFs(key)
+          fs
         }
-      } else {
-        fs = createFileSystem(jarPath, jarUri)
-        fsCache.put(key, fs)
-        logCreatedFs(key)
       }
-      return fs
+      if (resolvedFs != null) {
+        return resolvedFs
+      }
     }
   }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -150,9 +150,7 @@ class CachingJarFileSystemProvider(
         if (currentFs !== cachedFs) {
           null
         } else if (currentFs != null) {
-          val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
-            LOG.debug("Recreating an already closed filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
-          }
+          val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath)
           retainDelegate(jarFs)
           val fs = fsHandleFileSystem(key, jarFs, jarPath)
           fsCache.put(key, fs)
@@ -202,6 +200,7 @@ class CachingJarFileSystemProvider(
   }
 
   private fun logRecreatedFs(uriString: String) {
+    LOG.debug("Recreating an already closed filesystem handler for <{}> (Cache size: {})", uriString, fsCache.estimatedSize())
     if (enableEventLogging) eventLog.logRecreated(uriString)
   }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -35,7 +35,7 @@ class CachingJarFileSystemProvider(
 
   private val delegateJarFileSystemProvider = UriJarFileSystemProvider { it.toUri().withSuperScheme(JAR_SCHEME) }
 
-  private val delegateRefCounts = ConcurrentHashMap<String, AtomicInteger>()
+  private val delegateRefCounts = ConcurrentHashMap<DelegateFileSystemKey, AtomicInteger>()
 
   private val fsCache = Caffeine.newBuilder()
     .maximumSize(MAX_OPEN_JAR_FILE_SYSTEMS)
@@ -54,27 +54,54 @@ class CachingJarFileSystemProvider(
     val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
       LOG.debug("Creating a filesystem handler via delegate for <{}> (Cache size: {})", jarUri, fsCache.estimatedSize())
     }
-    delegateRefCounts.computeIfAbsent(key) { AtomicInteger(0) }.incrementAndGet()
-    return FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath) { delegate ->
-      releaseDelegate(key, delegate)
-    }
+    retainDelegate(jarFs)
+    return fsHandleFileSystem(key, jarFs, jarPath)
   }
 
   private fun releaseDelegate(key: String, delegate: FileSystem) {
     synchronized(key.intern()) {
-      val count = delegateRefCounts[key]
-      if (count != null && count.decrementAndGet() == 0) {
-        delegateRefCounts.remove(key)
-        try {
-          if (delegate.isOpen) delegate.close()
-        } catch (_: InterruptedException) {
-          Thread.currentThread().interrupt()
-          LOG.info("Cannot close delegate due to an interruption for [{}]", delegate)
-        } catch (e: Exception) {
-          LOG.error("Unable to close delegate [{}]", delegate, e)
-        }
+      releaseDelegate(delegate)
+    }
+  }
+
+  private fun replaceDelegate(key: String, oldDelegate: FileSystem, newDelegate: FileSystem) {
+    if (oldDelegate === newDelegate) {
+      return
+    }
+    synchronized(key.intern()) {
+      retainDelegate(newDelegate)
+      releaseDelegate(oldDelegate)
+    }
+  }
+
+  private fun retainDelegate(delegate: FileSystem) {
+    delegateRefCounts.computeIfAbsent(DelegateFileSystemKey(delegate)) { AtomicInteger(0) }.incrementAndGet()
+  }
+
+  private fun releaseDelegate(delegate: FileSystem) {
+    val delegateKey = DelegateFileSystemKey(delegate)
+    val count = delegateRefCounts[delegateKey]
+    if (count != null && count.decrementAndGet() == 0) {
+      delegateRefCounts.remove(delegateKey)
+      try {
+        if (delegate.isOpen) delegate.close()
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        LOG.info("Cannot close delegate due to an interruption for [{}]", delegate)
+      } catch (e: Exception) {
+        LOG.error("Unable to close delegate [{}]", delegate, e)
       }
     }
+  }
+
+  private fun fsHandleFileSystem(key: String, delegate: FileSystem, jarPath: Path): FsHandleFileSystem {
+    return FsHandleFileSystem(
+      delegate,
+      delegateJarFileSystemProvider,
+      jarPath,
+      onDelegateRelease = { releasedDelegate -> releaseDelegate(key, releasedDelegate) },
+      onDelegateReplace = { oldDelegate, newDelegate -> replaceDelegate(key, oldDelegate, newDelegate) }
+    )
   }
 
   override fun getFileSystem(jarPath: Path): FileSystem {
@@ -98,10 +125,8 @@ class CachingJarFileSystemProvider(
           val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
             LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
           }
-          delegateRefCounts.computeIfAbsent(key) { AtomicInteger(0) }.incrementAndGet()
-          fs = FsHandleFileSystem(jarFs, delegateJarFileSystemProvider, jarPath) { delegate ->
-            releaseDelegate(key, delegate)
-          }
+          retainDelegate(jarFs)
+          fs = fsHandleFileSystem(key, jarFs, jarPath)
           fsCache.put(key, fs)
           logRecreatedFs(key)
         }
@@ -158,5 +183,13 @@ class CachingJarFileSystemProvider(
       data class Reused(val key: String) : Event()
       data class Recreated(val key: String) : Event()
     }
+  }
+
+  private class DelegateFileSystemKey(private val delegate: FileSystem) {
+    override fun equals(other: Any?): Boolean {
+      return other is DelegateFileSystemKey && delegate === other.delegate
+    }
+
+    override fun hashCode(): Int = System.identityHashCode(delegate)
   }
 }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 private val LOG: Logger = LoggerFactory.getLogger(CachingJarFileSystemProvider::class.java)
 
 private const val MAX_OPEN_JAR_FILE_SYSTEMS: Long = 256
+private const val MAX_GET_FILE_SYSTEM_RETRIES = 1_024
 
 const val RETENTION_TIME_PROPERTY_NAME = "com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider.retentionTime"
 
@@ -119,7 +120,10 @@ class CachingJarFileSystemProvider(
     // Retry because increment() must run outside the per-key lock: while it is running,
     // Caffeine may evict the cached handle or another thread may replace it. In that case
     // undo the acquired references, re-read the cache, and try again against the current entry.
-    while (true) {
+    var retryAttempts = 0
+    while (retryAttempts < MAX_GET_FILE_SYSTEM_RETRIES) {
+      retryAttempts++
+
       val cachedFs = synchronized(key.intern()) {
         fsCache.getIfPresent(key)
       }
@@ -164,6 +168,21 @@ class CachingJarFileSystemProvider(
       if (resolvedFs != null) {
         return resolvedFs
       }
+    }
+
+    throw newRetryAttemptsExhausted(key.intern(), jarPath)
+  }
+
+  private fun newRetryAttemptsExhausted(jarUriKey: String, jarPath: Path): JarArchiveException {
+    val cacheSize = fsCache.estimatedSize()
+    val message = "Unable to resolve cached JAR filesystem for [$jarPath] (resolved URI: <$jarUriKey>) " +
+      "after $MAX_GET_FILE_SYSTEM_RETRIES attempts (Cache size: $cacheSize). " +
+      "Aborting to avoid a possible live lock."
+    return JarArchiveException(message).also { ex ->
+      LOG.error(
+        message,
+        ex
+      )
     }
   }
 

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProvider.kt
@@ -147,7 +147,7 @@ class CachingJarFileSystemProvider(
           null
         } else if (currentFs != null) {
           val jarFs = delegateJarFileSystemProvider.getFileSystem(jarPath).also {
-            LOG.debug("Recreating an already closed a filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
+            LOG.debug("Recreating an already closed filesystem handler for <{}> (Cache size: {})", key, fsCache.estimatedSize())
           }
           retainDelegate(jarFs)
           val fs = fsHandleFileSystem(key, jarFs, jarPath)

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/jar/FsHandleFileSystem.kt
@@ -37,7 +37,8 @@ class FsHandleFileSystem(
   val initialDelegateFileSystem: FileSystem,
   private val provider: JarFileSystemProvider,
   private val path: Path,
-  private val onDelegateRelease: ((FileSystem) -> Unit)? = null
+  private val onDelegateRelease: ((FileSystem) -> Unit)? = null,
+  private val onDelegateReplace: ((FileSystem, FileSystem) -> Unit)? = null
 ) : FileSystem() {
 
   // 0 for cached but idle, '-1' for removed from cache and permanently closed
@@ -89,9 +90,11 @@ class FsHandleFileSystem(
         return fs
       }
       LOG.debug("Reopening filesystem delegate for <{}>", path)
-      fs = provider.getFileSystem(path)
-      _delegateFileSystem = fs
-      return fs
+      val oldFs = fs
+      val reopenedFs = provider.getFileSystem(path)
+      onDelegateReplace?.invoke(oldFs, reopenedFs)
+      _delegateFileSystem = reopenedFs
+      return reopenedFs
     }
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -270,13 +270,12 @@ class CachingJarFileSystemProviderTest {
     fs.close()
     assertFalse(fs.isOpen)
     // Raw javaNioFs must still be open — it is still tracked by the javaNioFs-level ref-count.
-    assertTrue("raw java.nio.file.Filesystem must not close while its wrapper is still registered in the cache", javaNioFs.isOpen)
+    assertTrue("raw java.nio.file.FileSystem must not close while its wrapper is still registered in the cache", javaNioFs.isOpen)
 
     // Simulate Caffeine evicting 'fs' instance. This fires onCacheRemoval → closeDelegate → releaseDelegate.
     // raw javaNioFs has no other holders, so it should now close.
     fs.onCacheRemoval()
-    assertFalse("raw java.nio.file.Filesystem must close after the last wrapper is evicted", javaNioFs.isOpen)
-
+    assertFalse("raw java.nio.file.FileSystem must close after the last wrapper is evicted", javaNioFs.isOpen)
     fileSystemProvider.close()
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -318,6 +318,46 @@ class CachingJarFileSystemProviderTest {
     fileSystemProvider.close()
   }
 
+  /**
+   * Regression coverage for a wrapper that reopens its raw ZipFileSystem while another
+   * wrapper for the same JAR still points to the old, externally closed raw filesystem.
+   *
+   * The cache must release the reopened raw filesystem instance, not only decrement a
+   * URI-level counter attached to whichever stale delegate happens to be closed last.
+   */
+  @Test
+  fun `reopened delegate is closed when its wrapper is evicted before stale wrapper`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+
+    val fs1 = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val rawFs1 = fs1.initialDelegateFileSystem
+
+    // Keep fs1 active but remove it from the cache, then create fs2. Both wrappers now
+    // share rawFs1, while fs1 will be closed independently from the cached fs2.
+    fileSystemProvider.evictCachedHandle(jarPath)
+    fs1.onCacheRemoval()
+    val fs2 = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    assertNotSame(fs1, fs2)
+    assertSame(rawFs1, fs2.initialDelegateFileSystem)
+
+    // Simulate rawFs1 being closed externally. Using fs1 forces it to reopen and swap
+    // its delegate to rawFs2, while fs2 still points to the stale rawFs1 instance.
+    rawFs1.close()
+    val rawFs2 = fs1.delegateFileSystem
+    assertNotSame(rawFs1, rawFs2)
+    assertTrue(rawFs2.isOpen)
+
+    // Close the reopened wrapper first. This used to decrement only the URI-level count,
+    // leaving rawFs2 open until a stale wrapper released rawFs1.
+    fs1.close()
+    assertFalse("Reopened raw filesystem rawFs2 must close with fs1 eviction", rawFs2.isOpen)
+
+    fs2.close()
+    fs2.onCacheRemoval()
+
+    fileSystemProvider.close()
+  }
+
   @Suppress("UNCHECKED_CAST")
   private fun CachingJarFileSystemProvider.evictCachedHandle(jarPath: Path) {
     val fsCacheField = CachingJarFileSystemProvider::class.java.getDeclaredField("fsCache")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -270,12 +270,12 @@ class CachingJarFileSystemProviderTest {
     fs.close()
     assertFalse(fs.isOpen)
     // Raw javaNioFs must still be open — it is still tracked by the javaNioFs-level ref-count.
-    assertTrue("raw java.nio.Filesystem must not close while its wrapper is still registered in the cache", javaNioFs.isOpen)
+    assertTrue("raw java.nio.file.Filesystem must not close while its wrapper is still registered in the cache", javaNioFs.isOpen)
 
     // Simulate Caffeine evicting 'fs' instance. This fires onCacheRemoval → closeDelegate → releaseDelegate.
     // raw javaNioFs has no other holders, so it should now close.
     fs.onCacheRemoval()
-    assertFalse("raw java.nio.Filesystem must close after the last wrapper is evicted", javaNioFs.isOpen)
+    assertFalse("raw java.nio.file.Filesystem must close after the last wrapper is evicted", javaNioFs.isOpen)
 
     fileSystemProvider.close()
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -4,6 +4,7 @@
 
 package com.jetbrains.plugin.structure.jar
 
+import com.github.benmanes.caffeine.cache.Cache
 import com.jetbrains.plugin.structure.base.fs.isClosed
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.isFile
@@ -18,17 +19,7 @@ import org.junit.rules.TemporaryFolder
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.channels.SeekableByteChannel
-import java.nio.file.AccessMode
-import java.nio.file.ClosedFileSystemException
-import java.nio.file.CopyOption
-import java.nio.file.DirectoryStream
-import java.nio.file.FileStore
-import java.nio.file.FileSystem
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.LinkOption
-import java.nio.file.OpenOption
-import java.nio.file.Path
+import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileAttribute
 import java.nio.file.attribute.FileAttributeView
@@ -265,29 +256,75 @@ class CachingJarFileSystemProviderTest {
   }
 
   // Regression: MP-8146. The JVM caches ZipFileSystems globally, so two FsHandleFileSystem
-  // wrappers created for the same JAR at different times share the same underlying Z ZipFileSystem.
-  // A Z-level ref-count must gate Z.close() so that Z stays open until every wrapper
+  // wrappers created for the same JAR at different times share the same underlying javaNioFs ZipFileSystem.
+  // A javaNioFs-level ref-count must gate javaNioFs.close() so that javaNioFs stays open until every wrapper
   // that holds it has been evicted.
   @Test
-  fun `shared delegate Z stays open until the last wrapper is evicted`() {
-    val provider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+  fun `raw delegate javaNioFs stays open until its wrapper is evicted`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
 
-    // h1 and h2 are distinct wrapper instances that share the same underlying ZipFileSystem Z.
-    val h1 = provider.getFileSystem(jarPath) as FsHandleFileSystem
-    val z = h1.initialDelegateFileSystem
+    val fs = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val javaNioFs = fs.initialDelegateFileSystem
 
-    // Close h1's client reference so referenceCount drops to 0 (idle in cache).
-    h1.close()
-    assertFalse(h1.isOpen)
-    // Z must still be open — it is still tracked by the Z-level ref-count.
-    assertTrue("Z must not close while h1 is still registered in the cache", z.isOpen)
+    // Close fs's client reference so referenceCount drops to 0 (idle in cache).
+    fs.close()
+    assertFalse(fs.isOpen)
+    // Raw javaNioFs must still be open — it is still tracked by the javaNioFs-level ref-count.
+    assertTrue("raw java.nio.Filesystem must not close while its wrapper is still registered in the cache", javaNioFs.isOpen)
 
-    // Simulate Caffeine evicting h1. This fires onCacheRemoval → closeDelegate → releaseDelegate.
-    // Z has no other holders, so it should now close.
-    h1.onCacheRemoval()
-    assertFalse("Z must close after the last wrapper is evicted", z.isOpen)
+    // Simulate Caffeine evicting 'fs' instance. This fires onCacheRemoval → closeDelegate → releaseDelegate.
+    // raw javaNioFs has no other holders, so it should now close.
+    fs.onCacheRemoval()
+    assertFalse("raw java.nio.Filesystem must close after the last wrapper is evicted", javaNioFs.isOpen)
 
-    provider.close()
+    fileSystemProvider.close()
+  }
+
+  /**
+   * Regression coverage for the actual MP-8146 shape:
+   * one cached wrapper is evicted while it is still in use, and the next lookup creates
+   * a second wrapper around the same JVM-cached ZipFileSystem delegate.
+   */
+  @Test
+  fun `shared delegate Z stays open while one of multiple wrappers still holds it`() {
+    val fileSystemProvider = CachingJarFileSystemProvider(retentionTimeInSeconds = Long.MAX_VALUE)
+
+    val fs1 = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    val rawFs = fs1.initialDelegateFileSystem
+
+    // Evict the cache entry without closing fs1. This mirrors Caffeine removing an entry
+    // while a client still owns a reference, so fs1 is removed but remains usable.
+    fileSystemProvider.evictCachedHandle(jarPath)
+    fs1.onCacheRemoval()
+
+    // The JVM-level ZipFileSystem cache returns the same delegate 'rawFs' for the replacement
+    // wrapper. This is the case that needs delegate-level reference counting.
+    val fs2 = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
+    assertNotSame("fs1 and fs2 must be distinct wrapper instances", fs1, fs2)
+    assertSame("fs1 and fs2 must share the same underlying raw filesystem rawFs", rawFs, fs2.initialDelegateFileSystem)
+
+    fs1.close()
+    assertTrue("Raw filesystem rawFs must stay open while fs2 still holds it", rawFs.isOpen)
+    assertTrue(fs2.isOpen)
+
+    // Closing fs2 drops its client reference to zero, but the wrapper is still cached,
+    // so rawFs must remain open until fs2 is removed from the cache as well.
+    fs2.close()
+    assertTrue("Raw filesystem rawFs must stay open while fs2 is idle but still cached", rawFs.isOpen)
+
+    fs2.onCacheRemoval()
+    assertFalse("Raw filesystem rawFs must close after the last wrapper is evicted", rawFs.isOpen)
+
+    fileSystemProvider.close()
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun CachingJarFileSystemProvider.evictCachedHandle(jarPath: Path) {
+    val fsCacheField = CachingJarFileSystemProvider::class.java.getDeclaredField("fsCache")
+    fsCacheField.isAccessible = true
+    val fsCache = fsCacheField.get(this) as Cache<String, FsHandleFileSystem>
+    fsCache.invalidate(jarPath.toJarFileUri().toString())
+    fsCache.cleanUp()
   }
 
   // Regression: MP-7468. Targets the TOCTOU window in `unwrapped` — the FS is open at the

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/jar/CachingJarFileSystemProviderTest.kt
@@ -295,7 +295,6 @@ class CachingJarFileSystemProviderTest {
     // Evict the cache entry without closing fs1. This mirrors Caffeine removing an entry
     // while a client still owns a reference, so fs1 is removed but remains usable.
     fileSystemProvider.evictCachedHandle(jarPath)
-    fs1.onCacheRemoval()
 
     // The JVM-level ZipFileSystem cache returns the same delegate 'rawFs' for the replacement
     // wrapper. This is the case that needs delegate-level reference counting.
@@ -335,7 +334,6 @@ class CachingJarFileSystemProviderTest {
     // Keep fs1 active but remove it from the cache, then create fs2. Both wrappers now
     // share rawFs1, while fs1 will be closed independently from the cached fs2.
     fileSystemProvider.evictCachedHandle(jarPath)
-    fs1.onCacheRemoval()
     val fs2 = fileSystemProvider.getFileSystem(jarPath) as FsHandleFileSystem
     assertNotSame(fs1, fs2)
     assertSame(rawFs1, fs2.initialDelegateFileSystem)


### PR DESCRIPTION
Make delegate accounting track the actual delegate object, not just the JAR key, and notify the cache provider when `FsHandleFileSystem` swaps delegates during reopen.

The problem is this sequence:

1. `fsOne` and `fsTwo` both wrap the same delegate `D`; cache ref count is 2.
2. `D` is closed underneath them.
3. `fsOne` is used again, so it reopens and now points to `D2`.
4. The cache-level ref count still says 2, but it no longer knows that `fsOne` holds `D2` and `fsTwo` still holds stale `D`.
5. If `fsOne` is evicted first, it decrements the count to 1 and does not close `D2`.
6. If `fsTwo` is evicted second, it decrements to 0 against stale `D`, which is already closed, so `D2` can be left open.

The issue is that one wrapper migrates to a reopened delegate while another wrapper still references the old closed delegate.