### PR TITLE
Multiple dependencies blocks in the plugin.xml

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/PluginBean.java
@@ -4,10 +4,10 @@
 
 package com.jetbrains.plugin.structure.intellij.beans;
 
-import org.jdom2.Element;
-
 import jakarta.xml.bind.annotation.*;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import org.jdom2.Element;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +27,7 @@ public class PluginBean {
   @XmlElement(name = "product-descriptor") public ProductDescriptorBean productDescriptor;
   @XmlElement(name = "is-internal") public boolean isInternal = true;
   @XmlElement(name = "depends") public List<PluginDependencyBean> dependencies = new ArrayList<>();
-  @XmlElement(name = "dependencies") public PluginDependenciesBean dependenciesV2;
+  @XmlElement(name = "dependencies") public List<PluginDependenciesBean> dependenciesV2;
   @XmlElement(name = "content") public List<PluginContentBean> pluginContent = new ArrayList<>();
   @XmlElement(name = "incompatible-with") public List<String> incompatibleWith = new ArrayList<>();
   @XmlElement(name = "helpset") public List<PluginHelpSetBean> helpSets = new ArrayList<>();

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeans.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeans.kt
@@ -4,7 +4,6 @@ import com.jetbrains.plugin.structure.intellij.beans.ContentModuleDependencyBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginDependenciesPluginBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginDependencyBean
-import com.jetbrains.plugin.structure.intellij.beans.PluginModuleBean
 
 internal const val INTELLIJ_MODULE_PREFIX = "com.intellij.modules."
 
@@ -14,10 +13,10 @@ internal val PluginBean.dependenciesV1: List<PluginDependencyBean>
     ?: emptyList()
 
 internal val PluginBean.contentModuleDependencies: List<ContentModuleDependencyBean>
-  get() = dependenciesV2?.modules?.filter { it.moduleName != null } ?: emptyList()
+  get() = dependenciesV2?.flatMap { it.modules }?.filter { it.moduleName != null } ?: emptyList()
 
 internal val PluginBean.pluginMainModuleDependencies: List<PluginDependenciesPluginBean>
-  get() = dependenciesV2?.plugins?.filter { it.dependencyId != null } ?: emptyList()
+  get() = dependenciesV2?.flatMap { it.plugins }?.filter { it.dependencyId != null } ?: emptyList()
 
 internal val PluginDependencyBean.isOptional: Boolean
    get() = optional ?: false

--- a/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginCreatorTest.kt
+++ b/intellij-plugin-structure/structure-intellij/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/PluginCreatorTest.kt
@@ -5,11 +5,7 @@ import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.ReclassifiedPluginProblem
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.DescriptorResource
-import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
-import com.jetbrains.plugin.structure.intellij.problems.NoDependencies
-import com.jetbrains.plugin.structure.intellij.problems.PluginCreationResultResolver
-import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginId
-import com.jetbrains.plugin.structure.intellij.problems.TemplateWordInPluginName
+import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.intellij.utils.JDOMUtil
 import junit.framework.TestCase.assertEquals
@@ -69,6 +65,28 @@ class PluginCreatorTest {
       }
     }
   }
+
+
+  @Test
+  fun `plugin with multiple dependencies blocks`() {
+    val pluginCreator = createPlugin(PLUGIN_WITH_MULTIPLE_DEPENDENCIES_BLOCKS)
+    with(pluginCreator) {
+      assertTrue(isSuccess)
+      with(plugin.pluginMainModuleDependencies) {
+        assertEquals(
+          listOf(
+            "com.intellij.modules.os.mac",
+            "com.intellij.modules.arch.arm64",
+            "com.intellij.platform.images",
+            "org.intellij.groovy.live.templates",
+            "com.intellij.modules.json",
+            "org.jetbrains.kotlin",
+          ).sorted(), map { it.pluginId }.sorted()
+        )
+      }
+    }
+  }
+
 
   private fun createPlugin(pluginXml: String): PluginCreator {
     val uri = URI("file:///plugins/somePlugin/META-INF/plugin.xml")
@@ -139,4 +157,42 @@ private const val PLUGIN_XML_WITH_CONTENT_MODULES = """
        <module name="my.unknown.module" loading="unknown"/>
      </content>
   </idea-plugin> 
+"""
+
+private const val PLUGIN_WITH_MULTIPLE_DEPENDENCIES_BLOCKS = """
+  <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+    <name>Android</name>
+    <id>android</id>
+    <version>263.20260623.0-mac-arm64</version>
+    <idea-version since-build="263.SNAPSHOT" until-build="263.SNAPSHOT" />
+    <vendor>JetBrains</vendor>
+    <description><![CDATA[Supports the development of <a href="https://developer.android.com">Android</a> applications with IntelliJ IDEA and Android Studio.]]></description>
+    <dependencies>
+      <plugin id="com.intellij.modules.os.mac" />
+      <plugin id="com.intellij.modules.arch.arm64" />
+      <plugin id="com.intellij.platform.images" />
+      <module name="intellij.java.backend" />
+      <plugin id="org.intellij.groovy.live.templates" />
+      <plugin id="com.intellij.modules.json" />
+      <module name="intellij.platform.lvcs.impl" />
+      <module name="intellij.platform.vcs.impl" />
+      <module name="intellij.platform.vcs.dvcs.impl" />
+      <module name="intellij.properties.backend.psi" />
+      <module name="intellij.spellchecker" />
+      <module name="intellij.spellchecker.xml" />
+      <module name="intellij.platform.jewel.foundation" />
+      <module name="intellij.platform.jewel.ideLafBridge" />
+      <module name="intellij.platform.jewel.markdown.core" />
+      <module name="intellij.platform.jewel.markdown.ideLafBridgeStyling" />
+      <module name="intellij.platform.jewel.ui" />
+    </dependencies>
+    <dependencies>
+      <module name="intellij.xml.emmet" />
+      <module name="intellij.platform.bookmarks" />
+    </dependencies>
+    <dependencies>
+      <module name="intellij.gradle" />
+      <plugin id="org.jetbrains.kotlin" />
+    </dependencies>
+  </idea-plugin>
 """


### PR DESCRIPTION
Support multiple `<dependencies>` blocks in plugin descriptors. This allows multiple declarations of Plugin Model v2 dependencies in multiple places.