### PR TITLE
MP-3742: regression test confirming content-module dependency resolution is fixed

### DIFF
--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/ContentModuleDependencyResolutionTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/ContentModuleDependencyResolutionTest.kt
@@ -1,0 +1,104 @@
+package com.jetbrains.pluginverifier.tests.dependencies
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.ide.IdeManager
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.tests.BasePluginTest
+import com.jetbrains.pluginverifier.tests.VerificationRunner
+import com.jetbrains.pluginverifier.tests.mocks.buildIdePlugin
+import org.junit.Test
+
+/**
+ * Reproduces the false-positive dependency resolution reported in
+ * [MP-3742](https://youtrack.jetbrains.com/issue/MP-3742): a plugin whose content module
+ * (e.g. `intellij.selenium.docker`) is misreported as an unresolved "missing mandatory
+ * dependency" because content-module descriptors were not fed into [IdePlugin.definedModules],
+ * and a `com.intellij.modules.*` marker exposed only via an IDE content module (e.g.
+ * `com.intellij.modules.ultimate`) was likewise unresolvable.
+ *
+ * Both cases were fixed by "Support content modules descriptors" (843606da4, 2023-02-21) and
+ * hardened by later work (e.g. #1391, #1366, #1347). This test guards against a regression.
+ */
+class ContentModuleDependencyResolutionTest : BasePluginTest() {
+
+  private fun buildCoreIdeWithContentModule(): Ide {
+    val ideaDirectory = buildDirectory(temporaryFolder.newFolder("idea").toPath()) {
+      file("build.txt", "IU-213.1")
+      dir("lib") {
+        zip("idea.jar") {
+          dir("META-INF") {
+            file("plugin.xml") {
+              """
+                <idea-plugin>
+                  <id>com.intellij</id>
+                  <name>IDEA CORE</name>
+                  <version>1.0</version>
+                  <module value="com.intellij.modules.platform"/>
+                  <content>
+                    <module name="intellij.platform.ultimate"/>
+                  </content>
+                </idea-plugin>
+                """.trimIndent()
+            }
+          }
+          file("intellij.platform.ultimate.xml") {
+            """
+              <idea-plugin>
+                <module value="com.intellij.modules.ultimate"/>
+              </idea-plugin>
+              """.trimIndent()
+          }
+        }
+      }
+    }
+    return IdeManager.createManager().createIde(ideaDirectory)
+  }
+
+  private fun buildSeleniumLikePlugin(): IdePlugin =
+    pluginJarPath.buildIdePlugin {
+      dir("META-INF") {
+        file("plugin.xml") {
+          """
+            <idea-plugin>
+              <id>SeleniumUITesting</id>
+              <name>Selenium UI Testing</name>
+              <version>1.0</version>
+              <vendor email="vendor.com" url="url">vendor</vendor>
+              <description>this description is looooooooooong enough</description>
+              <change-notes>these change-notes are looooooooooong enough</change-notes>
+              <idea-version since-build="213.1" until-build="231.1"/>
+              <depends>com.intellij.modules.ultimate</depends>
+              <content>
+                <module name="intellij.selenium.docker"/>
+              </content>
+              <dependencies>
+                <module name="intellij.selenium.docker"/>
+              </dependencies>
+            </idea-plugin>
+            """.trimIndent()
+        }
+      }
+      file("intellij.selenium.docker.xml") {
+        """
+          <idea-plugin>
+          </idea-plugin>
+          """.trimIndent()
+      }
+    }
+
+  @Test
+  fun `plugin's own content module and IDE content-module-exposed synthetic module both resolve`() {
+    val ide = buildCoreIdeWithContentModule()
+    val plugin = buildSeleniumLikePlugin()
+
+    val verificationResult = VerificationRunner().runPluginVerification(ide, plugin)
+    check(verificationResult is PluginVerificationResult.Verified) {
+      "Expected Verified result, got $verificationResult"
+    }
+    assertEmpty("Compatibility problems", verificationResult.compatibilityProblems)
+    assertEmpty("Direct Missing Mandatory Dependencies", verificationResult.directMissingMandatoryDependencies)
+  }
+}


### PR DESCRIPTION
## Summary

[MP-3742](https://youtrack.jetbrains.com/issue/MP-3742) reported that the verifier misreported the Selenium UI Testing plugin's own content modules (`intellij.selenium.docker`/`python`/`jvm`) and IDE-exposed synthetic markers (`com.intellij.modules.json`/`ultimate`) as unresolved "missing mandatory dependencies".

This was already fixed by "Support content modules descriptors" (843606da4, 2023-02-21) — before that change, `<content>` blocks were parsed but never fed into `IdePlugin.definedModules`, so a plugin's own content-module-declared modules (and an IDE's content-module-exposed `com.intellij.modules.*` markers) looked externally unresolved even though they were self-provided/IDE-bundled. Follow-up hardening continued for years afterward (#1391, #1366, #1347, #1423, etc).

This ticket was never closed on YouTrack despite the underlying bug being fixed.

- No production code changes; adds a regression test reproducing the reported shape (plugin's own content module + IDE content-module-exposed `com.intellij.modules.ultimate`) and confirms it resolves cleanly with no missing mandatory dependencies on current master.
- Verified the assertion is meaningful, not vacuous, by temporarily breaking the dependency reference and confirming the test fails as expected, then restoring it.

## Test plan
- [x] `./gradlew ":intellij-plugin-verifier:verifier-test:test" --tests "com.jetbrains.pluginverifier.tests.dependencies.ContentModuleDependencyResolutionTest"` passes on current master
- [x] Confirmed the test fails when the dependency target doesn't match a defined module (negative control)
