### PR TITLE
Simplify not-found message in LastCompatibleVersionSelector

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/LastCompatibleVersionSelector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/LastCompatibleVersionSelector.kt
@@ -17,11 +17,7 @@ class LastCompatibleVersionSelector(val ideVersion: IdeVersion) : PluginVersionS
     if (pluginInfo != null) {
       return PluginVersionSelector.Result.Selected(pluginInfo)
     }
-    val allVersions = pluginRepository.getAllVersionsOfPlugin(pluginId)
-    if (allVersions.isEmpty()) {
-      return PluginVersionSelector.Result.NotFound("Plugin $pluginId is not available in ${pluginRepository.presentableName}")
-    }
-    return PluginVersionSelector.Result.NotFound("Plugin $pluginId doesn't have a build compatible with $ideVersion in ${pluginRepository.presentableName}")
+    return PluginVersionSelector.Result.NotFound("Plugin $pluginId is not available or doesn't have a build compatible with $ideVersion in ${pluginRepository.presentableName}")
   }
 
   override fun selectPluginByModuleId(moduleId: String, pluginRepository: PluginRepository): PluginVersionSelector.Result {


### PR DESCRIPTION
`LastCompatibleVersionSelector` was calling `getAllVersionsOfPlugin` solely to choose between two NotFound message variants. For certain plugins this triggers a full Marketplace version-list fetch (e.g. 5 320 versions for AI Assistant, 3 930 for Scala), adding minutes to verification of plugins with many optional dependencies. The two messages are merged into one, eliminating the call  entirely.