### PR TITLE
Deduplicate `PluginDependencyImpl` in `DependenciesGraph`

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraph.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraph.kt
@@ -72,8 +72,10 @@ sealed class DependencyNode {
    * Only the IdePlugin takes part in equality/hashCode checks!
    */
   class PluginDependency(override val plugin: IdePlugin): DependencyNode(), PluginAware {
-    override val id = plugin.id
-    override val version = plugin.pluginVersion ?: UNKNOWN_VERSION
+    override val id: String
+      get() = plugin.id
+    override val version: String
+      get() = plugin.pluginVersion ?: UNKNOWN_VERSION
 
     private val _aliases: MutableSet<String> = mutableSetOf()
     val aliases: Set<String> get() = _aliases

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphProvider.kt
@@ -5,13 +5,11 @@
 package com.jetbrains.pluginverifier.dependencies
 
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
-import com.jetbrains.plugin.structure.intellij.plugin.dependencies.Dependency
-import com.jetbrains.plugin.structure.intellij.plugin.dependencies.DependencyTreeResolution
-import com.jetbrains.plugin.structure.intellij.plugin.dependencies.PluginAware
-import com.jetbrains.plugin.structure.intellij.plugin.dependencies.id
-import com.jetbrains.plugin.structure.intellij.plugin.dependencies.pluginDependency
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import com.jetbrains.plugin.structure.intellij.plugin.dependencies.*
 import com.jetbrains.pluginverifier.dependencies.DependencyNode.Companion.dependencyNode
 import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Function
 
 internal const val UNKNOWN_VERSION = "unknown version"
 
@@ -45,6 +43,7 @@ class DependenciesGraphProvider {
 
   private fun DependencyTreeResolution.getEdges(): Set<DependencyEdge> {
     val edges = LinkedHashSet<DependencyEdge>()
+    val dependenciesCache = HashMap<PluginDependency, PluginDependency>()
     forEach { from, dependency ->
       dependency.pluginDependency?.let { pluginDependency ->
         require(from is PluginAware && dependency is PluginAware) // Invariant by the pluginDependency getter returning non-null
@@ -52,7 +51,7 @@ class DependenciesGraphProvider {
         edges += DependencyEdge(
           newDependencyNode(from.plugin),
           newDependencyNode(dependency.plugin),
-          pluginDependency
+          dependenciesCache.computeIfAbsent(pluginDependency, Function.identity())
         )
       }
     }


### PR DESCRIPTION
Here's a visualization of a problem which is solved here:
<img width="1129" height="711" alt="Screenshot 2026-06-27 at 09 44 37" src="https://github.com/user-attachments/assets/9def65d9-f652-4b8e-8d8d-2fd505b942a6" />

That's from a memory dump from comparing plugins compatible with IU-262 and IU-263. Total 12865 plugins verification results are stored in memory. Each has ~518 `PluginDependencyImpl("com.intellij", false, false)` nodes.
And there are other nodes.
After change, only 12865 `PluginDependencyImpl("com.intellij", false, false)` nodes will remain in memory.
