### PR TITLE
MP-7133: do not attribute API usages inlined from SDK inline functions to the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 ### Fixed
 
 - Close `ZipFile` handles eagerly in `ZipFileHandler` to release archive files after use to restore compatibility with Windows ([#1521](https://github.com/JetBrains/intellij-plugin-verifier/pull/1521), [#1549](https://github.com/JetBrains/intellij-plugin-verifier/pull/1549))
+- Do not attribute internal, experimental, and `OverrideOnly` API usages inlined from Kotlin `inline fun`s declared outside the plugin to the plugin ([MP-7133](https://youtrack.jetbrains.com/issue/MP-7133))
 
 ## 1.408 - 2026-07-02
 

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/ApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/ApiUsageProcessor.kt
@@ -17,7 +17,8 @@ interface ApiUsageProcessor {
     resolvedClass: ClassFile,
     context: VerificationContext,
     referrer: ClassFileMember,
-    classUsageType: ClassUsageType
+    classUsageType: ClassUsageType,
+    instructionNode: AbstractInsnNode? = null
   ) = Unit
 
   fun processMethodInvocation(

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/FilteringApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/FilteringApiUsageProcessor.kt
@@ -18,10 +18,11 @@ abstract class FilteringApiUsageProcessor(private val usageFilter: ApiUsageFilte
     resolvedClass: ClassFile,
     context: VerificationContext,
     referrer: ClassFileMember,
-    classUsageType: ClassUsageType
+    classUsageType: ClassUsageType,
+    instructionNode: AbstractInsnNode?
   ) {
     if (usageFilter.allow(classReference, resolvedClass, referrer, classUsageType, context)) return
-    doProcessClassReference(classReference, resolvedClass, referrer, classUsageType, context)
+    doProcessClassReference(classReference, resolvedClass, referrer, classUsageType, context, instructionNode)
   }
 
   final override fun processMethodInvocation(
@@ -51,6 +52,7 @@ abstract class FilteringApiUsageProcessor(private val usageFilter: ApiUsageFilte
     referrer: ClassFileMember,
     classUsageType: ClassUsageType,
     context: VerificationContext,
+    instructionNode: AbstractInsnNode?
   )
 
   protected abstract fun doProcessMethodInvocation(

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/LdcInstructionVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/LdcInstructionVerifier.kt
@@ -18,17 +18,17 @@ class LdcInstructionVerifier : InstructionVerifier {
 
     val type = instructionNode.cst as? Type ?: return
     if (type.sort == Type.OBJECT) {
-      checkTypeExists(type, context, method)
+      checkTypeExists(type, context, method, instructionNode)
     } else if (type.sort == Type.METHOD) {
       for (argumentType in type.argumentTypes) {
-        checkTypeExists(argumentType, context, method)
+        checkTypeExists(argumentType, context, method, instructionNode)
       }
-      checkTypeExists(type.returnType, context, method)
+      checkTypeExists(type.returnType, context, method, instructionNode)
     }
   }
 
-  private fun checkTypeExists(type: Type, context: VerificationContext, method: Method) {
+  private fun checkTypeExists(type: Type, context: VerificationContext, method: Method, instructionNode: AbstractInsnNode) {
     val className = type.descriptor.extractClassNameFromDescriptor() ?: return
-    context.classResolver.resolveClassChecked(className, method, context)
+    context.classResolver.resolveClassChecked(className, method, context, instructionNode)
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MemberAccessVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MemberAccessVerifier.kt
@@ -85,12 +85,12 @@ class MemberAccessVerifier : InstructionVerifier {
     if (memberOwner.startsWith("[")) {
       val arrayType = memberOwner.extractClassNameFromDescriptor()
       if (arrayType != null) {
-        context.classResolver.resolveClassChecked(arrayType, callerMethod, context)
+        context.classResolver.resolveClassChecked(arrayType, callerMethod, context, instructionNode)
       }
       return
     }
 
-    val ownerClassFile = context.classResolver.resolveClassChecked(memberOwner, callerMethod, context)
+    val ownerClassFile = context.classResolver.resolveClassChecked(memberOwner, callerMethod, context, instructionNode)
     if (ownerClassFile != null) {
       when (instruction) {
         Instruction.INVOKE_VIRTUAL, Instruction.INVOKE_INTERFACE, Instruction.INVOKE_STATIC, Instruction.INVOKE_SPECIAL -> {

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MethodInvokeInstructionVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MethodInvokeInstructionVerifier.kt
@@ -97,10 +97,10 @@ class MethodInvokeInstructionVerifier(
        So I caught up a nasty bug of incorrectly determining the method to be invoked.
     */
     val classRef: ClassFile = if (method.name != "<init>" && (!methodOwnerClass.isInterface && methodReference.hostClass.className == callerMethod.containingClassFile.superName) && callerMethod.containingClassFile.isSuperFlag) {
-      context.classResolver.resolveClassChecked(callerMethod.containingClassFile.superName!!, callerMethod, context)
+      context.classResolver.resolveClassChecked(callerMethod.containingClassFile.superName!!, callerMethod, context, instructionNode)
         ?: return
     } else {
-      context.classResolver.resolveClassChecked(methodReference.hostClass.className, callerMethod, context) ?: return
+      context.classResolver.resolveClassChecked(methodReference.hostClass.className, callerMethod, context, instructionNode) ?: return
     }
 
     /*

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MultiANewArrayInstructionVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/MultiANewArrayInstructionVerifier.kt
@@ -19,6 +19,6 @@ class MultiANewArrayInstructionVerifier : InstructionVerifier {
 
     //During resolution of the symbolic reference to the class, array, or interface type,
     // any of the exceptions documented in §5.4.3.1 can be thrown.
-    context.classResolver.resolveClassChecked(className, method, context)
+    context.classResolver.resolveClassChecked(className, method, context, instructionNode)
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/TypeInstructionVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/instruction/TypeInstructionVerifier.kt
@@ -23,7 +23,7 @@ class TypeInstructionVerifier : InstructionVerifier {
 
     val className = instructionNode.desc.extractClassNameFromDescriptor() ?: return
 
-    val typeClassFile = context.classResolver.resolveClassChecked(className, method, context) ?: return
+    val typeClassFile = context.classResolver.resolveClassChecked(className, method, context, instructionNode) ?: return
 
     if (instructionNode.opcode == Opcodes.NEW) {
       if (typeClassFile.isInterface) {

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodArgumentTypesVerifier.kt
@@ -22,7 +22,7 @@ class MethodArgumentTypesVerifier : MethodVerifier {
     val argumentTypes = methodType.argumentTypes
     for (type in argumentTypes) {
       val className = type.descriptor.extractClassNameFromDescriptor() ?: continue
-      context.classResolver.resolveClassChecked(className, method, context, ClassUsageType.METHOD_PARAMETER)
+      context.classResolver.resolveClassChecked(className, method, context, classUsageType = ClassUsageType.METHOD_PARAMETER)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodLocalVarsVerifier.kt
@@ -18,7 +18,7 @@ class MethodLocalVarsVerifier : MethodVerifier {
 
     for (variable in method.localVariables) {
       val className = variable.desc.extractClassNameFromDescriptor() ?: continue
-      context.classResolver.resolveClassChecked(className, method, context)
+      context.classResolver.resolveClassChecked(className, method, context, instructionNode = variable.start)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodTryCatchVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodTryCatchVerifier.kt
@@ -14,7 +14,7 @@ class MethodTryCatchVerifier : MethodVerifier {
     for (block in method.tryCatchBlocks) {
       val catchException = block.type ?: continue
       val className = catchException.extractClassNameFromDescriptor() ?: continue
-      context.classResolver.resolveClassChecked(className, method, context)
+      context.classResolver.resolveClassChecked(className, method, context, instructionNode = block.start)
     }
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/ResolutionUtil.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/ResolutionUtil.kt
@@ -13,6 +13,7 @@ import com.jetbrains.pluginverifier.results.problems.IllegalClassAccessProblem
 import com.jetbrains.pluginverifier.results.problems.InvalidClassFileProblem
 import com.jetbrains.pluginverifier.results.reference.ClassReference
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import org.objectweb.asm.tree.AbstractInsnNode
 
 fun Resolver.caching(): Resolver = CacheResolver(this)
 
@@ -25,6 +26,7 @@ fun Resolver.resolveClassChecked(
   className: String,
   referrer: ClassFileMember,
   context: VerificationContext,
+  instructionNode: AbstractInsnNode? = null,
   classUsageType: ClassUsageType = ClassUsageType.DEFAULT
 ): ClassFile? =
   when (val resolutionResult = resolveClass(className)) {
@@ -56,7 +58,7 @@ fun Resolver.resolveClassChecked(
         )
       }
       val classReference = ClassReference(className)
-      context.apiUsageProcessors.forEach { it.processClassReference(classReference, classFile, context, referrer, classUsageType) }
+      context.apiUsageProcessors.forEach { it.processClassReference(classReference, classFile, context, referrer, classUsageType, instructionNode) }
       classFile
     }
   }

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/deprecated/DeprecatedApiUsageProcessor.kt
@@ -40,7 +40,8 @@ class DeprecatedApiUsageProcessor(private val deprecatedApiRegistrar: Deprecated
     resolvedClass: ClassFile,
     referrer: ClassFileMember,
     classUsageType: ClassUsageType,
-    context: VerificationContext
+    context: VerificationContext,
+    instructionNode: AbstractInsnNode?
   ) {
     val deprecationInfo = resolvedClass.deprecationInfo ?: return
     deprecatedApiRegistrar.registerDeprecatedUsage(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/discouraging/DiscouragingClassUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/discouraging/DiscouragingClassUsageProcessor.kt
@@ -15,6 +15,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
 import com.jetbrains.pluginverifier.verifiers.resolution.isDiscouragingJdkClass
+import org.objectweb.asm.tree.AbstractInsnNode
 
 class DiscouragingClassUsageProcessor(private val deprecatedApiRegistrar: DeprecatedApiRegistrar) : ApiUsageProcessor {
   override fun processClassReference(
@@ -22,7 +23,8 @@ class DiscouragingClassUsageProcessor(private val deprecatedApiRegistrar: Deprec
     resolvedClass: ClassFile,
     context: VerificationContext,
     referrer: ClassFileMember,
-    classUsageType: ClassUsageType
+    classUsageType: ClassUsageType,
+    instructionNode: AbstractInsnNode?
   ) {
     if (resolvedClass.isDiscouragingJdkClass()) {
       val classFileOrigin = resolvedClass.classFileOrigin

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/experimental/ExperimentalApiUsageProcessor.kt
@@ -10,6 +10,7 @@ import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.FilteringApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.SamePluginUsageFilter
+import com.jetbrains.pluginverifier.usages.util.KotlinInlinedCodeDetector
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
@@ -22,6 +23,8 @@ class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: Experi
   SamePluginUsageFilter()
 ) {
 
+  private val inlinedCodeDetector = KotlinInlinedCodeDetector()
+
   private fun isExperimental(
     resolvedMember: ClassFileMember,
     context: VerificationContext,
@@ -33,10 +36,16 @@ class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: Experi
     resolvedClass: ClassFile,
     referrer: ClassFileMember,
     classUsageType: ClassUsageType,
-    context: VerificationContext
+    context: VerificationContext,
+    instructionNode: AbstractInsnNode?
   ) {
     val usageLocation = referrer.location
     if (isExperimental(resolvedClass, context, usageLocation)) {
+      if (instructionNode != null && referrer is Method
+        && inlinedCodeDetector.isInlinedFromOutsidePlugin(instructionNode, referrer, context)) {
+        return
+      }
+
       experimentalApiRegistrar.registerExperimentalApiUsage(
         ExperimentalClassUsage(classReference, resolvedClass.location, usageLocation)
       )
@@ -52,6 +61,10 @@ class ExperimentalApiUsageProcessor(private val experimentalApiRegistrar: Experi
   ) {
     val usageLocation = callerMethod.location
     if (isExperimental(invokedMethod, context, usageLocation)) {
+      if (inlinedCodeDetector.isInlinedFromOutsidePlugin(invocationInstruction, callerMethod, context)) {
+        return
+      }
+
       experimentalApiRegistrar.registerExperimentalApiUsage(
         ExperimentalMethodUsage(invokedMethodReference, invokedMethod.location, usageLocation)
       )

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/BaseInternalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/BaseInternalApiUsageProcessor.kt
@@ -8,6 +8,7 @@ import com.jetbrains.pluginverifier.results.reference.ClassReference
 import com.jetbrains.pluginverifier.results.reference.FieldReference
 import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.ApiUsageProcessor
+import com.jetbrains.pluginverifier.usages.util.KotlinInlinedCodeDetector
 import com.jetbrains.pluginverifier.usages.util.isFromVerifiedPlugin
 import com.jetbrains.pluginverifier.verifiers.ProblemRegistrar
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
@@ -26,15 +27,23 @@ abstract class BaseInternalApiUsageProcessor(
 ) :
   ApiUsageProcessor {
 
+  private val inlinedCodeDetector = KotlinInlinedCodeDetector()
+
   override fun processClassReference(
     classReference: ClassReference,
     resolvedClass: ClassFile,
     context: VerificationContext,
     referrer: ClassFileMember,
-    classUsageType: ClassUsageType
+    classUsageType: ClassUsageType,
+    instructionNode: AbstractInsnNode?
   ) {
     val usageLocation = referrer.location
     if (isInternal(resolvedClass, context, usageLocation) && context.isFromVerifiedPlugin(referrer)) {
+      if (instructionNode != null && referrer is Method
+        && inlinedCodeDetector.isInlinedFromOutsidePlugin(instructionNode, referrer, context)) {
+        return
+      }
+
       internalUsageRegistrar.registerClass(classReference, resolvedClass.location, usageLocation)
     }
   }
@@ -48,6 +57,10 @@ abstract class BaseInternalApiUsageProcessor(
   ) {
     val usageLocation = callerMethod.location
     if (isInternal(resolvedMethod, context, usageLocation)) {
+      if (inlinedCodeDetector.isInlinedFromOutsidePlugin(instructionNode, callerMethod, context)) {
+        return
+      }
+
       // Check if the method is an override, and if so check top declaration
       val canBeOverridden = !resolvedMethod.isStatic && !resolvedMethod.isPrivate
         && resolvedMethod.name != "<init>" && resolvedMethod.name != "<clinit>"

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/JavaPluginApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/javaPlugin/JavaPluginApiUsageProcessor.kt
@@ -15,9 +15,10 @@ import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
+import org.objectweb.asm.tree.AbstractInsnNode
 
 class JavaPluginApiUsageProcessor(private val javaPluginApiUsageRegistrar: JavaPluginApiUsageRegistrar) : ApiUsageProcessor {
-  override fun processClassReference(classReference: ClassReference, resolvedClass: ClassFile, context: VerificationContext, referrer: ClassFileMember, classUsageType: ClassUsageType) {
+  override fun processClassReference(classReference: ClassReference, resolvedClass: ClassFile, context: VerificationContext, referrer: ClassFileMember, classUsageType: ClassUsageType, instructionNode: AbstractInsnNode?) {
     if (resolvedClass.isJavaPluginApi() && context.isFromVerifiedPlugin(referrer)) {
       javaPluginApiUsageRegistrar.registerJavaPluginClassUsage(
         JavaPluginClassUsage(resolvedClass.containingClassFile.location, referrer.location)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/overrideOnly/OverrideOnlyMethodUsageProcessor.kt
@@ -10,6 +10,7 @@ import com.jetbrains.pluginverifier.results.reference.MethodReference
 import com.jetbrains.pluginverifier.usages.FilteringApiUsageProcessor
 import com.jetbrains.pluginverifier.usages.annotation.AnnotationResolver
 import com.jetbrains.pluginverifier.usages.annotation.isMemberEffectivelyAnnotatedWith
+import com.jetbrains.pluginverifier.usages.util.KotlinInlinedCodeDetector
 import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.filter.CompositeApiUsageFilter
 import com.jetbrains.pluginverifier.verifiers.filter.SameModuleUsageFilter
@@ -39,6 +40,8 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
   FilteringApiUsageProcessor(overrideOnlyUsageFilter) {
 
   private val overrideOnlyAnnotationResolver = AnnotationResolver(overrideOnlyAnnotationName)
+
+  private val inlinedCodeDetector = KotlinInlinedCodeDetector()
 
   /**
    * Processes the invocation of a method, if allowed.
@@ -70,6 +73,10 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
   ) {
 
     if (invokedMethod.isOverrideOnlyMethod(context)) {
+      if (inlinedCodeDetector.isInlinedFromOutsidePlugin(invocationInstruction, callerMethod, context)) {
+        return
+      }
+
       overrideOnlyRegistrar.registerOverrideOnlyMethodUsage(
         OverrideOnlyMethodUsage(invokedMethodReference, invokedMethod.location, callerMethod.location)
       )
@@ -105,7 +112,8 @@ class OverrideOnlyMethodUsageProcessor(private val overrideOnlyRegistrar: Overri
     resolvedClass: ClassFile,
     referrer: ClassFileMember,
     classUsageType: ClassUsageType,
-    context: VerificationContext
+    context: VerificationContext,
+    instructionNode: AbstractInsnNode?
   ) = Unit
 
   override fun doProcessFieldAccess(

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/util/KotlinInlinedCodeDetector.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/util/KotlinInlinedCodeDetector.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.usages.util
+
+import com.jetbrains.pluginverifier.verifiers.VerificationContext
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.resolveClassOrNull
+import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.LineNumberNode
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+
+private const val SOURCE_DEBUG_EXTENSION_ANNOTATION = "Lkotlin/jvm/internal/SourceDebugExtension;"
+
+class KotlinInlinedCodeDetector {
+  private val smapCache = ConcurrentHashMap<String, Optional<Smap>>()
+
+  fun isInlinedFromOutsidePlugin(
+    instructionNode: AbstractInsnNode,
+    callerMethod: Method,
+    context: VerificationContext
+  ): Boolean {
+    val callerClass = callerMethod.containingClassFile as? ClassFileAsm ?: return false
+    val line = findLineNumber(instructionNode) ?: return false
+    val smap = smapCache.computeIfAbsent(callerClass.name) {
+      Optional.ofNullable(Smap.parse(callerClass.sourceDebugInfo()))
+    }.orElse(null) ?: return false
+    val originClassName = smap.sourceClassOf(line) ?: return false
+    if (originClassName == callerClass.name) return false
+    val originClass = context.classResolver.resolveClassOrNull(originClassName) ?: return false
+    return !context.isFromVerifiedPlugin(originClass)
+  }
+
+  private fun findLineNumber(instructionNode: AbstractInsnNode): Int? {
+    var node: AbstractInsnNode? = instructionNode
+    while (node != null) {
+      if (node is LineNumberNode) return node.line
+      node = node.previous
+    }
+    return null
+  }
+
+  private fun ClassFileAsm.sourceDebugInfo(): String? =
+    asmNode.sourceDebug ?: sourceDebugExtensionAnnotationValue()
+
+  private fun ClassFileAsm.sourceDebugExtensionAnnotationValue(): String? {
+    val annotation = asmNode.invisibleAnnotations.orEmpty()
+      .find { it.desc == SOURCE_DEBUG_EXTENSION_ANNOTATION } ?: return null
+    val values = annotation.values ?: return null
+    val valueIndex = (values.indices step 2).find { values[it] == "value" } ?: return null
+    val parts = (values.getOrNull(valueIndex + 1) as? List<*>)?.filterIsInstance<String>() ?: return null
+    return parts.joinToString("").takeIf { it.isNotEmpty() }
+  }
+}
+
+/**
+ * The Kotlin section of a JSR-45 source map (SMAP): which source class each output line comes from.
+ */
+internal class Smap private constructor(
+  private val sourceClassesByFileId: Map<Int, String>,
+  private val lineRanges: List<LineRange>
+) {
+
+  /** The JVM internal name of the class whose source produced the given output line, if known. */
+  fun sourceClassOf(outputLine: Int): String? =
+    lineRanges.lastOrNull { outputLine in it.outputStart..it.outputEnd }
+      ?.let { sourceClassesByFileId[it.fileId] }
+
+  private data class LineRange(val outputStart: Int, val outputEnd: Int, val fileId: Int)
+
+  companion object {
+    // InputStartLine [ '#' LineFileID ] [ ',' RepeatCount ] ':' OutputStartLine [ ',' OutputLineIncrement ]
+    private val LINE_INFO = Regex("""(\d+)(?:#(\d+))?(?:,(\d+))?:(\d+)(?:,(\d+))?""")
+
+    fun parse(sourceDebug: String?): Smap? {
+      val lines = sourceDebug?.lines() ?: return null
+      if (lines.firstOrNull()?.trim() != "SMAP") return null
+      var i = lines.indexOfFirst { it.trim() == "*S Kotlin" }
+      if (i < 0) return null
+      i++
+
+      val sourceClasses = mutableMapOf<Int, String>()
+      val ranges = mutableListOf<LineRange>()
+      var section = ""
+      var previousFileId = 1
+      while (i < lines.size) {
+        val line = lines[i].trim()
+        when {
+          line.startsWith("*S ") || line == "*E" -> break
+          line == "*F" || line == "*L" -> section = line
+          section == "*F" && line.startsWith("+ ") -> {
+            // "+ <id> <file name>" followed by a line with the source class internal name
+            val id = line.removePrefix("+ ").substringBefore(' ').toIntOrNull()
+            val sourceClass = lines.getOrNull(i + 1)?.trim()
+            if (id != null && !sourceClass.isNullOrEmpty()) {
+              sourceClasses[id] = sourceClass
+            }
+            i++
+          }
+          section == "*L" -> {
+            val match = LINE_INFO.matchEntire(line)
+            if (match != null) {
+              val (_, fileIdText, repeatText, outputStartText, incrementText) = match.destructured
+              val fileId = fileIdText.toIntOrNull() ?: previousFileId
+              previousFileId = fileId
+              val repeat = repeatText.toIntOrNull() ?: 1
+              val increment = incrementText.toIntOrNull() ?: 1
+              val outputStart = outputStartText.toInt()
+              ranges += LineRange(outputStart, outputStart + repeat * increment - 1, fileId)
+            }
+          }
+        }
+        i++
+      }
+      return Smap(sourceClasses, ranges)
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/BaseBytecodeTest.kt
@@ -279,7 +279,7 @@ abstract class BaseBytecodeTest {
     return ide
   }
 
-  private fun buildIdePlugin(
+  internal fun buildIdePlugin(
     ideaPluginSpec: IdeaPluginSpec = IdeaPluginSpec("com.intellij", "JetBrains s.r.o."),
     pluginClassesContentBuilder: (ContentBuilder).() -> Unit
   ): IdePlugin {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionExperimentalApiUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionExperimentalApiUsageTest.kt
@@ -1,0 +1,94 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.tests.bytecode.DirectExperimentalCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.ExperimentalInlinedCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.ExperimentalProgressKtDump
+import com.jetbrains.pluginverifier.tests.bytecode.ExperimentalReporterHandleDump
+import com.jetbrains.pluginverifier.tests.bytecode.OwnExperimentalInlineCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.PluginExperimentalUtilsKtDump
+import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import com.jetbrains.pluginverifier.usages.experimental.ExperimentalApiUsage
+import com.jetbrains.pluginverifier.usages.experimental.ExperimentalMethodUsage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KotlinInlineFunctionExperimentalApiUsageTest : BaseBytecodeTest() {
+
+  private val thirdPartyPluginSpec = IdeaPluginSpec("com.example.progress", "Third Party Inc.")
+
+  @Test
+  fun `experimental API referenced only from the inlined body of a public SDK inline function is not reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("MyExperimentalAction.class", ExperimentalInlinedCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(
+      "Experimental API usages coming from an inlined body of a public SDK inline function " +
+        "must not be attributed to the plugin",
+      emptySet<ExperimentalApiUsage>(),
+      verificationResult.experimentalApiUsages
+    )
+  }
+
+  @Test
+  fun `experimental API inlined from the plugin's own inline function is still reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("OwnExperimentalCaller.class", OwnExperimentalInlineCallerDump.dump())
+        file("ExperimentalUtilsKt.class", PluginExperimentalUtilsKtDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertTrue(
+      "Experimental API usage inlined from the plugin's own inline function is the plugin author's " +
+        "own code and must still be reported",
+      verificationResult.experimentalApiUsages
+        .filterIsInstance<ExperimentalMethodUsage>()
+        .any { "experimentalCurrentStep" in it.fullDescription }
+    )
+  }
+
+  @Test
+  fun `experimental API invoked directly by plugin code is reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("DirectExperimentalUsage.class", DirectExperimentalCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertTrue(
+      "Direct invocation of an experimental API method must be reported",
+      verificationResult.experimentalApiUsages
+        .filterIsInstance<ExperimentalMethodUsage>()
+        .any { "experimentalCurrentStep" in it.fullDescription }
+    )
+  }
+
+  private fun runVerification(idePlugin: IdePlugin): PluginVerificationResult.Verified {
+    val ide = buildSdkIde()
+    return VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+  }
+
+  private fun buildSdkIde(): Ide =
+    buildIdeWithBundledPlugins(includeKotlinStdLib = true) {
+      dirs("com/intellij/platform/util/progress") {
+        file("ExperimentalReporterHandle.class", ExperimentalReporterHandleDump.dump())
+        file("ExperimentalProgressKt.class", ExperimentalProgressKtDump.dump())
+      }
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionInternalApiUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionInternalApiUsageTest.kt
@@ -1,0 +1,128 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
+import com.jetbrains.pluginverifier.tests.bytecode.DirectCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.InlinedCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.OwnInlineCallerDump
+import com.jetbrains.pluginverifier.tests.bytecode.PluginUtilsKtDump
+import com.jetbrains.pluginverifier.tests.bytecode.RawProgressKtDump
+import com.jetbrains.pluginverifier.tests.bytecode.RawProgressReporterHandleDump
+import com.jetbrains.pluginverifier.tests.bytecode.SuspendLambdaCallerDump
+import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalMethodUsage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reproduces https://youtrack.jetbrains.com/issue/MP-7133
+ */
+class KotlinInlineFunctionInternalApiUsageTest : BaseBytecodeTest() {
+
+  private val thirdPartyPluginSpec = IdeaPluginSpec("com.example.progress", "Third Party Inc.")
+
+  @Test
+  fun `internal API referenced only from the inlined body of a public SDK inline function is not reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("MyAction.class", InlinedCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(
+      "Internal API usages coming from an inlined body of a public SDK inline function " +
+        "must not be attributed to the plugin",
+      emptySet<InternalApiUsage>(),
+      verificationResult.internalApiUsages
+    )
+  }
+
+  @Test
+  fun `internal API inlined into the invokeSuspend method of a suspend lambda is not reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("MyAction\$run\$1.class", SuspendLambdaCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(emptySet<InternalApiUsage>(), verificationResult.internalApiUsages)
+  }
+
+  @Test
+  fun `internal API usage suppression works when the SMAP survives only in the SourceDebugExtension annotation`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("MyAction.class", InlinedCallerDump.dump(smapInSourceAttribute = false))
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(
+      "Internal API usage should be suppressed even when the SMAP is only available in the SourceDebugExtension annotation",
+      emptySet<InternalApiUsage>(),
+      verificationResult.internalApiUsages
+    )
+  }
+
+  @Test
+  fun `internal API inlined from the plugin's own inline function is still reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("OwnCaller.class", OwnInlineCallerDump.dump())
+        file("UtilsKt.class", PluginUtilsKtDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertTrue(
+      "Internal API usage inlined from the plugin's own inline function is the plugin author's " +
+        "own code and must still be reported",
+      verificationResult.internalApiUsages
+        .filterIsInstance<InternalMethodUsage>()
+        .any { "internalCurrentStepAsRaw" in it.fullDescription }
+    )
+  }
+
+  @Test
+  fun `internal API invoked directly by plugin code is reported`() {
+    val idePlugin = buildIdePlugin(thirdPartyPluginSpec) {
+      dirs("com/example/plugin") {
+        file("DirectUsage.class", DirectCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertTrue(
+      "Direct invocation of an internal API method must be reported",
+      verificationResult.internalApiUsages
+        .filterIsInstance<InternalMethodUsage>()
+        .any { "internalCurrentStepAsRaw" in it.fullDescription }
+    )
+  }
+
+  private fun runVerification(idePlugin: IdePlugin): PluginVerificationResult.Verified {
+    val ide = buildSdkIde()
+    return VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+  }
+
+  private fun buildSdkIde(): Ide =
+    buildIdeWithBundledPlugins(includeKotlinStdLib = true) {
+      dirs("com/intellij/platform/util/progress") {
+        file("RawProgressReporterHandle.class", RawProgressReporterHandleDump.dump())
+        file("RawProgressKt.class", RawProgressKtDump.dump())
+      }
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionOverrideOnlyUsageTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/KotlinInlineFunctionOverrideOnlyUsageTest.kt
@@ -1,0 +1,287 @@
+package com.jetbrains.pluginverifier.tests
+
+import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
+import com.jetbrains.pluginverifier.PluginVerificationResult
+import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.Opcodes.*
+
+class KotlinInlineFunctionOverrideOnlyUsageTest : BaseBytecodeTest() {
+
+  private val pluginSpec = IdeaPluginSpec("com.example.toolwindow", "Third Party Inc.")
+
+  @Test
+  fun `OverrideOnly method invoked from the inlined body of a public SDK inline function is not reported`() {
+    val idePlugin = buildIdePlugin(pluginSpec) {
+      dirs("com/example/plugin") {
+        file("TwCaller.class", InlinedToolWindowCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertTrue(
+      "Override-only usage inlined from the public SDK inline builder must not be attributed " +
+        "to the plugin. Actual: ${verificationResult.overrideOnlyMethodUsages}",
+      verificationResult.overrideOnlyMethodUsages.none { "registerToolWindow" in it.fullDescription }
+    )
+  }
+
+  @Test
+  fun `OverrideOnly method invoked directly by plugin code is reported`() {
+    val idePlugin = buildIdePlugin(pluginSpec) {
+      dirs("com/example/plugin") {
+        file("DirectTwCaller.class", DirectToolWindowCallerDump.dump())
+      }
+    }
+
+    val verificationResult = runVerification(idePlugin)
+
+    assertTrue(
+      "Direct invocation of an @OverrideOnly method must still be reported",
+      verificationResult.overrideOnlyMethodUsages.any { "registerToolWindow" in it.fullDescription }
+    )
+  }
+
+  private fun runVerification(idePlugin: IdePlugin): PluginVerificationResult.Verified {
+    val ide = buildIdeWithBundledPlugins(includeKotlinStdLib = true) {
+      dirs("com/intellij/openapi/wm") {
+        file("ToolWindowManager.class", ToolWindowManagerDump.dump())
+        file("ToolWindow.class", ToolWindowDump.dump())
+        file("RegisterToolWindowTask.class", RegisterToolWindowTaskDump.dump())
+      }
+    }
+    return VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+  }
+
+  /**
+   * Mimics the post-MP-6705 `com.intellij.openapi.wm.ToolWindowManager`:
+   * ```
+   * abstract class ToolWindowManager {
+   *   @ApiStatus.OverrideOnly
+   *   abstract fun registerToolWindow(task: RegisterToolWindowTask): ToolWindow
+   * }
+   * ```
+   */
+  private object ToolWindowManagerDump {
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      classWriter.visit(
+        V11,
+        ACC_PUBLIC or ACC_SUPER or ACC_ABSTRACT,
+        "com/intellij/openapi/wm/ToolWindowManager",
+        null,
+        "java/lang/Object",
+        null
+      )
+      classWriter.visitSource("ToolWindowManager.kt", null)
+      classWriter.visitInnerClass(
+        "org/jetbrains/annotations/ApiStatus\$OverrideOnly",
+        "org/jetbrains/annotations/ApiStatus",
+        "OverrideOnly",
+        ACC_PUBLIC or ACC_STATIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE
+      )
+      classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+        visitCode()
+        visitVarInsn(ALOAD, 0)
+        visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+        visitInsn(RETURN)
+        visitMaxs(1, 1)
+        visitEnd()
+      }
+      classWriter.visitMethod(
+        ACC_PUBLIC or ACC_ABSTRACT,
+        "registerToolWindow",
+        "(Lcom/intellij/openapi/wm/RegisterToolWindowTask;)Lcom/intellij/openapi/wm/ToolWindow;",
+        null,
+        null
+      ).apply {
+        visitAnnotation("Lorg/jetbrains/annotations/ApiStatus\$OverrideOnly;", false).visitEnd()
+        visitEnd()
+      }
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+
+  private object ToolWindowDump {
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      classWriter.visit(
+        V11,
+        ACC_PUBLIC or ACC_ABSTRACT or ACC_INTERFACE,
+        "com/intellij/openapi/wm/ToolWindow",
+        null,
+        "java/lang/Object",
+        null
+      )
+      classWriter.visitSource("ToolWindow.kt", null)
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+
+  private object RegisterToolWindowTaskDump {
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      classWriter.visit(
+        V11,
+        ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+        "com/intellij/openapi/wm/RegisterToolWindowTask",
+        null,
+        "java/lang/Object",
+        null
+      )
+      classWriter.visitSource("RegisterToolWindowTask.kt", null)
+      classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+        visitCode()
+        visitVarInsn(ALOAD, 0)
+        visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+        visitInsn(RETURN)
+        visitMaxs(1, 1)
+        visitEnd()
+      }
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+
+  /**
+   * Plugin bytecode as the Kotlin compiler would emit it for:
+   * ```
+   * class TwCaller {
+   *   fun register(twm: ToolWindowManager): ToolWindow =
+   *     twm.registerToolWindow("id") { }   // public inline builder overload
+   * }
+   * ```
+   * The inlined body carries the `$i$f$registerToolWindow` fake-local marker and the SMAP mapping
+   * output lines 9..13 to `ToolWindowManager`, and calls the `@OverrideOnly` single-argument
+   * overload directly.
+   */
+  private object InlinedToolWindowCallerDump {
+    private const val SMAP = "SMAP\nTwCaller.kt\nKotlin\n*S Kotlin\n*F\n+ 1 TwCaller.kt\ncom/example/plugin/TwCaller\n+ 2 ToolWindowManager.kt\ncom/intellij/openapi/wm/ToolWindowManager\n*L\n1#1,8:1\n88#2,5:9\n*S KotlinDebug\n*F\n+ 1 TwCaller.kt\ncom/example/plugin/TwCaller\n*L\n5#1:9,5\n*E\n"
+
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      classWriter.visit(
+        V11,
+        ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+        "com/example/plugin/TwCaller",
+        null,
+        "java/lang/Object",
+        null
+      )
+      classWriter.visitSource("TwCaller.kt", SMAP)
+      classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+        visitCode()
+        visitVarInsn(ALOAD, 0)
+        visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+        visitInsn(RETURN)
+        visitMaxs(1, 1)
+        visitEnd()
+      }
+      classWriter.visitMethod(
+        ACC_PUBLIC or ACC_FINAL,
+        "register",
+        "(Lcom/intellij/openapi/wm/ToolWindowManager;)Lcom/intellij/openapi/wm/ToolWindow;",
+        null,
+        null
+      ).apply {
+        visitCode()
+        val label0 = Label()
+        visitLabel(label0)
+        visitLineNumber(5, label0)
+        visitInsn(ICONST_0)
+        visitVarInsn(ISTORE, 2)
+        val label1 = Label()
+        visitLabel(label1)
+        visitLineNumber(10, label1)
+        visitVarInsn(ALOAD, 1)
+        visitTypeInsn(NEW, "com/intellij/openapi/wm/RegisterToolWindowTask")
+        visitInsn(DUP)
+        visitMethodInsn(INVOKESPECIAL, "com/intellij/openapi/wm/RegisterToolWindowTask", "<init>", "()V", false)
+        visitMethodInsn(
+          INVOKEVIRTUAL,
+          "com/intellij/openapi/wm/ToolWindowManager",
+          "registerToolWindow",
+          "(Lcom/intellij/openapi/wm/RegisterToolWindowTask;)Lcom/intellij/openapi/wm/ToolWindow;",
+          false
+        )
+        val label2 = Label()
+        visitLabel(label2)
+        visitLineNumber(5, label2)
+        visitInsn(ARETURN)
+        val label3 = Label()
+        visitLabel(label3)
+        visitLocalVariable("\$i\$f\$registerToolWindow", "I", null, label1, label2, 2)
+        visitLocalVariable("twm", "Lcom/intellij/openapi/wm/ToolWindowManager;", null, label0, label3, 1)
+        visitLocalVariable("this", "Lcom/example/plugin/TwCaller;", null, label0, label3, 0)
+        visitMaxs(3, 3)
+        visitEnd()
+      }
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+
+  /**
+   * Control case: plugin code invoking the `@OverrideOnly` method directly, without any
+   * inlining markers. Such usage must always be reported.
+   */
+  private object DirectToolWindowCallerDump {
+    fun dump(): ByteArray {
+      val classWriter = ClassWriter(0)
+      classWriter.visit(
+        V11,
+        ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+        "com/example/plugin/DirectTwCaller",
+        null,
+        "java/lang/Object",
+        null
+      )
+      classWriter.visitSource("DirectTwCaller.kt", null)
+      classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+        visitCode()
+        visitVarInsn(ALOAD, 0)
+        visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+        visitInsn(RETURN)
+        visitMaxs(1, 1)
+        visitEnd()
+      }
+      classWriter.visitMethod(
+        ACC_PUBLIC or ACC_FINAL,
+        "register",
+        "(Lcom/intellij/openapi/wm/ToolWindowManager;)Lcom/intellij/openapi/wm/ToolWindow;",
+        null,
+        null
+      ).apply {
+        visitCode()
+        val label0 = Label()
+        visitLabel(label0)
+        visitVarInsn(ALOAD, 1)
+        visitTypeInsn(NEW, "com/intellij/openapi/wm/RegisterToolWindowTask")
+        visitInsn(DUP)
+        visitMethodInsn(INVOKESPECIAL, "com/intellij/openapi/wm/RegisterToolWindowTask", "<init>", "()V", false)
+        visitMethodInsn(
+          INVOKEVIRTUAL,
+          "com/intellij/openapi/wm/ToolWindowManager",
+          "registerToolWindow",
+          "(Lcom/intellij/openapi/wm/RegisterToolWindowTask;)Lcom/intellij/openapi/wm/ToolWindow;",
+          false
+        )
+        val label1 = Label()
+        visitLabel(label1)
+        visitInsn(ARETURN)
+        visitLocalVariable("twm", "Lcom/intellij/openapi/wm/ToolWindowManager;", null, label0, label1, 1)
+        visitLocalVariable("this", "Lcom/example/plugin/DirectTwCaller;", null, label0, label1, 0)
+        visitMaxs(3, 3)
+        visitEnd()
+      }
+      classWriter.visitEnd()
+      return classWriter.toByteArray()
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/KotlinInlineFunctionDumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/KotlinInlineFunctionDumps.kt
@@ -1,0 +1,509 @@
+/*
+ * Class-file dumps for KotlinInlineFunctionInternalApiUsageTest (MP-7133), obtained by compiling
+ * the Kotlin sources quoted in each KDoc with Kotlin 2.0.21 and converting them with ASMifier.
+ */
+package com.jetbrains.pluginverifier.tests.bytecode
+
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * `@ApiStatus.Internal` SDK interface:
+ * ```
+ * package com.intellij.platform.util.progress
+ *
+ * @ApiStatus.Internal
+ * interface RawProgressReporterHandle {
+ *   val reporter: String
+ *   fun close()
+ * }
+ * ```
+ */
+object RawProgressReporterHandleDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(
+      V11,
+      ACC_PUBLIC or ACC_ABSTRACT or ACC_INTERFACE,
+      "com/intellij/platform/util/progress/RawProgressReporterHandle",
+      null,
+      "java/lang/Object",
+      null
+    )
+    classWriter.visitSource("rawProgress.kt", null)
+    classWriter.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus\$Internal;", false).visitEnd()
+    classWriter.visitInnerClass(
+      "org/jetbrains/annotations/ApiStatus\$Internal",
+      "org/jetbrains/annotations/ApiStatus",
+      "Internal",
+      ACC_PUBLIC or ACC_STATIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE
+    )
+    classWriter.visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "getReporter", "()Ljava/lang/String;", null, null).visitEnd()
+    classWriter.visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "close", "()V", null, null).visitEnd()
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * SDK file facade holding the `@ApiStatus.Internal` function:
+ * ```
+ * @ApiStatus.Internal
+ * fun internalCurrentStepAsRaw(): RawProgressReporterHandle = ...
+ * ```
+ * Also declares the public `inline fun reportRawProgress`, inlined at each call site.
+ */
+object RawProgressKtDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(
+      V11,
+      ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+      "com/intellij/platform/util/progress/RawProgressKt",
+      null,
+      "java/lang/Object",
+      null
+    )
+    classWriter.visitSource("rawProgress.kt", null)
+    classWriter.visitInnerClass(
+      "org/jetbrains/annotations/ApiStatus\$Internal",
+      "org/jetbrains/annotations/ApiStatus",
+      "Internal",
+      ACC_PUBLIC or ACC_STATIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE
+    )
+    classWriter.visitMethod(
+      ACC_PUBLIC or ACC_FINAL or ACC_STATIC,
+      "internalCurrentStepAsRaw",
+      "()Lcom/intellij/platform/util/progress/RawProgressReporterHandle;",
+      null,
+      null
+    ).apply {
+      visitAnnotation("Lorg/jetbrains/annotations/ApiStatus\$Internal;", false).visitEnd()
+      visitCode()
+      visitInsn(ACONST_NULL)
+      visitInsn(ARETURN)
+      visitMaxs(1, 0)
+      visitEnd()
+    }
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * The plugin class:
+ * ```
+ * package com.example.plugin
+ *
+ * import com.intellij.platform.util.progress.reportRawProgress
+ *
+ * class MyAction {
+ *   fun run(): Int = reportRawProgress { reporter -> reporter.length }
+ * }
+ * ```
+ * SMAP maps output lines 10..14 to `rawProgress.kt`. Pass `smapInSourceAttribute = false`
+ * to emulate a tool that stripped the `SourceDebugExtension` attribute.
+ */
+object InlinedCallerDump {
+  private const val SMAP = "SMAP\nMyAction.kt\nKotlin\n*S Kotlin\n*F\n+ 1 MyAction.kt\ncom/example/plugin/MyAction\n" +
+    "+ 2 rawProgress.kt\ncom/intellij/platform/util/progress/RawProgressKt\n*L\n1#1,9:1\n23#2,5:10\n" +
+    "*S KotlinDebug\n*F\n+ 1 MyAction.kt\ncom/example/plugin/MyAction\n*L\n7#1:10,5\n*E\n"
+
+  fun dump(smapInSourceAttribute: Boolean = true): ByteArray {
+    val classWriter = ClassWriter(0)
+
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/MyAction", null, "java/lang/Object", null)
+    classWriter.visitSource("MyAction.kt", if (smapInSourceAttribute) SMAP else null)
+
+    classWriter.visitAnnotation("Lkotlin/Metadata;", true).apply {
+      visit("mv", intArrayOf(2, 0, 0))
+      visit("k", 1)
+      visit("xi", 48)
+      visitArray("d1").apply {
+        visit(
+          null,
+          "\u0000\u0012\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\u0008\u0003\n\u0002\u0010\u0008\n\u0000\u0018" +
+            "\u00002\u00020\u0001B\u0007\u00a2\u0006\u0004\u0008\u0002\u0010\u0003J\u0006\u0010\u0004\u001a\u00020\u0005\u00a8\u0006\u0006"
+        )
+        visitEnd()
+      }
+      visitArray("d2").apply {
+        visit(null, "Lcom/example/plugin/MyAction;")
+        visit(null, "")
+        visit(null, "<init>")
+        visit(null, "()V")
+        visit(null, "run")
+        visit(null, "")
+        visit(null, "plugin")
+        visitEnd()
+      }
+      visitEnd()
+    }
+
+    classWriter.visitAnnotation("Lkotlin/jvm/internal/SourceDebugExtension;", false).apply {
+      visitArray("value").apply {
+        visit(null, SMAP)
+        visitEnd()
+      }
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitLineNumber(6, label0)
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLocalVariable("this", "Lcom/example/plugin/MyAction;", null, label0, label1, 0)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      val label1 = Label()
+      val label2 = Label()
+      visitTryCatchBlock(label0, label1, label2, null)
+      val label3 = Label()
+      visitTryCatchBlock(label2, label3, label2, null)
+      val label4 = Label()
+      visitLabel(label4)
+      visitLineNumber(7, label4)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 1)
+      val label5 = Label()
+      visitLabel(label5)
+      visitLineNumber(10, label5)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/RawProgressKt",
+        "internalCurrentStepAsRaw",
+        "()Lcom/intellij/platform/util/progress/RawProgressReporterHandle;",
+        false
+      )
+      visitVarInsn(ASTORE, 2)
+      visitLabel(label0)
+      visitLineNumber(11, label0)
+      visitInsn(NOP)
+      val label6 = Label()
+      visitLabel(label6)
+      visitLineNumber(12, label6)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/RawProgressReporterHandle",
+        "getReporter",
+        "()Ljava/lang/String;",
+        true
+      )
+      visitVarInsn(ASTORE, 3)
+      val label7 = Label()
+      visitLabel(label7)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 4)
+      val label8 = Label()
+      visitLabel(label8)
+      visitLineNumber(7, label8)
+      visitVarInsn(ALOAD, 3)
+      visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false)
+      val label9 = Label()
+      visitLabel(label9)
+      visitLineNumber(12, label9)
+      visitVarInsn(ISTORE, 3)
+      visitLabel(label1)
+      visitLineNumber(14, label1)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/RawProgressReporterHandle",
+        "close",
+        "()V",
+        true
+      )
+      visitVarInsn(ILOAD, 3)
+      val label10 = Label()
+      visitLabel(label10)
+      visitLineNumber(12, label10)
+      val label11 = Label()
+      visitJumpInsn(GOTO, label11)
+      visitLabel(label2)
+      visitLineNumber(14, label2)
+      visitFrame(
+        F_FULL,
+        3,
+        arrayOf<Any>("com/example/plugin/MyAction", INTEGER, "com/intellij/platform/util/progress/RawProgressReporterHandle"),
+        1,
+        arrayOf<Any>("java/lang/Throwable")
+      )
+      visitVarInsn(ASTORE, 4)
+      visitLabel(label3)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/RawProgressReporterHandle",
+        "close",
+        "()V",
+        true
+      )
+      visitVarInsn(ALOAD, 4)
+      visitInsn(ATHROW)
+      visitLabel(label11)
+      visitLineNumber(7, label11)
+      visitFrame(
+        F_FULL,
+        5,
+        arrayOf<Any>("com/example/plugin/MyAction", INTEGER, "com/intellij/platform/util/progress/RawProgressReporterHandle", INTEGER, INTEGER),
+        1,
+        arrayOf<Any>(INTEGER)
+      )
+      visitInsn(IRETURN)
+      val label12 = Label()
+      visitLabel(label12)
+      visitLocalVariable("\$i\$a\$-reportRawProgress-MyAction\$run\$1", "I", null, label8, label9, 4)
+      visitLocalVariable("reporter", "Ljava/lang/String;", null, label7, label9, 3)
+      visitLocalVariable("\$i\$f\$reportRawProgress", "I", null, label5, label11, 1)
+      visitLocalVariable("handle\$iv", "Lcom/intellij/platform/util/progress/RawProgressReporterHandle;", null, label0, label11, 2)
+      visitLocalVariable("this", "Lcom/example/plugin/MyAction;", null, label4, label12, 0)
+      visitMaxs(1, 5)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * Control case: plugin code invoking the internal API directly, without any inlining markers:
+ * ```
+ * package com.example.plugin
+ *
+ * class DirectUsage {
+ *   fun run(): Int = internalCurrentStepAsRaw().reporter.length
+ * }
+ * ```
+ * Such usage must always be reported.
+ */
+object DirectCallerDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/DirectUsage", null, "java/lang/Object", null)
+    classWriter.visitSource("DirectUsage.kt", null)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/RawProgressKt",
+        "internalCurrentStepAsRaw",
+        "()Lcom/intellij/platform/util/progress/RawProgressReporterHandle;",
+        false
+      )
+      visitVarInsn(ASTORE, 1)
+      visitVarInsn(ALOAD, 1)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/RawProgressReporterHandle",
+        "getReporter",
+        "()Ljava/lang/String;",
+        true
+      )
+      visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false)
+      visitInsn(IRETURN)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLocalVariable("this", "Lcom/example/plugin/DirectUsage;", null, label0, label1, 0)
+      visitLocalVariable("handle", "Lcom/intellij/platform/util/progress/RawProgressReporterHandle;", null, label0, label1, 1)
+      visitMaxs(1, 2)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * Caller whose inlined code originates from the plugin's own
+ * `inline fun useProgress() { internalCurrentStepAsRaw() }` declared in its `utils.kt`:
+ * ```
+ * package com.example.plugin
+ *
+ * class OwnCaller {
+ *   fun run(): Int {
+ *     useProgress()
+ *     return 0
+ *   }
+ * }
+ * ```
+ * SMAP maps the inlined lines 10..14 to the plugin's own `UtilsKt` class.
+ */
+object OwnInlineCallerDump {
+  private const val SMAP = "SMAP\nOwnCaller.kt\nKotlin\n*S Kotlin\n*F\n+ 1 OwnCaller.kt\ncom/example/plugin/OwnCaller\n+ 2 utils.kt\ncom/example/plugin/UtilsKt\n*L\n1#1,9:1\n23#2,5:10\n*S KotlinDebug\n*F\n+ 1 OwnCaller.kt\ncom/example/plugin/OwnCaller\n*L\n7#1:10,5\n*E\n"
+
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/OwnCaller", null, "java/lang/Object", null)
+    classWriter.visitSource("OwnCaller.kt", SMAP)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitLineNumber(7, label0)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 1)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLineNumber(10, label1)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/RawProgressKt",
+        "internalCurrentStepAsRaw",
+        "()Lcom/intellij/platform/util/progress/RawProgressReporterHandle;",
+        false
+      )
+      visitInsn(POP)
+      val label2 = Label()
+      visitLabel(label2)
+      visitLineNumber(8, label2)
+      visitInsn(ICONST_0)
+      visitInsn(IRETURN)
+      val label3 = Label()
+      visitLabel(label3)
+      visitLocalVariable("\$i\$f\$useProgress", "I", null, label1, label2, 1)
+      visitLocalVariable("this", "Lcom/example/plugin/OwnCaller;", null, label0, label3, 0)
+      visitMaxs(1, 2)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * The plugin's own `utils.kt` file facade declaring `inline fun useProgress()`. Its presence
+ * lets the verifier resolve the SMAP origin of [OwnInlineCallerDump] to a class of the plugin.
+ */
+object PluginUtilsKtDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/UtilsKt", null, "java/lang/Object", null)
+    classWriter.visitSource("utils.kt", null)
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * The `MyAction\$run\$1` suspend lambda class generated for the shape reported in MP-7133:
+ * ```
+ * class MyAction {
+ *   suspend fun run(): Int = withBackgroundProgress(project, title) {
+ *     reportRawProgress { reporter -> reporter.length }
+ *   }
+ * }
+ * ```
+ * SMAP is attached to the lambda class itself. Coroutine machinery is simplified
+ * (extends `Object` instead of `SuspendLambda`): only the caller shape matters here.
+ */
+object SuspendLambdaCallerDump {
+  private const val SMAP = "SMAP\nMyAction.kt\nKotlin\n*S Kotlin\n*F\n+ 1 MyAction.kt\ncom/example/plugin/MyAction\$run\$1\n+ 2 rawProgress.kt\ncom/intellij/platform/util/progress/RawProgressKt\n*L\n1#1,9:1\n23#2,5:10\n*S KotlinDebug\n*F\n+ 1 MyAction.kt\ncom/example/plugin/MyAction\$run\$1\n*L\n7#1:10,5\n*E\n"
+
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(
+      V11,
+      ACC_FINAL or ACC_SUPER,
+      "com/example/plugin/MyAction\$run\$1",
+      null,
+      "java/lang/Object",
+      null
+    )
+    classWriter.visitSource("MyAction.kt", SMAP)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "invokeSuspend", "(Ljava/lang/Object;)Ljava/lang/Object;", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitLineNumber(7, label0)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 2)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLineNumber(10, label1)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/RawProgressKt",
+        "internalCurrentStepAsRaw",
+        "()Lcom/intellij/platform/util/progress/RawProgressReporterHandle;",
+        false
+      )
+      visitVarInsn(ASTORE, 3)
+      val label2 = Label()
+      visitLabel(label2)
+      visitLineNumber(14, label2)
+      visitVarInsn(ALOAD, 3)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/RawProgressReporterHandle",
+        "close",
+        "()V",
+        true
+      )
+      val label3 = Label()
+      visitLabel(label3)
+      visitLineNumber(8, label3)
+      visitInsn(ACONST_NULL)
+      visitInsn(ARETURN)
+      val label4 = Label()
+      visitLabel(label4)
+      visitLocalVariable("\$i\$f\$reportRawProgress", "I", null, label1, label3, 2)
+      visitLocalVariable("handle\$iv", "Lcom/intellij/platform/util/progress/RawProgressReporterHandle;", null, label2, label3, 3)
+      visitLocalVariable("this", "Lcom/example/plugin/MyAction\$run\$1;", null, label0, label4, 0)
+      visitLocalVariable("result", "Ljava/lang/Object;", null, label0, label4, 1)
+      visitMaxs(1, 4)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/KotlinInlineFunctionExperimentalApiDumps.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/bytecode/KotlinInlineFunctionExperimentalApiDumps.kt
@@ -1,0 +1,392 @@
+/*
+ * Class-file dumps for KotlinInlineFunctionExperimentalApiUsageTest (MP-7133), obtained by compiling
+ * the Kotlin sources quoted in each KDoc with Kotlin 2.0.21 and converting them with ASMifier.
+ */
+package com.jetbrains.pluginverifier.tests.bytecode
+
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.Opcodes.*
+
+/**
+ * `@ApiStatus.Experimental` SDK interface:
+ * ```
+ * package com.intellij.platform.util.progress
+ *
+ * @ApiStatus.Experimental
+ * interface ExperimentalReporterHandle {
+ *   val reporter: String
+ *   fun close()
+ * }
+ * ```
+ */
+object ExperimentalReporterHandleDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(
+      V11,
+      ACC_PUBLIC or ACC_ABSTRACT or ACC_INTERFACE,
+      "com/intellij/platform/util/progress/ExperimentalReporterHandle",
+      null,
+      "java/lang/Object",
+      null
+    )
+    classWriter.visitSource("experimentalProgress.kt", null)
+    classWriter.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus\$Experimental;", false).visitEnd()
+    classWriter.visitInnerClass(
+      "org/jetbrains/annotations/ApiStatus\$Experimental",
+      "org/jetbrains/annotations/ApiStatus",
+      "Experimental",
+      ACC_PUBLIC or ACC_STATIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE
+    )
+    classWriter.visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "getReporter", "()Ljava/lang/String;", null, null).visitEnd()
+    classWriter.visitMethod(ACC_PUBLIC or ACC_ABSTRACT, "close", "()V", null, null).visitEnd()
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * SDK file facade holding the `@ApiStatus.Experimental` function:
+ * ```
+ * @ApiStatus.Experimental
+ * fun experimentalCurrentStep(): ExperimentalReporterHandle = ...
+ * ```
+ * Also declares the public `inline fun reportExperimentalProgress`, inlined at each call site.
+ */
+object ExperimentalProgressKtDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(
+      V11,
+      ACC_PUBLIC or ACC_FINAL or ACC_SUPER,
+      "com/intellij/platform/util/progress/ExperimentalProgressKt",
+      null,
+      "java/lang/Object",
+      null
+    )
+    classWriter.visitSource("experimentalProgress.kt", null)
+    classWriter.visitInnerClass(
+      "org/jetbrains/annotations/ApiStatus\$Experimental",
+      "org/jetbrains/annotations/ApiStatus",
+      "Experimental",
+      ACC_PUBLIC or ACC_STATIC or ACC_ANNOTATION or ACC_ABSTRACT or ACC_INTERFACE
+    )
+    classWriter.visitMethod(
+      ACC_PUBLIC or ACC_FINAL or ACC_STATIC,
+      "experimentalCurrentStep",
+      "()Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;",
+      null,
+      null
+    ).apply {
+      visitAnnotation("Lorg/jetbrains/annotations/ApiStatus\$Experimental;", false).visitEnd()
+      visitCode()
+      visitInsn(ACONST_NULL)
+      visitInsn(ARETURN)
+      visitMaxs(1, 0)
+      visitEnd()
+    }
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * The plugin class:
+ * ```
+ * package com.example.plugin
+ *
+ * import com.intellij.platform.util.progress.reportExperimentalProgress
+ *
+ * class MyExperimentalAction {
+ *   fun run(): Int = reportExperimentalProgress { reporter -> reporter.length }
+ * }
+ * ```
+ * The source only calls the public `reportExperimentalProgress`, but the compiled `run()`
+ * contains the inlined experimental API calls plus the compiler's inlining markers, and an SMAP
+ * mapping output lines 10..14 to `experimentalProgress.kt`.
+ */
+object ExperimentalInlinedCallerDump {
+  private const val SMAP = "SMAP\nMyExperimentalAction.kt\nKotlin\n*S Kotlin\n*F\n+ 1 MyExperimentalAction.kt\n" +
+    "com/example/plugin/MyExperimentalAction\n+ 2 experimentalProgress.kt\n" +
+    "com/intellij/platform/util/progress/ExperimentalProgressKt\n*L\n1#1,9:1\n23#2,5:10\n" +
+    "*S KotlinDebug\n*F\n+ 1 MyExperimentalAction.kt\ncom/example/plugin/MyExperimentalAction\n*L\n7#1:10,5\n*E\n"
+
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/MyExperimentalAction", null, "java/lang/Object", null)
+    classWriter.visitSource("MyExperimentalAction.kt", SMAP)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      val label1 = Label()
+      val label2 = Label()
+      visitTryCatchBlock(label0, label1, label2, null)
+      val label3 = Label()
+      visitTryCatchBlock(label2, label3, label2, null)
+      val label4 = Label()
+      visitLabel(label4)
+      visitLineNumber(7, label4)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 1)
+      val label5 = Label()
+      visitLabel(label5)
+      visitLineNumber(10, label5)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/ExperimentalProgressKt",
+        "experimentalCurrentStep",
+        "()Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;",
+        false
+      )
+      visitVarInsn(ASTORE, 2)
+      visitLabel(label0)
+      visitLineNumber(11, label0)
+      visitInsn(NOP)
+      val label6 = Label()
+      visitLabel(label6)
+      visitLineNumber(12, label6)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/ExperimentalReporterHandle",
+        "getReporter",
+        "()Ljava/lang/String;",
+        true
+      )
+      visitVarInsn(ASTORE, 3)
+      val label7 = Label()
+      visitLabel(label7)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 4)
+      val label8 = Label()
+      visitLabel(label8)
+      visitLineNumber(7, label8)
+      visitVarInsn(ALOAD, 3)
+      visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false)
+      val label9 = Label()
+      visitLabel(label9)
+      visitLineNumber(12, label9)
+      visitVarInsn(ISTORE, 3)
+      visitLabel(label1)
+      visitLineNumber(14, label1)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/ExperimentalReporterHandle",
+        "close",
+        "()V",
+        true
+      )
+      visitVarInsn(ILOAD, 3)
+      val label10 = Label()
+      visitLabel(label10)
+      visitLineNumber(12, label10)
+      val label11 = Label()
+      visitJumpInsn(GOTO, label11)
+      visitLabel(label2)
+      visitLineNumber(14, label2)
+      visitFrame(
+        F_FULL,
+        3,
+        arrayOf<Any>("com/example/plugin/MyExperimentalAction", INTEGER, "com/intellij/platform/util/progress/ExperimentalReporterHandle"),
+        1,
+        arrayOf<Any>("java/lang/Throwable")
+      )
+      visitVarInsn(ASTORE, 4)
+      visitLabel(label3)
+      visitVarInsn(ALOAD, 2)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/ExperimentalReporterHandle",
+        "close",
+        "()V",
+        true
+      )
+      visitVarInsn(ALOAD, 4)
+      visitInsn(ATHROW)
+      visitLabel(label11)
+      visitLineNumber(7, label11)
+      visitFrame(
+        F_FULL,
+        5,
+        arrayOf<Any>("com/example/plugin/MyExperimentalAction", INTEGER, "com/intellij/platform/util/progress/ExperimentalReporterHandle", INTEGER, INTEGER),
+        1,
+        arrayOf<Any>(INTEGER)
+      )
+      visitInsn(IRETURN)
+      val label12 = Label()
+      visitLabel(label12)
+      visitLocalVariable("\$i\$a\$-reportExperimentalProgress-MyExperimentalAction\$run\$1", "I", null, label8, label9, 4)
+      visitLocalVariable("reporter", "Ljava/lang/String;", null, label7, label9, 3)
+      visitLocalVariable("\$i\$f\$reportExperimentalProgress", "I", null, label5, label11, 1)
+      visitLocalVariable("handle\$iv", "Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;", null, label0, label11, 2)
+      visitLocalVariable("this", "Lcom/example/plugin/MyExperimentalAction;", null, label4, label12, 0)
+      visitMaxs(1, 5)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * Control case: plugin code invoking the experimental API directly, without any inlining
+ * markers:
+ * ```
+ * package com.example.plugin
+ *
+ * class DirectExperimentalUsage {
+ *   fun run(): Int = experimentalCurrentStep().reporter.length
+ * }
+ * ```
+ * Such usage must always be reported.
+ */
+object DirectExperimentalCallerDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/DirectExperimentalUsage", null, "java/lang/Object", null)
+    classWriter.visitSource("DirectExperimentalUsage.kt", null)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/ExperimentalProgressKt",
+        "experimentalCurrentStep",
+        "()Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;",
+        false
+      )
+      visitVarInsn(ASTORE, 1)
+      visitVarInsn(ALOAD, 1)
+      visitMethodInsn(
+        INVOKEINTERFACE,
+        "com/intellij/platform/util/progress/ExperimentalReporterHandle",
+        "getReporter",
+        "()Ljava/lang/String;",
+        true
+      )
+      visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false)
+      visitInsn(IRETURN)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLocalVariable("this", "Lcom/example/plugin/DirectExperimentalUsage;", null, label0, label1, 0)
+      visitLocalVariable("handle", "Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;", null, label0, label1, 1)
+      visitMaxs(1, 2)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * Caller whose inlined code originates from the plugin's own
+ * `inline fun useExperimentalProgress() { experimentalCurrentStep() }` declared in its
+ * `utils.kt`:
+ * ```
+ * package com.example.plugin
+ *
+ * class OwnExperimentalCaller {
+ *   fun run(): Int {
+ *     useExperimentalProgress()
+ *     return 0
+ *   }
+ * }
+ * ```
+ * SMAP maps the inlined lines 10..14 to the plugin's own `UtilsKt` class.
+ */
+object OwnExperimentalInlineCallerDump {
+  private const val SMAP = "SMAP\nOwnExperimentalCaller.kt\nKotlin\n*S Kotlin\n*F\n+ 1 OwnExperimentalCaller.kt\n" +
+    "com/example/plugin/OwnExperimentalCaller\n+ 2 utils.kt\ncom/example/plugin/ExperimentalUtilsKt\n*L\n1#1,9:1\n23#2,5:10\n" +
+    "*S KotlinDebug\n*F\n+ 1 OwnExperimentalCaller.kt\ncom/example/plugin/OwnExperimentalCaller\n*L\n7#1:10,5\n*E\n"
+
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/OwnExperimentalCaller", null, "java/lang/Object", null)
+    classWriter.visitSource("OwnExperimentalCaller.kt", SMAP)
+
+    classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
+      visitCode()
+      visitVarInsn(ALOAD, 0)
+      visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+      visitInsn(RETURN)
+      visitMaxs(1, 1)
+      visitEnd()
+    }
+
+    classWriter.visitMethod(ACC_PUBLIC or ACC_FINAL, "run", "()I", null, null).apply {
+      visitCode()
+      val label0 = Label()
+      visitLabel(label0)
+      visitLineNumber(7, label0)
+      visitInsn(ICONST_0)
+      visitVarInsn(ISTORE, 1)
+      val label1 = Label()
+      visitLabel(label1)
+      visitLineNumber(10, label1)
+      visitMethodInsn(
+        INVOKESTATIC,
+        "com/intellij/platform/util/progress/ExperimentalProgressKt",
+        "experimentalCurrentStep",
+        "()Lcom/intellij/platform/util/progress/ExperimentalReporterHandle;",
+        false
+      )
+      visitInsn(POP)
+      val label2 = Label()
+      visitLabel(label2)
+      visitLineNumber(8, label2)
+      visitInsn(ICONST_0)
+      visitInsn(IRETURN)
+      val label3 = Label()
+      visitLabel(label3)
+      visitLocalVariable("\$i\$f\$useExperimentalProgress", "I", null, label1, label2, 1)
+      visitLocalVariable("this", "Lcom/example/plugin/OwnExperimentalCaller;", null, label0, label3, 0)
+      visitMaxs(1, 2)
+      visitEnd()
+    }
+
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}
+
+/**
+ * The plugin's own `utils.kt` file facade declaring `inline fun useExperimentalProgress()`. Its
+ * presence lets the verifier resolve the SMAP origin of [OwnExperimentalInlineCallerDump] to a
+ * class of the plugin.
+ */
+object PluginExperimentalUtilsKtDump {
+  fun dump(): ByteArray {
+    val classWriter = ClassWriter(0)
+    classWriter.visit(V11, ACC_PUBLIC or ACC_FINAL or ACC_SUPER, "com/example/plugin/ExperimentalUtilsKt", null, "java/lang/Object", null)
+    classWriter.visitSource("utils.kt", null)
+    classWriter.visitEnd()
+    return classWriter.toByteArray()
+  }
+}


### PR DESCRIPTION
Fixes [MP-7133](https://youtrack.jetbrains.com/issue/MP-7133)

## Root cause

Kotlin's `inline fun` bodies get copied into the caller's class file at compile time. So if a plugin calls a public inline function whose body uses `@ApiStatus.Internal` API, the verifier reports that the plugin uses internal API, which is not the case.
Simiarly with `@ApiStatus.OverrideOnly` and `@ApiStatus.Experimental`.

## Fix

Kotlin already embeds an SMAP in compiled class files, so it's possible to know the origin of an inlined instruction.
It can be know from:
- the class-file attribute
- or (if the class-file attribute was stripped) from the `SourceDebugExtension` annotation 

`KotlinInlinedCodeDetector` reads the SMAP, check if the origin is from outside the plugin, and if yes, suppresses the report for:
- internal API (`@ApiStatus.Internal`, `@IntellijInternalApi`, Kotlin `internal`) — both method invocations and class references
- `@ApiStatus.OverrideOnly` — method invocations
- `@ApiStatus.Experimental` — method invocations and class references

If we can't determine the origin, we don't suppress.

## Testing

Unit tests for:
- reproducing the false positives (using bytecode dumps)
- verified locally with a sample of real marketplace plugins. Results: `rust` dropped from 1594 to 1541 internal usages, `IdeaVIM` from 353 to 346, and `minecraft-dev` from 227 to 215 experimental usages. For other 15 plugins tested - no changes.