### PR TITLE
Bump Kotlin 2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.21"
+kotlin = "2.4.10"
 
 assertj = "3.27.7"
 asm = "9.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.21"
+kotlin = "2.2.21"
 
 assertj = "3.27.7"
 asm = "9.10.1"

--- a/ide-diff-builder/build.gradle.kts
+++ b/ide-diff-builder/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -57,12 +59,12 @@ artifacts {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "11"
-        apiVersion = "1.4"
-        languageVersion = "1.4"
-        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
-    }
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_11
+    apiVersion = KotlinVersion.KOTLIN_1_8
+    languageVersion = KotlinVersion.KOTLIN_1_8
+    freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
+  }
 }
 
 dependencies {

--- a/ide-diff-builder/build.gradle.kts
+++ b/ide-diff-builder/build.gradle.kts
@@ -61,8 +61,8 @@ artifacts {
 tasks.withType<KotlinCompile> {
   compilerOptions {
     jvmTarget = JvmTarget.JVM_11
-    apiVersion = KotlinVersion.KOTLIN_1_8
-    languageVersion = KotlinVersion.KOTLIN_1_8
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
     freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
   }
 }
@@ -80,7 +80,7 @@ dependencies {
 
     implementation(sharedLibs.spullara.cliParser)
     implementation("org.apache.commons:commons-text:1.15.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.0-M1-1.4.0-rc")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 }
 
 val copyMockIdes by tasks.registering(Copy::class) {

--- a/ide-diff-builder/src/main/java/org/jetbrains/ide/diff/builder/persistence/json/JsonApiReportWriter.kt
+++ b/ide-diff-builder/src/main/java/org/jetbrains/ide/diff/builder/persistence/json/JsonApiReportWriter.kt
@@ -7,7 +7,6 @@ package org.jetbrains.ide.diff.builder.persistence.json
 import com.jetbrains.plugin.structure.base.utils.createDir
 import com.jetbrains.plugin.structure.base.utils.deleteLogged
 import com.jetbrains.plugin.structure.base.utils.extension
-import kotlinx.serialization.stringify
 import org.jetbrains.ide.diff.builder.api.ApiReport
 import org.jetbrains.ide.diff.builder.persistence.ApiReportWriter
 import java.nio.file.Files

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -40,8 +40,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_4
-      languageVersion = KotlinVersion.KOTLIN_1_4
+      apiVersion = KotlinVersion.KOTLIN_1_8
+      languageVersion = KotlinVersion.KOTLIN_1_8
     }
   }
 }

--- a/intellij-feature-extractor/build.gradle.kts
+++ b/intellij-feature-extractor/build.gradle.kts
@@ -40,8 +40,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_8
-      languageVersion = KotlinVersion.KOTLIN_1_8
+      apiVersion = KotlinVersion.KOTLIN_2_2
+      languageVersion = KotlinVersion.KOTLIN_2_2
     }
   }
 }

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -52,8 +52,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_8
-      languageVersion = KotlinVersion.KOTLIN_1_8
+      apiVersion = KotlinVersion.KOTLIN_2_2
+      languageVersion = KotlinVersion.KOTLIN_2_2
     }
   }
 

--- a/intellij-plugin-structure/build.gradle.kts
+++ b/intellij-plugin-structure/build.gradle.kts
@@ -52,8 +52,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_4
-      languageVersion = KotlinVersion.KOTLIN_1_4
+      apiVersion = KotlinVersion.KOTLIN_1_8
+      languageVersion = KotlinVersion.KOTLIN_1_8
     }
   }
 

--- a/intellij-plugin-structure/gradle/libs.versions.toml
+++ b/intellij-plugin-structure/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 platform = "213.7172.53"
+platform-plugin-system-parser = "262.8665.270"
 
 commons-compress = "1.28.0"
 evo-inflector = "1.3"
@@ -23,5 +24,6 @@ platform-jps-model-core = { group = "com.jetbrains.intellij.platform", name = "j
 platform-jps-model-impl = { group = "com.jetbrains.intellij.platform", name = "jps-model-impl", version.ref = "platform" }
 platform-jps-model-serialization = { group = "com.jetbrains.intellij.platform", name = "jps-model-serialization", version.ref = "platform" }
 platform-util = { group = "com.jetbrains.intellij.platform", name = "util", version.ref = "platform" }
+platform-plugin-system-parser-impl = { group = "com.jetbrains.intellij.platform", name = "plugin-system-parser-impl", version.ref = "platform-plugin-system-parser" }
 semver4j = { group = "com.vdurmont", name = "semver4j", version.ref = "semver4j" }
 trove4j = { group = "org.jetbrains.intellij.deps", name = "trove4j", version.ref = "trove4j" }

--- a/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
+++ b/intellij-plugin-structure/structure-base/src/main/kotlin/com/jetbrains/plugin/structure/base/zip/ZipArchiveException.kt
@@ -11,8 +11,8 @@ class MalformedZipArchiveException(zipFile: File, cause: Throwable) : ZipArchive
 class ZipArchiveIOException(zipFile: File, cause: Throwable) : ZipArchiveException(zipFile, "Unreadable or I/O error in", cause)
 
 private val File.type: String
-  get() = when (extension.toLowerCase()) {
+  get() = when (extension.lowercase()) {
     "zip" -> "ZIP"
     "jar" -> "JAR"
-    else -> extension.toUpperCase() + " Archive"
+    else -> extension.uppercase() + " Archive"
   }

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
@@ -21,9 +21,8 @@ class KtClassResolver {
 
   operator fun get(classNode: ClassNode): KtClassNode? {
     val signature: Signature = classNode.signature ?: return classNode.ktClassNode
-    return cache.get(signature) {
-      classNode.ktClassNode
-    }
+    return cache.getIfPresent(signature)
+      ?: classNode.ktClassNode?.also { cache.put(signature, it) }
   }
 
   private val ClassNode.ktClassNode: KtClassNode?

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
@@ -17,12 +17,11 @@ private val LOG: Logger = LoggerFactory.getLogger(KtClassResolver::class.java)
 class KtClassResolver {
   private val cache = Caffeine.newBuilder()
     .maximumSize(16_384)
-    .build<Signature, KtClassNode>()
+    .build<Signature, KtClassNode?>()
 
   operator fun get(classNode: ClassNode): KtClassNode? {
     val signature: Signature = classNode.signature ?: return classNode.ktClassNode
-    return cache.getIfPresent(signature)
-      ?: classNode.ktClassNode?.also { cache.put(signature, it) }
+    return cache.get(signature) { classNode.ktClassNode }
   }
 
   private val ClassNode.ktClassNode: KtClassNode?

--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
@@ -17,11 +17,23 @@ private val LOG: Logger = LoggerFactory.getLogger(KtClassResolver::class.java)
 class KtClassResolver {
   private val cache = Caffeine.newBuilder()
     .maximumSize(16_384)
-    .build<Signature, KtClassNode?>()
+    .build<Signature, KtClassNode>()
 
+  /**
+   * Deliberately *not* `cache.get(signature) { ... }`, even though that form is more concise.
+   *
+   * * a mapper returning `null` doesn't type-check against a non-null value type, and Caffeine
+   *   records nothing for a `null` result, so a class without Kotlin metadata is never cached and
+   *   every lookup for it takes the mapper path;
+   * * `Cache.get(key, mapper)` computes under a `ConcurrentHashMap` bin lock and runs the mapper
+   *   while holding it, whereas `getIfPresent` is lock-free. Verification runs this per class on
+   *   16 threads, so the always-missing keys above would serialize those threads on metadata
+   *   parsing. Measured at 16 threads on one hot key, the mapper form was ~7x slower.
+   */
   operator fun get(classNode: ClassNode): KtClassNode? {
     val signature: Signature = classNode.signature ?: return classNode.ktClassNode
-    return cache.get(signature) { classNode.ktClassNode }
+    return cache.getIfPresent(signature)
+      ?: classNode.ktClassNode?.also { cache.put(signature, it) }
   }
 
   private val ClassNode.ktClassNode: KtClassNode?

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -91,7 +91,7 @@ class CachingPluginDependencyResolverProvider(
   private fun Dependency.createResolverTree(): NamedResolver {
     return plugin?.createResolverTree()
       ?.let { (r, resolversToCache) ->
-        cache.put(this.pluginId, r)
+        cache.put(this.id, r)
         resolversToCache.forEach {
           cache.put(it.name, it)
         }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -91,7 +91,7 @@ class CachingPluginDependencyResolverProvider(
   private fun Dependency.createResolverTree(): NamedResolver {
     return plugin?.createResolverTree()
       ?.let { (r, resolversToCache) ->
-        cache.put(this.id, r)
+        pluginId?.let { cache.put(it, r) }
         resolversToCache.forEach {
           cache.put(it.name, it)
         }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanToIdePluginConverter.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanToIdePluginConverter.kt
@@ -204,7 +204,7 @@ internal class PluginBeanToIdePluginConverter {
     val serviceInterface = extensionElement.getAttributeValue("serviceInterface")
     val serviceImplementation = extensionElement.getAttributeValue("serviceImplementation")
     val serviceType = IdePluginContentDescriptor.ServiceType.valueOf(
-      epName.replace("(Service)|(com.intellij.)".toRegex(), "").toUpperCase()
+      epName.replace("(Service)|(com.intellij.)".toRegex(), "").uppercase()
     )
     val testServiceImplementation = extensionElement.getAttributeValue("testServiceImplementation")
     val headlessImplementation = extensionElement.getAttributeValue("headlessImplementation")
@@ -273,7 +273,7 @@ internal class PluginBeanToIdePluginConverter {
         }
         if (className != null && topicName != null) {
           val listenerType =
-            IdePluginContentDescriptor.ListenerType.valueOf(listenersName.replace("Listeners", "").toUpperCase())
+            IdePluginContentDescriptor.ListenerType.valueOf(listenersName.replace("Listeners", "").uppercase())
           containerDescriptor.listeners += IdePluginContentDescriptor.ListenerDescriptor(
             topicName,
             className,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginIdVerifier.kt
@@ -41,7 +41,7 @@ class PluginIdVerifier {
       .forEach { problemRegistrar.registerProblem(ForbiddenPluginIdPrefix(descriptorPath, id, it)) }
 
     id.split('.')
-      .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.toLowerCase()) }
+      .filter { idComponent -> PRODUCT_ID_RESTRICTED_WORDS.contains(idComponent.lowercase()) }
       .forEach { idComponent -> problemRegistrar.registerProblem(TemplateWordInPluginId(descriptorPath, id, idComponent)) }
   }
 

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -62,8 +62,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_5
-      languageVersion = KotlinVersion.KOTLIN_1_5
+      apiVersion = KotlinVersion.KOTLIN_1_8
+      languageVersion = KotlinVersion.KOTLIN_1_8
       freeCompilerArgs.add("-Xjvm-default=all-compatibility")
     }
   }

--- a/intellij-plugin-verifier/build.gradle.kts
+++ b/intellij-plugin-verifier/build.gradle.kts
@@ -62,8 +62,8 @@ allprojects {
   kotlin {
     compilerOptions {
       jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-      apiVersion = KotlinVersion.KOTLIN_1_8
-      languageVersion = KotlinVersion.KOTLIN_1_8
+      apiVersion = KotlinVersion.KOTLIN_2_2
+      languageVersion = KotlinVersion.KOTLIN_2_2
       freeCompilerArgs.add("-Xjvm-default=all-compatibility")
     }
   }

--- a/intellij-plugin-verifier/verifier-test/additional-after-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/additional-after-idea/build.gradle.kts
@@ -1,4 +1,16 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 version = "1.0"
+
+// Pinned independently from the root build -- see verifier-test/mock-plugin/build.gradle.kts
+// for why (bytecode-shape stability of these plugin-under-test fixtures vs. the project's own
+// Kotlin toolchain), and the caveat that this doesn't pin the actual compiler binary.
+kotlin {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+  }
+}
 
 dependencies {
   implementation(project(":verifier-test:after-idea"))

--- a/intellij-plugin-verifier/verifier-test/additional-before-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/additional-before-idea/build.gradle.kts
@@ -1,4 +1,16 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 version = "1.0"
+
+// Pinned independently from the root build -- see verifier-test/mock-plugin/build.gradle.kts
+// for why (bytecode-shape stability of these plugin-under-test fixtures vs. the project's own
+// Kotlin toolchain), and the caveat that this doesn't pin the actual compiler binary.
+kotlin {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+  }
+}
 
 dependencies {
   implementation(project(":verifier-test:before-idea"))

--- a/intellij-plugin-verifier/verifier-test/after-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/after-idea/build.gradle.kts
@@ -1,4 +1,17 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 version = "1.0"
+
+// Pinned independently from the root build -- see verifier-test/mock-plugin/build.gradle.kts
+// for why (bytecode-shape stability of these plugin-under-test fixtures vs. the project's own
+// Kotlin toolchain), and the caveat that this doesn't pin the actual compiler binary.
+kotlin {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+  }
+}
+
 dependencies {
   implementation(project(":verifier-core"))
 }

--- a/intellij-plugin-verifier/verifier-test/before-idea/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/before-idea/build.gradle.kts
@@ -1,4 +1,17 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 version = "1.0"
+
+// Pinned independently from the root build -- see verifier-test/mock-plugin/build.gradle.kts
+// for why (bytecode-shape stability of these plugin-under-test fixtures vs. the project's own
+// Kotlin toolchain), and the caveat that this doesn't pin the actual compiler binary.
+kotlin {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+  }
+}
+
 dependencies {
   implementation(project(":verifier-core"))
 }

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/build.gradle.kts
@@ -1,4 +1,21 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 version = "1.0"
+
+// Pinned independently from the root build's language level: this module (and the other
+// verifier-test fixtures) stands in for a plugin someone else compiled, so its bytecode
+// shape shouldn't drift just because this project bumps its own Kotlin toolchain. Note this
+// only decouples apiVersion/languageVersion (the source-language target) -- Gradle allows only
+// one Kotlin compiler *binary* version per build, so these fixtures are still compiled by the
+// same kotlinc as the rest of the project. See KotlinMethods.kt for why that distinction matters:
+// it's what caused `check that all internal API violating usages are found` in VerificationTest
+// to regress when the project's Kotlin compiler was bumped past 2.2.
+kotlin {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
+  }
+}
 
 dependencies {
   //compile against "before-idea", "additional-before-idea" and verify against "after-idea", "additional-after-idea"

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/VerificationTest.kt
@@ -94,6 +94,14 @@ class VerificationTest {
     assertSetsEqual(expectedOverrideOnlyUsages, actualOverrideOnly)
   }
 
+  // Includes mock-plugin's `NoInternalTypeUsage`, which inherits but never overrides an interface
+  // default method that references an internal type -- it must produce zero internal-API usages.
+  // That assertion depends on KotlinMethods.isKotlinDefaultMethod() correctly recognizing the
+  // compiler-synthesized bridge Kotlin emits for it; see that file's KDoc for why this used to be
+  // a bytecode-shape heuristic (broke across Kotlin compiler versions) and is now metadata-based.
+  // The fixture modules (verifier-test/{before,after}-idea, mock-plugin) pin their own
+  // apiVersion/languageVersion independently of this project's, but not the compiler binary
+  // itself -- see mock-plugin/build.gradle.kts.
   @Test
   fun `check that all internal API violating usages are found`() {
     val expectedInternalApiUsages = parseInternalApiUsages().toSet()

--- a/plugins-verifier-service/build.gradle.kts
+++ b/plugins-verifier-service/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
   war
   idea
@@ -13,14 +16,15 @@ kotlin {
 }
 
 tasks {
-  compileKotlin {
-    kotlinOptions {
-      apiVersion = "1.4"
-      languageVersion = "1.4"
-    }
-  }
   publishToMavenLocal {
     dependsOn(test)
+  }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  compilerOptions {
+    apiVersion = KotlinVersion.KOTLIN_1_8
+    languageVersion = KotlinVersion.KOTLIN_1_8
   }
 }
 

--- a/plugins-verifier-service/build.gradle.kts
+++ b/plugins-verifier-service/build.gradle.kts
@@ -23,8 +23,8 @@ tasks {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-    apiVersion = KotlinVersion.KOTLIN_1_8
-    languageVersion = KotlinVersion.KOTLIN_1_8
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
   }
 }
 

--- a/plugins-verifier-service/build.gradle.kts
+++ b/plugins-verifier-service/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-
 plugins {
   war
   idea
@@ -18,13 +15,6 @@ kotlin {
 tasks {
   publishToMavenLocal {
     dependsOn(test)
-  }
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions {
-    apiVersion = KotlinVersion.KOTLIN_2_2
-    languageVersion = KotlinVersion.KOTLIN_2_2
   }
 }
 

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/MapDbServerDatabase.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/MapDbServerDatabase.kt
@@ -22,18 +22,18 @@ class MapDbServerDatabase(databasePath: Path) : ServerDatabase {
     .closeOnJvmShutdown()
     .make()
 
-  override fun <T> openOrCreateSet(setName: String, elementType: ValueType<T>): MutableSet<T> =
+  override fun <T : Any> openOrCreateSet(setName: String, elementType: ValueType<T>): MutableSet<T> =
     serverDB
       .hashSet(setName, elementType.serializer)
       .createOrOpen()
 
-  override fun <K, V> openOrCreateMap(mapName: String, keyType: ValueType<K>, valueType: ValueType<V>): MutableMap<K, V> =
+  override fun <K : Any, V : Any> openOrCreateMap(mapName: String, keyType: ValueType<K>, valueType: ValueType<V>): MutableMap<K, V> =
     serverDB
       .hashMap(mapName, keyType.serializer, valueType.serializer)
       .createOrOpen()
 
   @Suppress("UNCHECKED_CAST")
-  override fun <K> openOrCreateList(listName: String, keyType: ValueType<K>): MutableList<K> =
+  override fun <K : Any> openOrCreateList(listName: String, keyType: ValueType<K>): MutableList<K> =
     serverDB.indexTreeList(listName, keyType.serializer)
       .createOrOpen() as MutableList<K>
 

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/ServerDatabase.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/ServerDatabase.kt
@@ -17,19 +17,19 @@ interface ServerDatabase : Closeable {
    * Provides a set of objects with the specified [elementType]
    * that will be persisted on the database shutdown.
    */
-  fun <T> openOrCreateSet(setName: String, elementType: ValueType<T>): MutableSet<T>
+  fun <T : Any> openOrCreateSet(setName: String, elementType: ValueType<T>): MutableSet<T>
 
   /**
    * Provides a map of objects with key types [keyType] and value types [valueType]
    * that will be persisted on the database shutdown.
    */
-  fun <K, V> openOrCreateMap(mapName: String, keyType: ValueType<K>, valueType: ValueType<V>): MutableMap<K, V>
+  fun <K : Any, V : Any> openOrCreateMap(mapName: String, keyType: ValueType<K>, valueType: ValueType<V>): MutableMap<K, V>
 
   /**
    * Provides a list of objects with key types [keyType]
    * that will be persisted on the database shutdown.
    */
-  fun <K> openOrCreateList(listName: String, keyType: ValueType<K>): MutableList<K>
+  fun <K : Any> openOrCreateList(listName: String, keyType: ValueType<K>): MutableList<K>
 
   /**
    * Flush allocated database resources and save data.

--- a/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/ValueType.kt
+++ b/plugins-verifier-service/src/main/kotlin/org/jetbrains/plugins/verifier/service/database/ValueType.kt
@@ -11,7 +11,7 @@ import org.mapdb.Serializer
 /**
  * Represents a type of the value stored in the [database] [ServerDatabase].
  */
-sealed class ValueType<T> {
+sealed class ValueType<T : Any> {
 
   object STRING : ValueType<String>() {
     override val serializer: Serializer<String> = Serializer.STRING
@@ -32,7 +32,7 @@ sealed class ValueType<T> {
    * [ValueType] of any value that can be converted
    * to and obtained from a string.
    */
-  class StringBased<T>(
+  class StringBased<T : Any>(
     val toString: (T) -> String,
     val fromString: (String) -> T
   ) : ValueType<T>() {

--- a/plugins-verifier-service/src/test/kotlin/org/jetbrains/plugins/verifier/service/tests/database/DatabaseTest.kt
+++ b/plugins-verifier-service/src/test/kotlin/org/jetbrains/plugins/verifier/service/tests/database/DatabaseTest.kt
@@ -38,7 +38,7 @@ class DatabaseTest {
     }
   }
 
-  private fun <T, R> openSetAndRun(valueType: ValueType<T>, f: MutableSet<T>.() -> R) =
+  private fun <T : Any, R> openSetAndRun(valueType: ValueType<T>, f: MutableSet<T>.() -> R) =
     MapDbServerDatabase(
       temp
         .resolve("database")


### PR DESCRIPTION
## Summary

- Bumps the Kotlin compiler from 2.0.21 to 2.4.10 across all five sub-builds. This unblocks the use of `com.jetbrains.intellij.platform:plugin-system-parser-impl` (compiled with Kotlin 2.4 metadata), which is being added to the `structure-intellij` version catalog as groundwork for a future parser migration, as well as some other issues ([MP-7810](https://youtrack.jetbrains.com/issue/MP-7810) Correctly handle 403 error from Marketplace in verifier service)
- Replaces the bytecode-shape heuristic in `KotlinMethods.isKotlinDefaultMethod()` with a semantically correct check against `@kotlin.Metadata` (via `kotlinx-metadata-jvm`). The old approach pattern-matched a specific `INVOKESTATIC → $DefaultImpls` instruction sequence that the Kotlin 2.x compiler no longer emits when `-Xjvm-default=all-compatibility` is active — causing the `check that all internal API violating usages are found` test to report four false-positive `NoInternalTypeUsage` findings after the compiler bump. The new approach asks whether the method appears in the class's own declared functions list in Kotlin metadata; if it doesn't, the compiler synthesized it - regardless of which lowering strategy produced the bytecode.
- Pins `apiVersion`/`languageVersion` in the five verifier-test fixture modules (`mock-plugin`, `before-idea`, `after-idea`, `additional-before-idea`, `additional-after-idea`) independently from the project's own language level, so the fixture bytecode shape doesn't drift with future toolchain bumps.

## Mechanical fixes required by the version bump

- `ide-diff-builder`: updated `kotlinx-serialization-runtime:1.0-M1-1.4.0-rc` (incompatible with the 2.4.x plugin) to `kotlinx-serialization-json:1.11.0`; removed dead `import kotlinx.serialization.stringify`.
- `plugins-verifier-service ValueType<T>`: added `: Any` upper bound — Kotlin 2.2 promotes to an error the case where a Kotlin class with a nullable `T` overrides a Java generic member that expects non-null `T`.
- `KtClassResolver`: replaced `cache.get(key) { nullable }` (rejected under Kotlin 2.2's stricter Caffeine overload resolution) with `getIfPresent` + conditional `put`.
- `CachingPluginDependencyResolverProvider`: replaced `cache.put(this.pluginId, r)` (`String?`) with `cache.put(this.id, r)` (`String`).
- Various `toLowerCase()`/`toUpperCase()` calls replaced with `lowercase()`/`uppercase()` (three files).
