### PR TITLE
MP-2974 Suppress class-not-found problems from transitive optional dependencies

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/ClassReachabilityAnalysis.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/analysis/ClassReachabilityAnalysis.kt
@@ -107,19 +107,43 @@ fun buildClassReachabilityGraph(
 
   val missingOptionalDependencies = dependenciesGraph.getDirectMissingDependencies().filter { it.dependency.isOptional }
   for (missingOptionalDependency in missingOptionalDependencies) {
-    val optionalPlugin = idePlugin.optionalDescriptors.find { it.dependency == missingOptionalDependency.dependency }?.optionalPlugin
+    val dependencyId = missingOptionalDependency.dependency.id
+    val optionalPlugins = idePlugin.findOptionalPluginsByDependencyId(dependencyId)
     val modules = idePlugin.modulesDescriptors
-      .filter { it.dependencies.map { it.id }.contains(missingOptionalDependency.dependency.id) }
+      .filter { it.dependencies.map { it.id }.contains(dependencyId) }
       .map { it.module }
-    (if (optionalPlugin != null) modules + optionalPlugin else modules).forEach {
-      val optionalClasses = PluginXmlUtil.getAllClassesReferencedFromXml(it)
-      for (className in optionalClasses) {
-        reachabilityGraph.markClass(className, ReachabilityGraph.ReachabilityMark.OPTIONAL_PLUGIN)
-      }
+    val optionalClasses = hashSetOf<ClassName>()
+    modules.forEach { optionalClasses += PluginXmlUtil.getAllClassesReferencedFromXml(it) }
+    optionalPlugins.forEach { optionalClasses += it.collectClassesReferencedFromXmlRecursively() }
+    for (className in optionalClasses) {
+      reachabilityGraph.markClass(className, ReachabilityGraph.ReachabilityMark.OPTIONAL_PLUGIN)
     }
   }
 
   return reachabilityGraph
+}
+
+private fun IdePlugin.findOptionalPluginsByDependencyId(dependencyId: String): List<IdePlugin> {
+  val result = arrayListOf<IdePlugin>()
+  for (optionalDescriptor in optionalDescriptors) {
+    if (optionalDescriptor.dependency.id == dependencyId) {
+      result += optionalDescriptor.optionalPlugin
+    }
+    result += optionalDescriptor.optionalPlugin.findOptionalPluginsByDependencyId(dependencyId)
+  }
+  return result
+}
+
+private fun IdePlugin.collectClassesReferencedFromXmlRecursively(): Set<ClassName> {
+  val classes = hashSetOf<ClassName>()
+  classes += PluginXmlUtil.getAllClassesReferencedFromXml(this)
+  for (optionalDescriptor in optionalDescriptors) {
+    classes += optionalDescriptor.optionalPlugin.collectClassesReferencedFromXmlRecursively()
+  }
+  for (moduleDescriptor in modulesDescriptors) {
+    classes += PluginXmlUtil.getAllClassesReferencedFromXml(moduleDescriptor.module)
+  }
+  return classes
 }
 
 private fun buildTypeGraph(pluginResolver: Resolver): TypeGraph {


### PR DESCRIPTION
## Problem

[MP-2974] Unresolved **optional** dependencies must not be highlighted as errors.

The verifier already suppresses `ClassNotFoundProblem`s that originate from a plugin's optional parts when the triggering optional dependency is missing (this is expected — the code is only loaded when the optional dependency is present). However, this suppression only worked for **directly declared, top-level** optional descriptors. For **transitive / nested** optional dependencies the analysis silently did nothing, so those class-not-found problems leaked as errors even though the missing dependency is optional.

## Root cause

`buildClassReachabilityGraph` (`ClassReachabilityAnalysis.kt`) marks the classes of the optional parts so that problems inside them can be recognized as expected. It had two limitations:

1. **Non-recursive lookup** — it only inspected `idePlugin.optionalDescriptors` (the top level). An optional descriptor nested inside another optional descriptor (a transitive optional dependency) was never found, so its classes were not marked as optional.
2. **Matching by object equality** — descriptors were matched with `descriptor.dependency == missingDependency.dependency`. Module dependencies are normalized by the graph builder into a proxy type that is not object-equal to the descriptor's original dependency, so module optional dependencies (e.g. `com.intellij.modules.clion.cmake`) never matched.

## Fix

- Search the whole optional-descriptor tree **recursively**.
- Match descriptors **by dependency id** instead of object equality.
- Collect referenced classes **recursively** from nested optional and module descriptors (`PluginXmlUtil.getAllClassesReferencedFromXml` does not descend into nested descriptors on its own).

Only `ClassReachabilityAnalysis.kt` changes; the guard in `PluginVerifier` is untouched, since `getDirectMissingDependencies()` already contains the (flattened) transitive optional dependencies.

## Scope note

This addresses the case where an unresolved optional dependency produces actual **compatibility errors** (`ClassNotFoundProblem`). It does not change how a missing optional dependency is rendered in the dependency tree (the informational `(failed) (optional)` line), which is a separate presentation concern.
