### PR TITLE
Reapply "Close ZipFile eagerly" to fix Windows file leak

### DIFF
--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipFileHandler.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipFileHandler.kt
@@ -6,10 +6,6 @@ package com.jetbrains.plugin.structure.base.zip
 
 import java.io.File
 import java.io.IOException
-import java.lang.ref.Cleaner
-import java.lang.ref.Reference
-import java.lang.ref.SoftReference
-import java.lang.ref.WeakReference
 import java.nio.file.Path
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
@@ -46,102 +42,15 @@ class ZipFileHandler(private val zipFile: File) : ZipHandler<ZipResource.ZipFile
     zip.getEntry(entryName.toString()) != null
   }
 
-  private var zipFileHolderRef: Reference<ZipFileHolder>? = null
-
-  /**
-   * Either opens new `ZipFile` or reuses existing one stored under [reference][zipFileHolderRef] (WeakReference or SoftReference).
-   * `ZipFileHolder` used to perform `ZipFile` closing once it's no longer reachable from GC roots.
-   *
-   * In this method [reference][zipFileHolderRef] is accessed with synchronization to ensure we won't create more than one ZipFileHolder.
-   *
-   * Three states are possible:
-   * 1. Reference is null, no `ZipFileHolder` is created yet
-   * 2. Reference is not null, but `ZipFileHolder` is null, which means that `ZipFileHolder` was garbage collected
-   * 3. Reference and `ZipFileHolder` are not null, `ZipFileHolder` is still valid
-   *
-   * In the case of the first two, we create a new `ZipFile`, `ZipFileHolder` and store it under [reference][zipFileHolderRef], so it becomes state three.
-   */
-  @Throws(ZipException::class, IOException::class)
-  private fun getActiveHolder(): Pair<ZipFileHolder, Reference<ZipFileHolder>> {
-    val (holder: ZipFileHolder?, ref: Reference<ZipFileHolder>?) = synchronized(this) {
-      val ref = zipFileHolderRef
-      if (ref == null) null to null
-      else ref.get() to ref
-    }
-    if (holder != null) {
-      return holder to ref!!
-    }
-    synchronized(this) {
-      var ref = zipFileHolderRef
-      var holder = ref?.get()
-      if (holder != null) {
-        return holder to ref!!
-      }
-      holder = ZipFileHolder(ZipFile(zipFile))
-      ref = createReference(holder)
-      zipFileHolderRef = ref
-      return holder to ref
-    }
-  }
-
-  companion object {
-    private val refType = System.getProperty("intellij.structure.zip.handler.references", "weak")
-    private fun createReference(holder: ZipFileHolder): Reference<ZipFileHolder> {
-      return when (refType) {
-        "weak" -> WeakReference(holder)
-        "soft" -> SoftReference(holder)
-        else -> WeakReference(holder)
-      }
-    }
-  }
-
   private inline fun <R> withZip(block: (ZipFile) -> R): R {
     return try {
-      val (holder, ref) = getActiveHolder()
-      val result = block.invoke(holder.zipFile)
-
-      //region Tricks to keep both ZipFileHolder and reference alive, so it won't be garbage collected
-      // It's OK to access zipFileHolderRef without synchronization here.
-      // Since `ref` and `holder` are accessible, `zipFileHolderRef` cannot change
-      if (ref !== zipFileHolderRef) {
-        throw IllegalStateException("Reference to ZipFileHolder was changed mid-execution")
+      ZipFile(zipFile).use { zip ->
+        block.invoke(zip)
       }
-      val holder2 = zipFileHolderRef?.get()
-      if (holder2 !== holder) {
-        throw IllegalStateException("ZipFileHolder was changed mid-execution")
-      }
-      //endregion
-
-      result
     } catch (e: ZipException) {
       throw MalformedZipArchiveException(zipFile, e)
     } catch (e: IOException) {
       throw ZipArchiveIOException(zipFile, e)
     }
   }
-}
-
-/**
- * Holder for ZipFile. Although it implements AutoCloseable, we don't use that.
- * Once there are no more references to ZipFileHolder, ZipFile will be closed by Cleaner
- */
-private class ZipFileHolder(zipFile: ZipFile) : AutoCloseable {
-  private val state: State = State(zipFile)
-  private val cleanable: Cleaner.Cleanable = CLEANER.register(this, state)
-
-  companion object {
-    private val CLEANER = Cleaner.create()
-  }
-
-  class State(val zipFile: ZipFile) : Runnable {
-    override fun run() {
-      zipFile.close()
-    }
-  }
-
-  override fun close() {
-    cleanable.clean()
-  }
-
-  val zipFile get() = state.zipFile
 }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/zip/ZipHandlerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/zip/ZipHandlerTest.kt
@@ -13,6 +13,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.nio.file.Path
+import java.nio.file.Files
 
 @RunWith(Parameterized::class)
 class ZipHandlerTest<T : ZipResource>(private val type: ZipHandlerType) {
@@ -48,6 +49,20 @@ class ZipHandlerTest<T : ZipResource>(private val type: ZipHandlerType) {
     assertTrue(zipHandler.containsEntry("META-INF/plugin.xml"))
     assertTrue(zipHandler.containsEntry("intellij.example.xml"))
     assertFalse(zipHandler.containsEntry("nonexistent.txt"))
+  }
+
+  @Test
+  fun `handler releases archive file after use`() {
+    val jarPath = buildZipFile(createJar()) {
+      dir("META-INF") {
+        file("plugin.xml", "<idea-plugin />")
+      }
+    }
+
+    val zipHandler = newZipHandler(jarPath)
+    assertTrue(zipHandler.containsEntry("META-INF/plugin.xml"))
+
+    Files.delete(jarPath)
   }
 
   private fun newZipHandler(zipPath: Path) = when (type) {


### PR DESCRIPTION
There was a very significant performance optimization that replaced deterministic ZIP closing with registering Cleaners that do it based on GC heuristics, making ZIP file reuse possible.

Unfortunately on windows it introduced some problems, but so did reverting it - the latter caused CI failures, so we decided to temporarily rather have the windows issues.


Now we have managed to get the CI to a more stable and performant state (again, thanks to @VladRassokhin ), so we can live with the increased runtime that reapplying this change causes -- the long CI jobs are still faster now than ever before.