### PR TITLE
MP-3345: Consider ignoring invocations and overriding of deprecated Kotlin default methods

### DIFF
--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/filter/CompositeApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/filter/CompositeApiUsageFilter.kt
@@ -1,6 +1,12 @@
 package com.jetbrains.pluginverifier.verifiers.filter
 
+import com.jetbrains.pluginverifier.results.reference.ClassReference
+import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
@@ -10,6 +16,29 @@ class CompositeApiUsageFilter(private val apiUsageFilters: List<ApiUsageFilter>)
   override fun allow(invokedMethod: Method, invocationInstruction: AbstractInsnNode, callerMethod: Method, context: VerificationContext): Boolean {
     return apiUsageFilters.any {
       it.allow(invokedMethod, invocationInstruction, callerMethod, context)
+    }
+  }
+
+  override fun allow(
+    classReference: ClassReference,
+    invocationTarget: ClassFile,
+    caller: ClassFileMember,
+    usageType: ClassUsageType,
+    context: VerificationContext
+  ): Boolean {
+    return apiUsageFilters.any {
+      it.allow(classReference, invocationTarget, caller, usageType, context)
+    }
+  }
+
+  override fun allow(
+    fieldReference: FieldReference,
+    resolvedField: Field,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    return apiUsageFilters.any {
+      it.allow(fieldReference, resolvedField, callerMethod, context)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedApiUsageProcessor.kt
@@ -10,6 +10,7 @@ import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.FilteringApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.SamePluginUsageFilter
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.CompositeApiUsageFilter
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
@@ -17,7 +18,8 @@ import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import org.objectweb.asm.tree.AbstractInsnNode
 
-class DeprecatedApiUsageProcessor(private val deprecatedApiRegistrar: DeprecatedApiRegistrar) : FilteringApiUsageProcessor(SamePluginUsageFilter()) {
+class DeprecatedApiUsageProcessor(private val deprecatedApiRegistrar: DeprecatedApiRegistrar) :
+  FilteringApiUsageProcessor(CompositeApiUsageFilter(SamePluginUsageFilter(), KotlinDefaultImplsUsageFilter())) {
 
   /**
    * Process a reference to a [Class] from the API.

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedMethodOverridingProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedMethodOverridingProcessor.kt
@@ -5,11 +5,20 @@
 package com.jetbrains.pluginverifier.usages.deprecated
 
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultMethod
 import com.jetbrains.pluginverifier.verifiers.method.MethodOverridingProcessor
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 
 class DeprecatedMethodOverridingProcessor(private val deprecatedApiRegistrar: DeprecatedApiRegistrar) : MethodOverridingProcessor {
   override fun processMethodOverriding(method: Method, overriddenMethod: Method, context: VerificationContext) {
+    // Kotlin compiles interface default methods by generating, in the implementing class, a stub
+    // override that just forwards to the interface's `$DefaultImpls` holder. That stub is
+    // bytecode-indistinguishable from a genuine override, so without this guard a deprecated
+    // default method would be reported as "overridden" in every implementing class, even though
+    // the plugin author never wrote such an override.
+    // Note: this only recognizes the pre-`-Xjvm-default` `$DefaultImpls`-forwarding shape.
+    if (method.isKotlinDefaultMethod()) return
+
     val methodDeprecated = overriddenMethod.deprecationInfo
     if (methodDeprecated != null) {
       deprecatedApiRegistrar.registerDeprecatedUsage(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/KotlinDefaultImplsUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/KotlinDefaultImplsUsageFilter.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.usages.deprecated
+
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.filter.ApiUsageFilter
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import org.objectweb.asm.tree.AbstractInsnNode
+
+/**
+ * Kotlin interface default methods may be implemented via a generated inner class `DefaultImpls`
+ * (depending on `-Xjvm-default` mode). Invocations of such synthetic methods are compiler
+ * artifacts, not references written by the plugin author, so they should not be reported as
+ * deprecated API usages.
+ */
+class KotlinDefaultImplsUsageFilter : ApiUsageFilter {
+  override fun allow(invokedMethod: Method, invocationInstruction: AbstractInsnNode, callerMethod: Method, context: VerificationContext): Boolean =
+    invokedMethod.containingClassFile.name.endsWith("\$DefaultImpls")
+}

--- a/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/deprecated/DeprecatedDefaultMethodInterface.kt
+++ b/intellij-plugin-verifier/verifier-test/after-idea/src/main/kotlin/deprecated/DeprecatedDefaultMethodInterface.kt
@@ -1,0 +1,6 @@
+package deprecated
+
+interface DeprecatedDefaultMethodInterface {
+  @Deprecated(message = "No longer available in the after-idea")
+  fun foo(): String = "default"
+}

--- a/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/deprecated/DeprecatedDefaultMethodInterface.kt
+++ b/intellij-plugin-verifier/verifier-test/before-idea/src/main/kotlin/deprecated/DeprecatedDefaultMethodInterface.kt
@@ -1,0 +1,5 @@
+package deprecated
+
+interface DeprecatedDefaultMethodInterface {
+  fun foo(): String = "default"
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/ExplicitOverrideOfDeprecatedDefaultMethod.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/ExplicitOverrideOfDeprecatedDefaultMethod.kt
@@ -1,0 +1,12 @@
+package mock.plugin.deprecated
+
+import deprecated.DeprecatedDefaultMethodInterface
+
+/*expected(DEPRECATED)
+  Deprecated method deprecated.DeprecatedDefaultMethodInterface.foo() is overridden
+
+  Deprecated method deprecated.DeprecatedDefaultMethodInterface.foo() : java.lang.String is overridden in class mock.plugin.deprecated.ExplicitOverrideOfDeprecatedDefaultMethod
+*/
+class ExplicitOverrideOfDeprecatedDefaultMethod : DeprecatedDefaultMethodInterface {
+  override fun foo(): String = "overridden"
+}

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/NoOverrideOfDeprecatedDefaultMethod.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/NoOverrideOfDeprecatedDefaultMethod.kt
@@ -1,0 +1,8 @@
+package mock.plugin.deprecated
+
+import deprecated.DeprecatedDefaultMethodInterface
+
+// The Kotlin compiler generates, in this class, a stub override of foo() that only forwards to
+// DeprecatedDefaultMethodInterface$DefaultImpls.foo(this). Neither that forwarding call nor the
+// stub override itself were written by the plugin author, so no deprecation warning is expected.
+class NoOverrideOfDeprecatedDefaultMethod : DeprecatedDefaultMethodInterface

--- a/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/SamePluginDeprecatedOverride.kt
+++ b/intellij-plugin-verifier/verifier-test/mock-plugin/src/main/kotlin/mock/plugin/deprecated/SamePluginDeprecatedOverride.kt
@@ -1,0 +1,17 @@
+package mock.plugin.deprecated
+
+open class SamePluginDeprecatedBase {
+  @Deprecated(message = "Use newFoo() instead")
+  open fun foo() {}
+}
+
+/*expected(DEPRECATED)
+  Deprecated method mock.plugin.deprecated.SamePluginDeprecatedBase.foo() is overridden
+
+  Deprecated method mock.plugin.deprecated.SamePluginDeprecatedBase.foo() : void is overridden in class mock.plugin.deprecated.SamePluginDeprecatedOverride
+*/
+class SamePluginDeprecatedOverride : SamePluginDeprecatedBase() {
+  override fun foo() {
+    // real override logic, not a compiler-generated DefaultImpls-forwarding stub
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedKotlinDefaultMethodTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedKotlinDefaultMethodTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.usages.deprecated
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.pluginverifier.tests.mocks.MockVerificationContext
+import com.jetbrains.pluginverifier.usages.internal.classDump.`TestInterface$DefaultImplsDump`
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isKotlinDefaultMethod
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.VarInsnNode
+
+class DeprecatedKotlinDefaultMethodTest {
+  private val verificationContext: VerificationContext = MockVerificationContext()
+
+  @Test
+  fun `invocation of a DefaultImpls-owned method is ignored by KotlinDefaultImplsUsageFilter`() {
+    val classNode = ClassNode(Opcodes.ASM7)
+    ClassReader(`TestInterface$DefaultImplsDump`.dump()).accept(classNode, 0)
+    val classFile = ClassFileAsm(classNode, origin)
+
+    val internalMethod = classFile.methods.find { it.name == "internalMethod" }
+    assertNotNull(internalMethod)
+    internalMethod!!
+
+    val filter = KotlinDefaultImplsUsageFilter()
+    val noopInstruction = InsnNode(Opcodes.NOP)
+    assertTrue(filter.allow(internalMethod, noopInstruction, internalMethod, verificationContext))
+  }
+
+  @Test
+  fun `invocation of a regular method is not ignored by KotlinDefaultImplsUsageFilter`() {
+    val regularMethodClassFile = ClassFileAsm(regularClassNode(), origin)
+    val regularMethod = regularMethodClassFile.methods.find { it.name == "bar" }
+    assertNotNull(regularMethod)
+    regularMethod!!
+
+    val filter = KotlinDefaultImplsUsageFilter()
+    val noopInstruction = InsnNode(Opcodes.NOP)
+    assertFalse(filter.allow(regularMethod, noopInstruction, regularMethod, verificationContext))
+  }
+
+  @Test
+  fun `Kotlin compiler-generated DefaultImpls-forwarding stub is detected`() {
+    val classFile = ClassFileAsm(defaultImplsForwardingStubClassNode(), origin)
+    val stub = classFile.methods.find { it.name == "foo" }
+    assertNotNull(stub)
+    stub!!
+
+    assertTrue(stub.isKotlinDefaultMethod())
+  }
+
+  @Test
+  fun `a hand-written override with real logic is not detected as a DefaultImpls-forwarding stub`() {
+    val classFile = ClassFileAsm(genuineOverrideClassNode(), origin)
+    val override = classFile.methods.find { it.name == "foo" }
+    assertNotNull(override)
+    override!!
+
+    assertFalse(override.isKotlinDefaultMethod())
+  }
+
+  private fun regularClassNode(): ClassNode = ClassNode(Opcodes.ASM9).apply {
+    version = Opcodes.V1_8
+    access = Opcodes.ACC_PUBLIC
+    name = "mock/plugin/deprecated/RegularClass"
+    superName = "java/lang/Object"
+    methods.add(MethodNode().apply {
+      access = Opcodes.ACC_PUBLIC
+      name = "bar"
+      desc = "()V"
+      instructions.add(InsnNode(Opcodes.RETURN))
+    })
+  }
+
+  private fun defaultImplsForwardingStubClassNode(): ClassNode = ClassNode(Opcodes.ASM9).apply {
+    version = Opcodes.V1_8
+    access = Opcodes.ACC_PUBLIC
+    name = "mock/plugin/deprecated/NoOverrideOfDeprecatedDefaultMethod"
+    superName = "java/lang/Object"
+    interfaces = listOf("deprecated/DeprecatedDefaultMethodInterface")
+    visibleAnnotations = listOf(AnnotationNode("Lkotlin/Metadata;"))
+    methods.add(MethodNode().apply {
+      access = Opcodes.ACC_PUBLIC
+      name = "foo"
+      desc = "()Ljava/lang/String;"
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(
+        MethodInsnNode(
+          Opcodes.INVOKESTATIC,
+          "deprecated/DeprecatedDefaultMethodInterface\$DefaultImpls",
+          "foo",
+          "(Ldeprecated/DeprecatedDefaultMethodInterface;)Ljava/lang/String;",
+          false
+        )
+      )
+      instructions.add(InsnNode(Opcodes.ARETURN))
+    })
+  }
+
+  private fun genuineOverrideClassNode(): ClassNode = ClassNode(Opcodes.ASM9).apply {
+    version = Opcodes.V1_8
+    access = Opcodes.ACC_PUBLIC
+    name = "mock/plugin/deprecated/ExplicitOverrideOfDeprecatedDefaultMethod"
+    superName = "java/lang/Object"
+    interfaces = listOf("deprecated/DeprecatedDefaultMethodInterface")
+    visibleAnnotations = listOf(AnnotationNode("Lkotlin/Metadata;"))
+    methods.add(MethodNode().apply {
+      access = Opcodes.ACC_PUBLIC
+      name = "foo"
+      desc = "()Ljava/lang/String;"
+      instructions.add(LdcInsnNode("overridden"))
+      instructions.add(InsnNode(Opcodes.ARETURN))
+    })
+  }
+
+  private val origin = object : FileOrigin {
+    override val parent = null
+  }
+}


### PR DESCRIPTION
# Problem

When a Kotlin interface method is marked @Deprecated, the `pre--Xjvm-default `compilation strategy generates an `Interface$DefaultImpls` holder class for the method body, plus a compiler-generated stub in every implementing class that forwards to it. Plugin Verifier reported this compiler artifact as two false-positive warnings the plugin author never actually wrote:

1. An invocation warning: `KotlinInterface.DefaultImpls.foo(this)` is deprecated but called from `PluginClass`
2. An override warning: `PluginClass.foo` overrides deprecated fun `foo()`

This same class of false positive was already fixed once before for @ApiStatus.Internal/@IntellijInternalApi usages (`InternalApiUsage.kt`, `InternalMethodOverridingProcessor.kt`), but the equivalent fix was never applied to deprecation checks.

# Fix

- Added `KotlinDefaultImplsUsageFilter`, a new `ApiUsageFilter` that ignores invocations of methods owned by a synthetic `$DefaultImpls` class, and composed it into `DeprecatedApiUsageProcessor` alongside the existing `SamePluginUsageFilter`.
- Fixed `CompositeApiUsageFilter` to forward all three allow() overloads (class-reference, method-invocation, field-access) to its child filters — it previously only forwarded the method-invocation one, which would have silently broken SamePluginUsageFilter's existing class-reference/field-access suppression once wrapped in a composite.
- Guarded DeprecatedMethodOverridingProcessor with the existing `KotlinMethods.isKotlinDefaultMethod()` bytecode-pattern detector, skipping the compiler-generated stub override.
  - Deliberately did not reuse the broader hasDifferentOrigin heuristic from the internal-API fix: that check suppresses any same-origin override, not just Kotlin codegen artifacts, and would silently drop genuine same-plugin deprecated-method-override warnings — a real regression, not just theoretical (proven via a new same-plugin test fixture).
  - Known limitation, left as a documented follow-up rather than worked around: `isKotlinDefaultMethod()` only recognizes the pre--Xjvm-default $DefaultImpls-forwarding shape, not Kotlin 2.2+'s alternate stub shape.

# Testing

- New real-compiled Kotlin fixtures under verifier-test (`DeprecatedDefaultMethodInterface`, `NoOverrideOfDeprecatedDefaultMethod`, `ExplicitOverrideOfDeprecatedDefaultMethod`, `SamePluginDeprecatedOverride`) exercising:
  - the false-positive repro — now produces zero warnings,
  - a genuine hand-written override of the same deprecated method — still warns (proves no over-suppression),
  - a same-plugin, non-Kotlin-codegen override of a deprecated method — still warns (proves the `isKotlinDefaultMethod()` guard, unlike hasDifferentOrigin, doesn't regress same-origin detection).
- New unit test `DeprecatedKotlinDefaultMethodTest`, pinning `KotlinDefaultImplsUsageFilter` and the `isKotlinDefaultMethod()`-based override guard against hand-built ASM bytecode, independent of the current Kotlin toolchain version.
- Ran the full verifier-test suite and the full composite-build test task (all four modules: intellij-plugin-structure, intellij-plugin-verifier, ide-diff-builder, intellij-feature-extractor) — all green, no regressions.