### PR TITLE
Remove the storage of a fat DependenciesGraph, replace with a shallow…

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/html/HtmlResultPrinter.kt
@@ -8,7 +8,7 @@ import com.jetbrains.plugin.structure.base.utils.create
 import com.jetbrains.plugin.structure.ide.VersionComparatorUtil
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.presentation.DependenciesGraphPrettyPrinter
+import com.jetbrains.pluginverifier.dependencies.presentation.ResolvedDependenciesGraphPrettyPrinter
 import com.jetbrains.pluginverifier.misc.HtmlBuilder
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.ResultPrinter
@@ -145,7 +145,7 @@ class HtmlResultPrinter(
             }
           }
           printShortAndFullDescription("Dependencies used on verification") {
-            val graphPresentation = DependenciesGraphPrettyPrinter(dependenciesGraph).prettyPresentation()
+            val graphPresentation = ResolvedDependenciesGraphPrettyPrinter(dependenciesGraph).prettyPresentation()
             graphPresentation.lines().forEach { line ->
               +line
               br()

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -4,7 +4,7 @@ import com.jetbrains.plugin.structure.base.problems.isError
 import com.jetbrains.plugin.structure.base.utils.create
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.dymamic.DynamicPlugins.simplifiedReasonsNotToLoadUnloadWithoutRestart
 import com.jetbrains.pluginverifier.output.DYNAMIC_PLUGIN_FAIL
@@ -153,7 +153,7 @@ private operator fun Markdown.plus(result: PluginVerificationResult.Verified) {
 
 private fun Markdown.printVerificationResult(result: PluginVerificationResult.Verified) = with(result) {
   printVerificationResult("Plugin structure warnings", pluginStructureWarnings, PluginStructureWarning::describe)
-  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies(), MissingDependency::describe)
+  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies(), ResolvedMissingDependency::describe)
   printVerificationResult("Compatibility warnings", compatibilityWarnings, CompatibilityWarning::describe)
   printVerificationResult("Compatibility problems", compatibilityProblems, CompatibilityProblem::describe)
   printVerificationResult("Deprecated API usages", deprecatedUsages, DeprecatedApiUsage::describe)
@@ -202,7 +202,7 @@ private fun Markdown.appendShortAndFullDescriptions(shortToFullDescriptions: Map
 }
 
 fun PluginStructureWarning.describe() = "" to message
-fun MissingDependency.describe() = "" to "$dependency: $missingReason"
+fun ResolvedMissingDependency.describe() = "" to "$dependency: $missingReason"
 fun CompatibilityWarning.describe() = shortDescription to fullDescription
 fun CompatibilityProblem.describe() = shortDescription to fullDescription
 fun DeprecatedApiUsage.describe() = shortDescription to fullDescription

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/teamcity/TeamCityResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/teamcity/TeamCityResultPrinter.kt
@@ -10,7 +10,7 @@ import com.jetbrains.plugin.structure.ide.VersionComparatorUtil
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
 import com.jetbrains.pluginverifier.repository.Browseable
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.PluginRepository
@@ -115,8 +115,8 @@ class TeamCityResultPrinter(
       emptySet()
     }
 
-  private fun collectMissingDependenciesForRequiringPlugins(results: List<PluginVerificationResult>): Map<MissingDependency, Set<PluginInfo>> {
-    val missingToRequiring = mutableMapOf<MissingDependency, MutableSet<PluginInfo>>()
+  private fun collectMissingDependenciesForRequiringPlugins(results: List<PluginVerificationResult>): Map<ResolvedMissingDependency, Set<PluginInfo>> {
+    val missingToRequiring = mutableMapOf<ResolvedMissingDependency, MutableSet<PluginInfo>>()
     results.filterIsInstance<PluginVerificationResult.Verified>().forEach {
       it.directMissingMandatoryDependencies.forEach { missingDependency ->
         missingToRequiring.getOrPut(missingDependency) { hashSetOf() } += it.plugin
@@ -204,7 +204,7 @@ class TeamCityResultPrinter(
   private fun getMessageCompatibilityProblemsAndMissingDependencies(
     plugin: PluginInfo,
     problems: Set<CompatibilityProblem>,
-    missingDependencies: List<MissingDependency>
+    missingDependencies: List<ResolvedMissingDependency>
   ): String? {
     val mandatoryMissingDependencies = missingDependencies.filterNot { it.dependency.isOptional }
     if (problems.isNotEmpty() || mandatoryMissingDependencies.isNotEmpty()) {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/twoTargets/TwoTargetsResultPrinter.kt
@@ -6,10 +6,10 @@ package com.jetbrains.pluginverifier.tasks.twoTargets
 
 import com.jetbrains.plugin.structure.base.utils.pluralize
 import com.jetbrains.plugin.structure.base.utils.pluralizeWithNumber
-import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedPluginDependency
 import com.jetbrains.pluginverifier.output.OutputOptions
 import com.jetbrains.pluginverifier.output.html.HtmlResultPrinter
 import com.jetbrains.pluginverifier.output.markdown.MarkdownResultPrinter
@@ -335,10 +335,10 @@ class TwoTargetsResultPrinter : TaskResultPrinter {
     return "$pluginId:$version$updateId$browserUrl"
   }
 
-  private fun DependenciesGraph.getResolvedDependency(dependency: PluginDependency) =
+  private fun ResolvedDependenciesGraph.getResolvedDependency(dependency: ResolvedPluginDependency) =
     edges.find { it.dependency == dependency }?.to
 
-  private fun PluginVerificationResult.getResolvedDependency(dependency: PluginDependency) =
+  private fun PluginVerificationResult.getResolvedDependency(dependency: ResolvedPluginDependency) =
     (this as? PluginVerificationResult.Verified)?.dependenciesGraph?.getResolvedDependency(dependency)
 
   private fun getMissingDependenciesNote(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerificationResult.kt
@@ -6,8 +6,8 @@ package com.jetbrains.pluginverifier
 
 import com.jetbrains.plugin.structure.base.telemetry.PluginTelemetry
 import com.jetbrains.plugin.structure.base.utils.pluralize
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -32,7 +32,7 @@ sealed class PluginVerificationResult(
   class Verified(
     plugin: PluginInfo,
     verificationTarget: PluginVerificationTarget,
-    val dependenciesGraph: DependenciesGraph,
+    val dependenciesGraph: ResolvedDependenciesGraph,
     val compatibilityProblems: Set<CompatibilityProblem> = emptySet(),
     val ignoredProblems: Map<CompatibilityProblem, String> = emptyMap(),
     val compatibilityWarnings: Set<CompatibilityWarning> = emptySet(),
@@ -60,7 +60,7 @@ sealed class PluginVerificationResult(
     val isOk: Boolean
       get() = !hasDirectMissingMandatoryDependencies && !hasCompatibilityProblems && !hasCompatibilityWarnings
 
-    val directMissingMandatoryDependencies: List<MissingDependency>
+    val directMissingMandatoryDependencies: List<ResolvedMissingDependency>
       get() = dependenciesGraph.getDirectMissingDependencies().filterNot { it.dependency.isOptional }
 
     override val verificationVerdict

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/PluginVerifier.kt
@@ -18,6 +18,7 @@ import com.jetbrains.pluginverifier.analysis.ExtractedJsonPluginAnalyzer
 import com.jetbrains.pluginverifier.analysis.ReachabilityGraph
 import com.jetbrains.pluginverifier.analysis.buildClassReachabilityGraph
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.toResolved
 import com.jetbrains.pluginverifier.dependencies.ModuleVisibilityChecker
 import com.jetbrains.pluginverifier.dymamic.DynamicPlugins
 import com.jetbrains.pluginverifier.filtering.ApiUsageFilter
@@ -148,7 +149,7 @@ class PluginVerifier(
         PluginVerificationResult.Verified(
           verificationDescriptor.checkedPlugin,
           verificationDescriptor.toTarget(),
-          dependenciesGraph,
+          dependenciesGraph.toResolved(),
           reportProblems,
           ignoredProblems,
           compatibilityWarnings,

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.dependencies
+
+import com.jetbrains.plugin.structure.intellij.plugin.module.IdeModule
+
+/**
+ * String-only representation of a plugin dependency identifier, used after dependency resolution.
+ * Mirrors [com.jetbrains.plugin.structure.intellij.plugin.PluginDependency] but holds no live objects.
+ */
+data class ResolvedPluginDependency(val id: String, val isOptional: Boolean, val isModule: Boolean) {
+  override fun toString() = if (isOptional) "$id (optional)" else id
+}
+
+/**
+ * A node in [ResolvedDependenciesGraph]. Holds only string identifiers and carries no references
+ * to [com.jetbrains.plugin.structure.intellij.plugin.IdePlugin], allowing resolved plugin objects
+ * to be garbage-collected after verification completes.
+ */
+data class ResolvedDependencyNode(
+  val id: String,
+  val version: String,
+  val aliases: Set<String> = emptySet(),
+  val isProductModule: Boolean = false
+) {
+  override fun toString() = "$id:$version" + if (aliases.isNotEmpty()) " (aliased ${aliases.joinToString(" ")})" else ""
+}
+
+/**
+ * An edge in [ResolvedDependenciesGraph].
+ */
+data class ResolvedDependencyEdge(
+  val from: ResolvedDependencyNode,
+  val to: ResolvedDependencyNode,
+  val dependency: ResolvedPluginDependency
+) {
+  override fun toString() = if (dependency.isOptional) "$from ---optional---> $to" else "$from ---> $to"
+}
+
+/**
+ * A dependency of the verified plugin that could not be resolved during verification.
+ */
+data class ResolvedMissingDependency(val dependency: ResolvedPluginDependency, val missingReason: String) {
+  override fun toString() = "$dependency: $missingReason"
+}
+
+/**
+ * Post-resolution, string-only dependency graph stored in [com.jetbrains.pluginverifier.PluginVerificationResult.Verified].
+ *
+ * Built by [DependenciesGraph.toResolved] after dependency resolution completes. Retains no references to
+ * [com.jetbrains.plugin.structure.intellij.plugin.IdePlugin] instances, so they can be garbage-collected
+ * once verification finishes.
+ */
+data class ResolvedDependenciesGraph(
+  val verifiedPlugin: ResolvedDependencyNode,
+  val vertices: Set<ResolvedDependencyNode>,
+  val edges: Set<ResolvedDependencyEdge>,
+  val missingDependencies: Map<ResolvedDependencyNode, Set<ResolvedMissingDependency>>
+) {
+  fun getDirectMissingDependencies(): Set<ResolvedMissingDependency> =
+    missingDependencies.getOrDefault(verifiedPlugin, emptySet())
+
+  fun getEdgesFrom(node: ResolvedDependencyNode): List<ResolvedDependencyEdge> =
+    edges.filter { it.from == node }
+}
+
+/**
+ * Converts the fat [DependenciesGraph] (which holds live [com.jetbrains.plugin.structure.intellij.plugin.IdePlugin]
+ * references) into a [ResolvedDependenciesGraph] containing only string identifiers.
+ *
+ * Call this before storing the graph in a [com.jetbrains.pluginverifier.PluginVerificationResult] so that
+ * the plugin objects can be garbage-collected.
+ */
+fun DependenciesGraph.toResolved(): ResolvedDependenciesGraph {
+  val allNodes: Set<DependencyNode> = mutableSetOf<DependencyNode>().apply {
+    add(verifiedPlugin)
+    addAll(vertices)
+    edges.forEach { add(it.from); add(it.to) }
+    addAll(missingDependencies.keys)
+  }
+  val nodeMap = allNodes.associate { node ->
+    val isProductModule = node is DependencyNode.PluginDependency && node.plugin is IdeModule
+    val aliases = if (node is DependencyNode.PluginDependency) node.aliases.toSet() else emptySet()
+    node to ResolvedDependencyNode(node.id, node.version, aliases, isProductModule)
+  }
+
+  val resolvedEdges = edges.mapTo(hashSetOf()) { edge ->
+    ResolvedDependencyEdge(
+      nodeMap.getValue(edge.from),
+      nodeMap.getValue(edge.to),
+      ResolvedPluginDependency(edge.dependency.id, edge.dependency.isOptional, edge.dependency.isModule)
+    )
+  }
+
+  val resolvedMissingDeps = missingDependencies.entries.associate { (node, missing) ->
+    nodeMap.getValue(node) to missing.mapTo(hashSetOf()) { md ->
+      ResolvedMissingDependency(
+        ResolvedPluginDependency(md.dependency.id, md.dependency.isOptional, md.dependency.isModule),
+        md.missingReason
+      )
+    }
+  }
+
+  return ResolvedDependenciesGraph(
+    nodeMap.getValue(verifiedPlugin),
+    nodeMap.values.toSet(),
+    resolvedEdges,
+    resolvedMissingDeps
+  )
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.dependencies.presentation
+
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyEdge
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
+
+/**
+ * Provides the [prettyPresentation] method that prints a [ResolvedDependenciesGraph] in
+ * a fancy way like the 'gradle dependencies' does:
+ *
+ * ```
+ * start:1.0
+ * +--- b:1.0
+ * |    +--- c:1.0
+ * |    |    +--- (failed) e: plugin e is not found
+ * |    |    +--- (failed) f (optional): plugin e is not found
+ * |    |    \--- (optional) optional.module:IU-181.1 [declaring module optional.module]
+ * |    \--- some.module:IU-181.1 [product module]
+ * \--- c:1.0 (*)
+ * ```
+ */
+class ResolvedDependenciesGraphPrettyPrinter(private val graph: ResolvedDependenciesGraph) {
+
+  private val visitedNodes = hashSetOf<ResolvedDependencyNode>()
+
+  fun prettyPresentation(): String =
+    recursivelyCalculateLines(graph.verifiedPlugin).joinToString(separator = "\n")
+
+  private fun recursivelyCalculateLines(currentNode: ResolvedDependencyNode): List<String> {
+    if (currentNode in visitedNodes) {
+      return listOf("$currentNode (*)")
+    }
+    visitedNodes.add(currentNode)
+
+    val childrenLines = arrayListOf<List<String>>()
+
+    graph.missingDependencies
+      .getOrDefault(currentNode, emptySet())
+      .sortedBy { it.dependency.id }.mapTo(childrenLines) { missingDependency ->
+        listOf("(failed) ${missingDependency.dependency}: ${missingDependency.missingReason}")
+      }
+
+    val directEdges = graph.getEdgesFrom(currentNode)
+      .sortedWith(
+        compareBy<ResolvedDependencyEdge> { if (it.dependency.isOptional) 1 else -1 }
+          .thenBy { if (it.dependency.isModule) 1 else -1 }
+          .thenBy { it.dependency.id }
+          .thenBy { it.to.id }
+          .thenBy { it.to.version }
+      )
+
+    for (edge in directEdges) {
+      val childLines = recursivelyCalculateLines(edge.to)
+      val headerLine = buildString {
+        if (edge.dependency.isOptional) {
+          append("(optional) ")
+        }
+        append(childLines.first())
+        if (edge.to.isProductModule) {
+          append(" [product module]")
+        } else if (edge.dependency.isModule) {
+          append(" [declaring module ${edge.dependency.id}]")
+        }
+      }
+      val tailLines = childLines.drop(1)
+      childrenLines.add(listOf(headerLine) + tailLines)
+    }
+
+    val result = arrayListOf<String>()
+    result += currentNode.toString()
+
+    if (childrenLines.isNotEmpty()) {
+      val headingChildren = childrenLines.dropLast(1)
+      val lastChild = childrenLines.last()
+
+      if (headingChildren.isNotEmpty()) {
+        for (headingChild in headingChildren) {
+          val firstLine = headingChild.first().let { "+--- $it" }
+          val tailLines = headingChild.drop(1).map { "|    $it" }
+          result += firstLine
+          result += tailLines
+        }
+      }
+
+      result += lastChild.first().let { "\\--- $it" }
+      result += lastChild.drop(1).map { "     $it" }
+    }
+
+    return result
+  }
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/DirectoryBasedPluginVerificationReportage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/DirectoryBasedPluginVerificationReportage.kt
@@ -12,7 +12,6 @@ import com.jetbrains.plugin.structure.base.utils.closeLogged
 import com.jetbrains.plugin.structure.base.utils.replaceInvalidFileNameCharacters
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.presentation.DependenciesGraphPrettyPrinter
 import com.jetbrains.pluginverifier.reporting.common.FileReporter
 import com.jetbrains.pluginverifier.reporting.common.LogReporter
 import com.jetbrains.pluginverifier.reporting.ignoring.AllIgnoredProblemsReporter
@@ -131,7 +130,7 @@ class DirectoryBasedPluginVerificationReportage(
         is PluginVerificationResult.Verified -> {
           reportVerificationDetails(directory, "compatibility-warnings.txt", compatibilityWarnings)
           reportVerificationDetails(directory, "compatibility-problems.txt", compatibilityProblems)
-          reportVerificationDetails(directory, "dependencies.txt", listOf(dependenciesGraph)) { DependenciesGraphPrettyPrinter(it).prettyPresentation() }
+          reportVerificationDetails(directory, "dependencies.txt", listOf(dependenciesGraph)) { it.toString() }
           reportVerificationDetails(directory, "deprecated-usages.txt", deprecatedUsages)
           reportVerificationDetails(directory, "experimental-api-usages.txt", experimentalApiUsages)
           reportVerificationDetails(directory, "internal-api-usages.txt", internalApiUsages)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/DirectoryBasedPluginVerificationReportage.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/DirectoryBasedPluginVerificationReportage.kt
@@ -23,6 +23,7 @@ import com.jetbrains.pluginverifier.reporting.telemetry.TelemetryAggregator
 import com.jetbrains.pluginverifier.reporting.telemetry.toPlainString
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.marketplace.UpdateInfo
+import com.jetbrains.pluginverifier.dependencies.presentation.ResolvedDependenciesGraphPrettyPrinter
 import com.jetbrains.pluginverifier.usages.internal.kotlin.KtInternalModifierUsage
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
@@ -130,7 +131,7 @@ class DirectoryBasedPluginVerificationReportage(
         is PluginVerificationResult.Verified -> {
           reportVerificationDetails(directory, "compatibility-warnings.txt", compatibilityWarnings)
           reportVerificationDetails(directory, "compatibility-problems.txt", compatibilityProblems)
-          reportVerificationDetails(directory, "dependencies.txt", listOf(dependenciesGraph)) { it.toString() }
+          reportVerificationDetails(directory, "dependencies.txt", listOf(dependenciesGraph)) { ResolvedDependenciesGraphPrettyPrinter(it).prettyPresentation() }
           reportVerificationDetails(directory, "deprecated-usages.txt", deprecatedUsages)
           reportVerificationDetails(directory, "experimental-api-usages.txt", experimentalApiUsages)
           reportVerificationDetails(directory, "internal-api-usages.txt", internalApiUsages)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/kotlin/com/jetbrains/pluginverifier/response/VerifierServiceResultConverter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/kotlin/com/jetbrains/pluginverifier/response/VerifierServiceResultConverter.kt
@@ -4,13 +4,13 @@
 
 package com.jetbrains.pluginverifier.response
 
-import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.DependencyEdge
-import com.jetbrains.pluginverifier.dependencies.DependencyNode
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyEdge
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedPluginDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.ide.AvailableIde
 import com.jetbrains.pluginverifier.results.location.*
@@ -107,7 +107,7 @@ fun PluginVerificationResult.Verified.convertResultType(): VerificationResultTyp
 private fun AvailableIde.convert() =
   AvailableIdeDto(version.asString(), releaseVersion, product.productName)
 
-fun DependenciesGraph.convert() =
+fun ResolvedDependenciesGraph.convert() =
   DependenciesGraphDto(
     verifiedPlugin.convert(),
     vertices.map { it.convert() },
@@ -120,22 +120,22 @@ fun DependenciesGraph.convert() =
     }
   )
 
-private fun DependencyEdge.convert() =
+private fun ResolvedDependencyEdge.convert() =
   DependenciesGraphDto.DependencyEdgeDto(
     from.convert(),
     to.convert(),
     dependency.convert()
   )
 
-private fun DependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
+private fun ResolvedDependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
 
-private fun MissingDependency.convert() =
+private fun ResolvedMissingDependency.convert() =
   DependenciesGraphDto.MissingDependencyDto(
     dependency.convert(),
     missingReason
   )
 
-private fun PluginDependency.convert() =
+private fun ResolvedPluginDependency.convert() =
   DependenciesGraphDto.DependencyDto(
     id,
     isOptional,

--- a/intellij-plugin-verifier/verifier-intellij/src/main/kotlin/com/jetbrains/pluginverifier/response/VerifierServiceResultConverter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/kotlin/com/jetbrains/pluginverifier/response/VerifierServiceResultConverter.kt
@@ -107,7 +107,7 @@ fun PluginVerificationResult.Verified.convertResultType(): VerificationResultTyp
 private fun AvailableIde.convert() =
   AvailableIdeDto(version.asString(), releaseVersion, product.productName)
 
-fun ResolvedDependenciesGraph.convert() =
+fun ResolvedDependenciesGraph.convert(): DependenciesGraphDto =
   DependenciesGraphDto(
     verifiedPlugin.convert(),
     vertices.map { it.convert() },
@@ -120,22 +120,22 @@ fun ResolvedDependenciesGraph.convert() =
     }
   )
 
-private fun ResolvedDependencyEdge.convert() =
+private fun ResolvedDependencyEdge.convert(): DependenciesGraphDto.DependencyEdgeDto =
   DependenciesGraphDto.DependencyEdgeDto(
     from.convert(),
     to.convert(),
     dependency.convert()
   )
 
-private fun ResolvedDependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
+private fun ResolvedDependencyNode.convert(): DependenciesGraphDto.DependencyNodeDto = DependenciesGraphDto.DependencyNodeDto(id, version)
 
-private fun ResolvedMissingDependency.convert() =
+private fun ResolvedMissingDependency.convert(): DependenciesGraphDto.MissingDependencyDto =
   DependenciesGraphDto.MissingDependencyDto(
     dependency.convert(),
     missingReason
   )
 
-private fun ResolvedPluginDependency.convert() =
+private fun ResolvedPluginDependency.convert(): DependenciesGraphDto.DependencyDto =
   DependenciesGraphDto.DependencyDto(
     id,
     isOptional,

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputPrintTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputPrintTest.kt
@@ -4,15 +4,15 @@
 
 package com.jetbrains.pluginverifier.output
 
-import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.plugin.structure.intellij.problems.ForbiddenPluginIdPrefix
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.jar.PLUGIN_XML
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.DependencyNode
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedPluginDependency
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.jdk.JdkVersion
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
@@ -38,8 +38,8 @@ open class BaseOutputPrintTest<T : ResultPrinter>: BaseOutputTest() {
     out = StringWriter()
   }
 
-  private val dependenciesGraph: DependenciesGraph = DependenciesGraph(
-        verifiedPlugin = DependencyNode.IdAndVersionDependency(PLUGIN_ID, PLUGIN_VERSION),
+  private val dependenciesGraph: ResolvedDependenciesGraph = ResolvedDependenciesGraph(
+        verifiedPlugin = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION),
         vertices = emptySet(),
         edges = emptySet(),
         missingDependencies = emptyMap())
@@ -69,10 +69,10 @@ open class BaseOutputPrintTest<T : ResultPrinter>: BaseOutputTest() {
   }
 
   open fun `when plugin has missing dependencies`(testRunner: VerifiedPluginHandler) {
-    val pluginDependency = DependencyNode.IdAndVersionDependency(PLUGIN_ID, PLUGIN_VERSION)
-    val expectedDependency = MissingDependency(PluginDependencyImpl("MissingPlugin", true, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
+    val pluginDependency = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION)
+    val expectedDependency = ResolvedMissingDependency(ResolvedPluginDependency("MissingPlugin", true, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
 
-    val dependenciesGraph = DependenciesGraph(
+    val dependenciesGraph = ResolvedDependenciesGraph(
       verifiedPlugin = pluginDependency,
       vertices = emptySet(),
       edges = emptySet(),

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/marketplace/FullResultResponseTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/marketplace/FullResultResponseTest.kt
@@ -7,8 +7,8 @@ package com.jetbrains.pluginverifier.output.marketplace
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.DependencyNode.Companion.dependencyNode
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
 import com.jetbrains.pluginverifier.dymamic.DynamicPluginStatus
 import com.jetbrains.pluginverifier.jdk.JdkVersion
 import com.jetbrains.pluginverifier.output.BaseOutputTest
@@ -26,8 +26,8 @@ class FullResultResponseTest: BaseOutputTest() {
     private val ideVersion = IdeVersion.createIdeVersion("232")
     private val pluginInfo = mockPluginInfo()
     private val verificationTarget = PluginVerificationTarget.IDE(ideVersion, JdkVersion("11", null))
-    private val dependenciesGraph: DependenciesGraph = DependenciesGraph(
-        verifiedPlugin = dependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+    private val dependenciesGraph: ResolvedDependenciesGraph = ResolvedDependenciesGraph(
+        verifiedPlugin = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION),
         vertices = emptySet(),
         edges = emptySet(),
         missingDependencies = emptyMap())

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregatorTest.kt
@@ -9,8 +9,8 @@ import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.DependencyNode.Companion.dependencyNode
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
 import com.jetbrains.pluginverifier.jdk.JdkVersion
 import com.jetbrains.pluginverifier.reporting.common.LogReporter
 import com.jetbrains.pluginverifier.repository.PluginInfo
@@ -45,8 +45,8 @@ class LoggingPluginVerificationReportageAggregatorTest {
 
   @Test
   fun `verification results are aggregated`() {
-    val dependenciesGraph = DependenciesGraph(
-      verifiedPlugin = dependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+    val dependenciesGraph = ResolvedDependenciesGraph(
+      verifiedPlugin = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION),
       vertices = emptySet(),
       edges = emptySet(),
       missingDependencies = emptyMap()
@@ -76,8 +76,8 @@ class LoggingPluginVerificationReportageAggregatorTest {
 
   @Test
   fun `verification results are emitted from multiple plugins`() {
-    val dependenciesGraph = DependenciesGraph(
-      verifiedPlugin = dependencyNode(PLUGIN_ID, PLUGIN_VERSION),
+    val dependenciesGraph = ResolvedDependenciesGraph(
+      verifiedPlugin = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION),
       vertices = emptySet(),
       edges = emptySet(),
       missingDependencies = emptyMap()
@@ -85,8 +85,8 @@ class LoggingPluginVerificationReportageAggregatorTest {
     val verificationResult = PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
     val targetDirectory = createTempDirectory()
 
-    val anotherDependenciesGraph = DependenciesGraph(
-      verifiedPlugin = dependencyNode(ANOTHER_PLUGIN_ID, ANOTHER_PLUGIN_VERSION),
+    val anotherDependenciesGraph = ResolvedDependenciesGraph(
+      verifiedPlugin = ResolvedDependencyNode(ANOTHER_PLUGIN_ID, ANOTHER_PLUGIN_VERSION),
       vertices = emptySet(),
       edges = emptySet(),
       missingDependencies = emptyMap()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationTest.kt
@@ -3,10 +3,9 @@ package com.jetbrains.pluginverifier.tests
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
-import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
-import com.jetbrains.plugin.structure.intellij.plugin.PluginV1Dependency
 import com.jetbrains.pluginverifier.PluginVerificationResult
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedPluginDependency
 import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -39,14 +38,14 @@ class VerificationTest {
   fun `check that missing dependency is detected`() {
     val missingDependencies = verificationResult.dependenciesGraph.getDirectMissingDependencies()
     assertFalse(missingDependencies.isEmpty())
-    val expectedDep = MissingDependency(PluginV1Dependency.Optional("MissingPlugin"), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
+    val expectedDep = ResolvedMissingDependency(ResolvedPluginDependency("MissingPlugin", true, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
     assertTrue("$expectedDep not in $missingDependencies", expectedDep in missingDependencies)
   }
 
   @Test
   fun `check that module incompatibility is detected`() {
     val missingDependencies = verificationResult.dependenciesGraph.getDirectMissingDependencies()
-    val expectedDep = MissingDependency(PluginDependencyImpl("com.intellij.modules.arbitrary.module", false, true), "The plugin is incompatible with module 'com.intellij.modules.arbitrary.module'")
+    val expectedDep = ResolvedMissingDependency(ResolvedPluginDependency("com.intellij.modules.arbitrary.module", false, true), "The plugin is incompatible with module 'com.intellij.modules.arbitrary.module'")
     assertTrue("$expectedDep not in $missingDependencies", expectedDep in missingDependencies)
   }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/DependenciesGraphPrettyPrinterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/DependenciesGraphPrettyPrinterTest.kt
@@ -12,6 +12,7 @@ import com.jetbrains.pluginverifier.dependencies.DependencyEdge
 import com.jetbrains.pluginverifier.dependencies.DependencyNode
 import com.jetbrains.pluginverifier.dependencies.DependencyNode.Companion.dependencyNode
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.presentation.ResolvedDependenciesGraphPrettyPrinter
 import com.jetbrains.pluginverifier.dependencies.toResolved
 import org.junit.Assert
 import org.junit.Test
@@ -95,7 +96,7 @@ class DependenciesGraphPrettyPrinterTest {
       dependencyNode(id, version) to deps.toSet()
     }.toMap()
     val dependenciesGraph = DependenciesGraph(startVertex, vertices, edges, missingDeps)
-    val prettyPresentation = dependenciesGraph.toResolved().toString().trim()
+    val prettyPresentation = ResolvedDependenciesGraphPrettyPrinter(dependenciesGraph.toResolved()).prettyPresentation().trim()
 
     Assert.assertEquals(
       """

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/DependenciesGraphPrettyPrinterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/DependenciesGraphPrettyPrinterTest.kt
@@ -12,7 +12,7 @@ import com.jetbrains.pluginverifier.dependencies.DependencyEdge
 import com.jetbrains.pluginverifier.dependencies.DependencyNode
 import com.jetbrains.pluginverifier.dependencies.DependencyNode.Companion.dependencyNode
 import com.jetbrains.pluginverifier.dependencies.MissingDependency
-import com.jetbrains.pluginverifier.dependencies.presentation.DependenciesGraphPrettyPrinter
+import com.jetbrains.pluginverifier.dependencies.toResolved
 import org.junit.Assert
 import org.junit.Test
 
@@ -95,8 +95,7 @@ class DependenciesGraphPrettyPrinterTest {
       dependencyNode(id, version) to deps.toSet()
     }.toMap()
     val dependenciesGraph = DependenciesGraph(startVertex, vertices, edges, missingDeps)
-    val prettyPrinter = DependenciesGraphPrettyPrinter(dependenciesGraph)
-    val prettyPresentation = prettyPrinter.prettyPresentation().trim()
+    val prettyPresentation = dependenciesGraph.toResolved().toString().trim()
 
     Assert.assertEquals(
       """

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifierServiceResultConverter.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifierServiceResultConverter.kt
@@ -4,13 +4,13 @@
 
 package org.jetbrains.plugins.verifier.service.service.verifier
 
-import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
-import com.jetbrains.pluginverifier.dependencies.DependencyEdge
-import com.jetbrains.pluginverifier.dependencies.DependencyNode
-import com.jetbrains.pluginverifier.dependencies.MissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependenciesGraph
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyEdge
+import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
+import com.jetbrains.pluginverifier.dependencies.ResolvedMissingDependency
+import com.jetbrains.pluginverifier.dependencies.ResolvedPluginDependency
 import com.jetbrains.pluginverifier.ide.AvailableIde
 import com.jetbrains.pluginverifier.results.location.*
 import com.jetbrains.pluginverifier.results.presentation.*
@@ -106,7 +106,7 @@ fun PluginVerificationResult.Verified.convertResultType(): VerificationResultTyp
 private fun AvailableIde.convert() =
   AvailableIdeDto(version.asString(), releaseVersion, product.productName)
 
-fun DependenciesGraph.convert() =
+fun ResolvedDependenciesGraph.convert() =
   DependenciesGraphDto(
     verifiedPlugin.convert(),
     vertices.map { it.convert() },
@@ -119,22 +119,22 @@ fun DependenciesGraph.convert() =
     }
   )
 
-private fun DependencyEdge.convert() =
+private fun ResolvedDependencyEdge.convert() =
   DependenciesGraphDto.DependencyEdgeDto(
     from.convert(),
     to.convert(),
     dependency.convert()
   )
 
-private fun DependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
+private fun ResolvedDependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
 
-private fun MissingDependency.convert() =
+private fun ResolvedMissingDependency.convert() =
   DependenciesGraphDto.MissingDependencyDto(
     dependency.convert(),
     missingReason
   )
 
-private fun PluginDependency.convert() =
+private fun ResolvedPluginDependency.convert() =
   DependenciesGraphDto.DependencyDto(
     id,
     isOptional,

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifierServiceResultConverter.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/service/verifier/VerifierServiceResultConverter.kt
@@ -106,7 +106,7 @@ fun PluginVerificationResult.Verified.convertResultType(): VerificationResultTyp
 private fun AvailableIde.convert() =
   AvailableIdeDto(version.asString(), releaseVersion, product.productName)
 
-fun ResolvedDependenciesGraph.convert() =
+fun ResolvedDependenciesGraph.convert(): DependenciesGraphDto =
   DependenciesGraphDto(
     verifiedPlugin.convert(),
     vertices.map { it.convert() },
@@ -119,22 +119,22 @@ fun ResolvedDependenciesGraph.convert() =
     }
   )
 
-private fun ResolvedDependencyEdge.convert() =
+private fun ResolvedDependencyEdge.convert(): DependenciesGraphDto.DependencyEdgeDto =
   DependenciesGraphDto.DependencyEdgeDto(
     from.convert(),
     to.convert(),
     dependency.convert()
   )
 
-private fun ResolvedDependencyNode.convert() = DependenciesGraphDto.DependencyNodeDto(id, version)
+private fun ResolvedDependencyNode.convert(): DependenciesGraphDto.DependencyNodeDto = DependenciesGraphDto.DependencyNodeDto(id, version)
 
-private fun ResolvedMissingDependency.convert() =
+private fun ResolvedMissingDependency.convert(): DependenciesGraphDto.MissingDependencyDto =
   DependenciesGraphDto.MissingDependencyDto(
     dependency.convert(),
     missingReason
   )
 
-private fun ResolvedPluginDependency.convert() =
+private fun ResolvedPluginDependency.convert(): DependenciesGraphDto.DependencyDto =
   DependenciesGraphDto.DependencyDto(
     id,
     isOptional,


### PR DESCRIPTION
… copy that won't keep objects needlessly alive

This PR was done by Claude to quickly try out the approach, whether it fixes the CI pipeline's unstable state