### PR TITLE
Reduce object allocation during check-trunk

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/Ide.java
@@ -24,6 +24,7 @@ import static com.jetbrains.plugin.structure.intellij.plugin.PluginProviderResul
 public abstract class Ide implements PluginProvider {
   private final PluginQueryMatcher queryMatcher = new PluginQueryMatcher();
   private volatile Map<String, IdePlugin> bundledPluginsById;
+  private volatile Map<String, IdePlugin> bundledPluginsByModuleId;
 
   /**
    * Returns the IDE version either from 'build.txt' or specified with {@link IdeManager#createIde(java.nio.file.Path, IdeVersion)}
@@ -71,12 +72,7 @@ public abstract class Ide implements PluginProvider {
   @Nullable
   @Override
   final public IdePlugin findPluginByModule(@NotNull String moduleId) {
-    for (IdePlugin plugin : getBundledPlugins()) {
-      if (plugin.hasDefinedModuleWithId(moduleId)) {
-        return plugin;
-      }
-    }
-    return null;
+    return getBundledPluginsByModuleId().get(moduleId);
   }
 
   /**
@@ -91,10 +87,9 @@ public abstract class Ide implements PluginProvider {
     if (plugin != null) {
       return new PluginProviderResult(PLUGIN, plugin);
     }
-    for (IdePlugin bundledPlugin : getBundledPlugins()) {
-      if (bundledPlugin.hasDefinedModuleWithId(pluginIdOrModuleId)) {
-        return new PluginProviderResult(MODULE, bundledPlugin);
-      }
+    IdePlugin pluginByModule = getBundledPluginsByModuleId().get(pluginIdOrModuleId);
+    if (pluginByModule != null) {
+      return new PluginProviderResult(MODULE, pluginByModule);
     }
     return null;
   }
@@ -167,6 +162,27 @@ public abstract class Ide implements PluginProvider {
           }
         }
         bundledPluginsById = result;
+      }
+      return result;
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private @NotNull Map<String, IdePlugin> getBundledPluginsByModuleId() {
+    Map<String, IdePlugin> result = bundledPluginsByModuleId;
+    if (result != null) {
+      return result;
+    }
+    synchronized (this) {
+      result = bundledPluginsByModuleId;
+      if (result == null) {
+        result = new HashMap<>();
+        for (IdePlugin plugin : getBundledPlugins()) {
+          for (String moduleId : plugin.getDefinedModules()) {
+            result.putIfAbsent(moduleId, plugin);
+          }
+        }
+        bundledPluginsByModuleId = result;
       }
       return result;
     }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdePluginProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/domain/IdePluginProviderTest.kt
@@ -9,6 +9,7 @@ import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.ide.IdeManager
 import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision
 import com.jetbrains.plugin.structure.intellij.plugin.PluginProvision.Source.*
+import com.jetbrains.plugin.structure.intellij.plugin.PluginProviderResult
 import com.jetbrains.plugin.structure.intellij.plugin.PluginQuery
 import com.jetbrains.plugin.structure.mocks.modify
 import com.jetbrains.plugin.structure.mocks.perfectXmlBuilder
@@ -147,5 +148,37 @@ class IdePluginProviderTest {
     pluginProvision as PluginProvision.Found
     assertEquals(JAVA_PLUGIN_ID, pluginProvision.plugin.pluginId)
     assertEquals(CONTENT_MODULE_ID, pluginProvision.source)
+  }
+
+  @Test
+  fun `findPluginByModule returns bundled plugin defining module id`() {
+    val plugin = ide.findPluginByModule(MODULE_ALIAS)
+    assertEquals(JAVA_PLUGIN_ID, plugin?.pluginId)
+  }
+
+  @Test
+  fun `findPluginByModule returns null for unknown module id`() {
+    val plugin = ide.findPluginByModule("unknown.module.id")
+    assertEquals(null, plugin)
+  }
+
+  @Test
+  fun `findPluginByIdOrModuleId returns PLUGIN type for plugin id`() {
+    val result = ide.findPluginByIdOrModuleId(JAVA_PLUGIN_ID)
+    assertEquals(JAVA_PLUGIN_ID, result?.plugin?.pluginId)
+    assertEquals(PluginProviderResult.Type.PLUGIN, result?.type)
+  }
+
+  @Test
+  fun `findPluginByIdOrModuleId returns MODULE type for module id`() {
+    val result = ide.findPluginByIdOrModuleId(MODULE_ALIAS)
+    assertEquals(JAVA_PLUGIN_ID, result?.plugin?.pluginId)
+    assertEquals(PluginProviderResult.Type.MODULE, result?.type)
+  }
+
+  @Test
+  fun `findPluginByIdOrModuleId returns null for unknown id`() {
+    val result = ide.findPluginByIdOrModuleId("unknown.id")
+    assertEquals(null, result)
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/ClassFileAsm.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/ClassFileAsm.kt
@@ -13,13 +13,14 @@ import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.InnerClassNode
 
 class ClassFileAsm(val asmNode: ClassNode, override val classFileOrigin: FileOrigin) : ClassFile {
-  override val location
-    get() = ClassLocation(
+  override val location: ClassLocation by lazy(LazyThreadSafetyMode.NONE) {
+    ClassLocation(
       name,
       signature?.takeIf { it.isNotEmpty() },
       Modifiers(asmNode.access),
       classFileOrigin
     )
+  }
 
   override val containingClassFile
     get() = this
@@ -33,8 +34,11 @@ class ClassFileAsm(val asmNode: ClassNode, override val classFileOrigin: FileOri
   override val javaPackageName
     get() = packageName.replace('/', '.')
 
-  override val methods
-    get() = asmNode.methods.asSequence().map { MethodAsm(this, it) }
+  private val _methods: List<MethodAsm> by lazy(LazyThreadSafetyMode.NONE) {
+    asmNode.methods.map { MethodAsm(this, it) }
+  }
+  override val methods: Sequence<Method>
+    get() = _methods.asSequence()
 
   override val fields
     get() = asmNode.fields.asSequence().map { FieldAsm(this, it) }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodAsm.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodAsm.kt
@@ -16,8 +16,8 @@ import org.objectweb.asm.tree.LocalVariableNode
 import org.objectweb.asm.tree.MethodNode
 
 class MethodAsm(override val containingClassFile: ClassFile, val asmNode: MethodNode) : Method {
-  override val location
-    get() = MethodLocation(
+  override val location: MethodLocation by lazy(LazyThreadSafetyMode.NONE) {
+    MethodLocation(
       containingClassFile.location,
       name,
       descriptor,
@@ -25,6 +25,7 @@ class MethodAsm(override val containingClassFile: ClassFile, val asmNode: Method
       signature?.takeIf { it.isNotEmpty() },
       Modifiers(asmNode.access)
     )
+  }
 
   override val name: String
     get() = asmNode.name
@@ -44,45 +45,36 @@ class MethodAsm(override val containingClassFile: ClassFile, val asmNode: Method
   override val localVariables: List<LocalVariableNode>
     get() = asmNode.localVariables.orEmpty()
 
-  private var _methodParameters: List<MethodParameter>? = null
-  override val methodParameters: List<MethodParameter>
-    get() {
-      if (_methodParameters != null) {
-        return _methodParameters!!
+  override val methodParameters: List<MethodParameter> by lazy(LazyThreadSafetyMode.NONE) {
+    val parameterNames = asmNode.getParameterNames()
+    val parameterAnnotations: Array<out MutableList<AnnotationNode>?> = asmNode.invisibleParameterAnnotations.orEmpty()
+
+    // Enums have two synthetic parameters
+    if (name == "<init>" && containingClassFile.isEnum) {
+      parameterNames.mapIndexed { index, parameterName ->
+        MethodParameter(parameterName, parameterAnnotations.getOrElse(index - 2) { emptyList() }.orEmpty())
       }
-
-      val parameterNames = asmNode.getParameterNames()
-      val parameterAnnotations: Array<out MutableList<AnnotationNode>?> = asmNode.invisibleParameterAnnotations.orEmpty()
-
-      // Enums have two synthetic parameters
-      val result = if (name == "<init>" && containingClassFile.isEnum) {
-        return parameterNames.mapIndexed { index, parameterName ->
-          MethodParameter(parameterName, parameterAnnotations.getOrElse(index - 2) { emptyList() }.orEmpty())
-        }
-      }
-
-      // Non-static inner classes have a synthetic parameters
-      else if (name == "<init>" && containingClassFile.isNonStaticInnerClass()) {
-        return parameterNames.mapIndexed { index, parameterName ->
-          MethodParameter(parameterName, parameterAnnotations.getOrElse(index - 1) { emptyList() }.orEmpty())
-        }
-      }
-
-      //The simplest case: just zip parameter names and annotations.
-      else if (parameterNames.size == parameterAnnotations.size) {
-        return parameterNames.zip(parameterAnnotations) { name, annotation ->
-          MethodParameter(name, annotation.orEmpty())
-        }
-      }
-
-      //Fallback: we don't know how to zip parameter names and annotations.
-      else {
-        parameterNames.map { parameterName -> MethodParameter(parameterName, emptyList()) }
-      }
-
-      _methodParameters = result
-      return result
     }
+
+    // Non-static inner classes have a synthetic parameter
+    else if (name == "<init>" && containingClassFile.isNonStaticInnerClass()) {
+      parameterNames.mapIndexed { index, parameterName ->
+        MethodParameter(parameterName, parameterAnnotations.getOrElse(index - 1) { emptyList() }.orEmpty())
+      }
+    }
+
+    //The simplest case: just zip parameter names and annotations.
+    else if (parameterNames.size == parameterAnnotations.size) {
+      parameterNames.zip(parameterAnnotations) { name, annotation ->
+        MethodParameter(name, annotation.orEmpty())
+      }
+    }
+
+    //Fallback: we don't know how to zip parameter names and annotations.
+    else {
+      parameterNames.map { parameterName -> MethodParameter(parameterName, emptyList()) }
+    }
+  }
 
   override val exceptions
     get() = asmNode.exceptions.orEmpty()

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
@@ -27,22 +27,19 @@ class ResolvedDependenciesGraphPrettyPrinter(private val graph: ResolvedDependen
 
   private val visitedNodes = hashSetOf<ResolvedDependencyNode>()
 
-  fun prettyPresentation(): String =
-    recursivelyCalculateLines(graph.verifiedPlugin).joinToString(separator = "\n")
+  fun prettyPresentation(): String {
+    val result = StringBuilder()
+    visitedNodes.add(graph.verifiedPlugin)
+    // First occurrence carries the aliases; repeated occurrences are printed as plain "id:version (*)".
+    result.append(graph.verifiedPlugin.toStringWithAliases())
+    appendChildren(graph.verifiedPlugin, result, "")
+    return result.toString()
+  }
 
-  private fun recursivelyCalculateLines(currentNode: ResolvedDependencyNode): List<String> {
-    if (currentNode in visitedNodes) {
-      return listOf("$currentNode (*)")
-    }
-    visitedNodes.add(currentNode)
-
-    val childrenLines = arrayListOf<List<String>>()
-
-    graph.missingDependencies
+  private fun appendChildren(currentNode: ResolvedDependencyNode, result: StringBuilder, childrenPrefix: String) {
+    val missingDependencies = graph.missingDependencies
       .getOrDefault(currentNode, emptySet())
-      .sortedBy { it.dependency.id }.mapTo(childrenLines) { missingDependency ->
-        listOf("(failed) ${missingDependency.dependency}: ${missingDependency.missingReason}")
-      }
+      .sortedBy { it.dependency.id }
 
     val directEdges = graph.getEdgesFrom(currentNode)
       .sortedWith(
@@ -53,44 +50,37 @@ class ResolvedDependenciesGraphPrettyPrinter(private val graph: ResolvedDependen
           .thenBy { it.to.version }
       )
 
+    val childrenCount = missingDependencies.size + directEdges.size
+    var childIndex = 0
+
+    for (missingDependency in missingDependencies) {
+      val isLastChild = ++childIndex == childrenCount
+      result.append('\n').append(childrenPrefix).append(if (isLastChild) "\\--- " else "+--- ")
+      result.append("(failed) ${missingDependency.dependency}: ${missingDependency.missingReason}")
+    }
+
     for (edge in directEdges) {
-      val childLines = recursivelyCalculateLines(edge.to)
-      val headerLine = buildString {
-        if (edge.dependency.isOptional) {
-          append("(optional) ")
-        }
-        append(childLines.first())
-        if (edge.to.isProductModule) {
-          append(" [product module]")
-        } else if (edge.dependency.isModule) {
-          append(" [declaring module ${edge.dependency.id}]")
-        }
+      val isLastChild = ++childIndex == childrenCount
+      result.append('\n').append(childrenPrefix).append(if (isLastChild) "\\--- " else "+--- ")
+      if (edge.dependency.isOptional) {
+        result.append("(optional) ")
       }
-      val tailLines = childLines.drop(1)
-      childrenLines.add(listOf(headerLine) + tailLines)
-    }
-
-    val result = arrayListOf<String>()
-    // First occurrence carries the aliases; repeated occurrences are printed as plain "id:version (*)".
-    result += currentNode.toStringWithAliases()
-
-    if (childrenLines.isNotEmpty()) {
-      val headingChildren = childrenLines.dropLast(1)
-      val lastChild = childrenLines.last()
-
-      if (headingChildren.isNotEmpty()) {
-        for (headingChild in headingChildren) {
-          val firstLine = headingChild.first().let { "+--- $it" }
-          val tailLines = headingChild.drop(1).map { "|    $it" }
-          result += firstLine
-          result += tailLines
-        }
+      val to = edge.to
+      val alreadyVisited = to in visitedNodes
+      if (alreadyVisited) {
+        result.append("$to (*)")
+      } else {
+        visitedNodes.add(to)
+        result.append(to.toStringWithAliases())
       }
-
-      result += lastChild.first().let { "\\--- $it" }
-      result += lastChild.drop(1).map { "     $it" }
+      if (to.isProductModule) {
+        result.append(" [product module]")
+      } else if (edge.dependency.isModule) {
+        result.append(" [declaring module ${edge.dependency.id}]")
+      }
+      if (!alreadyVisited) {
+        appendChildren(to, result, childrenPrefix + if (isLastChild) "     " else "|    ")
+      }
     }
-
-    return result
   }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/annotation/AnnotationResolver.kt
@@ -18,6 +18,9 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.FullyQualifiedClassName
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import java.util.concurrent.ConcurrentHashMap
 import org.objectweb.asm.Type
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -25,6 +28,11 @@ import org.slf4j.LoggerFactory
 private val LOG: Logger = LoggerFactory.getLogger(AnnotationResolver::class.java)
 
 class AnnotationResolver(val annotation: FullyQualifiedClassName) {
+
+  // Keyed by Resolver identity (weakKeys → identity equality). AnnotationResolver instances are
+  // long-lived singletons while resolvers are per-verification snapshots; weak keys prevent leaks.
+  private val packageInfoAnnotationCache: Cache<Resolver, ConcurrentHashMap<String, Boolean>> =
+    Caffeine.newBuilder().weakKeys().build()
 
   fun resolve(classFileMember: ClassFileMember, classResolver: Resolver, usageLocation: Location?): MemberAnnotation? {
     return resolve(classFileMember, classResolver, ResolutionStack(annotation, usageLocation))
@@ -142,11 +150,14 @@ class AnnotationResolver(val annotation: FullyQualifiedClassName) {
 
   private fun resolveInPackageInfo(classFileMember: ClassFile, classResolver: Resolver): MemberAnnotation? {
     val packageName = classFileMember.containingClassFile.packageName
-    return packageName
-      .takeIf { it.isNotEmpty() }
-      ?.let { classResolver.resolveClassOrNull("$packageName/package-info") }
-      ?.takeIf { it.isDirectlyAnnotatedWith(annotation) }
-      ?.let { AnnotatedViaPackage(packageName, classFileMember, annotation) }
+    if (packageName.isEmpty()) {
+      return null
+    }
+    val perResolverCache = packageInfoAnnotationCache.get(classResolver) { ConcurrentHashMap() }
+    val isPackageAnnotated = perResolverCache.computeIfAbsent(packageName) { pkg ->
+      classResolver.resolveClassOrNull("$pkg/package-info")?.isDirectlyAnnotatedWith(annotation) ?: false
+    }
+    return if (isPackageAnnotated) AnnotatedViaPackage(packageName, classFileMember, annotation) else null
   }
 
   private inline fun ResolutionStack.execute(classFileMember: ClassFileMember, block: (ResolutionStack) -> MemberAnnotation?): MemberAnnotation? {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/overrideOnly/DelegateCallOnOverrideOnlyUsageFilterTest.kt
@@ -88,12 +88,12 @@ class DelegateCallOnOverrideOnlyUsageFilterTest {
 
   private fun ClassNode.loadMethod(methodName: String, methodDescriptor: String): MethodAsm? {
     val classFile = ClassFileAsm(this, TestClasspathFileOrigin)
-    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor }
+    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor } as? MethodAsm
   }
 
   private fun loadMethod(className: FullyQualifiedClassName, methodName: String, methodDescriptor: String): MethodAsm? {
     val classFile = getClassFile(className)
-    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor }
+    return classFile.methods.find { it.name == methodName && it.descriptor == methodDescriptor } as? MethodAsm
   }
 
   private fun getClassFile(className: FullyQualifiedClassName): ClassFileAsm {


### PR DESCRIPTION
API compatibility checks have started timing out against latest trunk IDE, so I have taken a deeper look at the JFR recordings.

Unfortunately most of the issues we have experiences recently all come down to an insanely huge allocation rate with a tendency for these objects to remain alive.

I have taken a look at the most allocation-heavy locations and made several, low-hanging fruit fixes (with the help of some LLM), that I deemed have a low risk of breaking anything.