### PR TITLE
Demote log level from INFO to DEBUG in dependency search and downloads

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/resolution/RepositoryDependencyFinder.kt
@@ -55,7 +55,7 @@ class RepositoryDependencyFinder(
   ): DependencyFinder.Result =
     when (selectResult) {
       is PluginVersionSelector.Result.Selected -> {
-        LOG.info(
+        LOG.debug(
           "Resolved dependency {} '{}' to {} against {}",
           kind,
           dependencyId,

--- a/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/downloader/DownloadProvider.kt
+++ b/intellij-plugin-verifier/verifier-repository/src/main/java/com/jetbrains/pluginverifier/repository/downloader/DownloadProvider.kt
@@ -58,7 +58,7 @@ class DownloadProvider<in K : Any>(
           is DownloadResult.Downloaded -> {
             val size = downloadedFileOrDirectory.fileSize
             downloadEvent.downloadEnded(size)
-            logger.info(
+            logger.debug(
               "Download finished: {} ({}, {})",
               key,
               size.presentableAmount(),
@@ -67,7 +67,7 @@ class DownloadProvider<in K : Any>(
             saveDownloadedFileToFinalDestination(key, downloadedFileOrDirectory, extension, isDirectory)
           }
           is DownloadResult.NotFound -> {
-            logger.info(
+            logger.debug(
               "Download not found: {} ({}). Reason: {}",
               key,
               formatElapsed(startNanos),


### PR DESCRIPTION
Reduce log level to DEBUG on dependency search and downloads.