### PR TITLE
Cache ContentModuleScanner results to fix Junie perf issue

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/IdePluginManager.kt
@@ -52,6 +52,7 @@ class IdePluginManager private constructor(
   private val moduleFromDescriptorLoader = pluginLoaderRegistry.get<ModuleFromDescriptorLoader.Context, ModuleFromDescriptorLoader>()
   private val jarModuleLoader = pluginLoaderRegistry.get<JarModuleLoader.Context, JarModuleLoader>()
   private val jarOrDirLoader = pluginLoaderRegistry.get<JarOrDirectoryPluginLoader.Context, JarOrDirectoryPluginLoader>()
+  private val libDirectoryLoader = pluginLoaderRegistry.get<LibDirectoryPluginLoader.Context, LibDirectoryPluginLoader>()
 
   private val contentModuleLoader = ContentModuleLoader(jarOrDirLoader, moduleFromDescriptorLoader)
 
@@ -210,11 +211,16 @@ class IdePluginManager private constructor(
     resourceResolver: ResourceResolver,
     problemResolver: PluginCreationResultResolver
   ): PluginCreator {
-    val pluginCreator = jarOrDirLoader.loadPlugin(JarOrDirectoryPluginLoader.Context(pluginFile, descriptorPath, validateDescriptor, resourceResolver, null, problemResolver))
-    resolveOptionalDependencies(pluginFile, pluginCreator, myResourceResolver, problemResolver)
-    resolveContentModules(pluginFile, pluginCreator, myResourceResolver, problemResolver)
+    try {
+      val pluginCreator = jarOrDirLoader.loadPlugin(JarOrDirectoryPluginLoader.Context(pluginFile, descriptorPath, validateDescriptor, resourceResolver, null, problemResolver))
+      resolveOptionalDependencies(pluginFile, pluginCreator, myResourceResolver, problemResolver)
+      resolveContentModules(pluginFile, pluginCreator, myResourceResolver, problemResolver)
 
-    return pluginCreator
+      return pluginCreator
+    } finally {
+      //The 'lib' directory is indexed for the duration of a single plugin artifact parse only.
+      libDirectoryLoader.invalidateDescriptorIndex(pluginFile)
+    }
   }
 
   private fun getInvalidPluginFileCreator(pluginFileName: String, descriptorPath: String): PluginCreator {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
@@ -20,6 +20,9 @@ import com.jetbrains.plugin.structure.intellij.resources.JarsResourceResolver
 import com.jetbrains.plugin.structure.intellij.resources.ResourceResolver
 import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+private const val JAR_ROOT_DESCRIPTOR_PREFIX = "../"
 
 internal class LibDirectoryPluginLoader(
   private val pluginLoaderRegistry: PluginLoaderProvider,
@@ -36,6 +39,16 @@ internal class LibDirectoryPluginLoader(
 
   private val libDirClasspathProvider = LibDirJarsClasspathProvider()
 
+  /**
+   * Descriptor indexes of plugin artifacts that are currently being parsed, see [ContentModuleScanner.getDescriptorIndex].
+   *
+   * A single plugin artifact parse resolves the plugin descriptor, every content module descriptor and every
+   * optional dependency descriptor from the same `lib` directory, so the directory is indexed once per parse.
+   * Entries are discarded by [invalidateDescriptorIndex] as soon as the parse completes: an index is of no use
+   * for other plugin artifacts, as each of them has its own `lib` directory.
+   */
+  private val descriptorIndexes = ConcurrentHashMap<Path, Map<String, List<Path>>>()
+
   override fun loadPlugin(pluginLoadingContext: Context): PluginCreator = with(pluginLoadingContext) {
     val libDir = libDirectoryParent.resolve("lib")
     val hasDotNetDirectory = libDirectoryParent.resolve("dotnet").exists()
@@ -51,7 +64,7 @@ internal class LibDirectoryPluginLoader(
     val compositeResolver: ResourceResolver = CompositeResourceResolver(listOf(libResourceResolver, resourceResolver))
 
     val results: MutableList<PluginCreator> = ArrayList()
-    for (file in files) {
+    for (file in getDescriptorProviders(libDirectoryParent, descriptorPath, files)) {
       val innerCreator: PluginCreator = if (file.isJar() || file.isZip()) {
         //Use the composite resource resolver, which can resolve resources in lib's jar files.
         jarLoader.loadPlugin(
@@ -110,6 +123,45 @@ internal class LibDirectoryPluginLoader(
       }
     }
   }
+
+  /**
+   * Discards the descriptor index of [pluginArtifactPath] and of any plugin artifact nested in it.
+   * Invoked once a plugin artifact parse completes, see [descriptorIndexes].
+   */
+  internal fun invalidateDescriptorIndex(pluginArtifactPath: Path) {
+    descriptorIndexes.keys.removeIf { it.startsWith(pluginArtifactPath) }
+  }
+
+  /**
+   * Returns those [files] of the `lib` directory that can provide [descriptorPath]: JARs indexed as containing
+   * such a descriptor, along with every directory, as directories are not indexed.
+   *
+   * All [files] are returned for a [descriptorPath] the index cannot answer for, see [getIndexableDescriptorName].
+   * The order of [files] is retained, so that an ambiguous descriptor is reported with the same pair of files
+   * as when every file is probed.
+   */
+  private fun getDescriptorProviders(libDirectoryParent: Path, descriptorPath: String, files: List<Path>): List<Path> {
+    val descriptorName = getIndexableDescriptorName(descriptorPath) ?: return files
+    val index = descriptorIndexes.computeIfAbsent(libDirectoryParent) { contentModuleScanner.getDescriptorIndex(it) }
+    val jars: Set<Path> = index[descriptorName]?.toHashSet() ?: emptySet()
+    return files.filter { it in jars || it.isDirectory }
+  }
+
+  /**
+   * Returns the file name under which [descriptorPath] is indexed, or `null` if it is not indexed at all.
+   *
+   * A JAR is searched for a descriptor in its `META-INF` directory, hence a `../` prefix escapes `META-INF`
+   * and denotes a descriptor in a JAR root. Such content module descriptors are the only indexed ones:
+   * a plugin artifact is parsed once, so indexing its `lib` directory to resolve a single `META-INF` descriptor
+   * would scan the very JARs the index saves from being scanned. Any other descriptor path may also resolve
+   * to an arbitrary JAR entry, which the index does not cover.
+   */
+  private fun getIndexableDescriptorName(descriptorPath: String): String? =
+    if (descriptorPath.startsWith(JAR_ROOT_DESCRIPTOR_PREFIX)) {
+      descriptorPath.removePrefix(JAR_ROOT_DESCRIPTOR_PREFIX).takeIf { it.isNotEmpty() && '/' !in it }
+    } else {
+      null
+    }
 
   private fun PluginCreator.withResolvedClasspath(path: Path): PluginCreator = apply {
     val libDirClasspath = libDirClasspathProvider.getClasspath(path)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -27,22 +27,46 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
   private val ideaPluginXmlDetector = createIdeaPluginXmlDetector()
 
   fun getContentModules(pluginArtifact: Path) : ContentModules {
-    val libDir = pluginArtifact.resolve(LIB_DIRECTORY)
-    if (!libDir.exists()) {
-      return ContentModules(pluginArtifact, emptyList())
-    }
-    val jarPaths = libDir.listJars()
-    val moduleJarPaths = libDir.resolve(MODULES_DIR).listJars()
-    val contentModules = (jarPaths + moduleJarPaths).flatMap { jarPath ->
+    val jarPaths = getLibJarPaths(pluginArtifact)
+      ?: return ContentModules(pluginArtifact, emptyList())
+    val contentModules = jarPaths.flatMap { jarPath ->
       getJarContentModules(jarPath)
     }
 
     return ContentModules(pluginArtifact, contentModules)
   }
 
+  /**
+   * Maps a plugin descriptor file name to the JARs of [pluginArtifact] that contain such a descriptor.
+   *
+   * Keys are bare file names: a descriptor is either `META-INF/plugin.xml` or a Plugin Model V2 module
+   * descriptor in a JAR root, hence its file name identifies it within a single plugin artifact.
+   * This allows a plugin loader to open only those JARs that can provide a requested descriptor
+   * instead of every JAR of the plugin.
+   */
+  fun getDescriptorIndex(pluginArtifact: Path): Map<String, List<Path>> {
+    val jarPaths = getLibJarPaths(pluginArtifact) ?: return emptyMap()
+    return jarPaths
+      .flatMap { jarPath -> getJarDescriptorNames(jarPath).map { descriptorName -> descriptorName to jarPath } }
+      .groupBy({ (descriptorName, _) -> descriptorName }, { (_, jarPath) -> jarPath })
+  }
+
+  private fun getLibJarPaths(pluginArtifact: Path): List<Path>? {
+    val libDir = pluginArtifact.resolve(LIB_DIRECTORY)
+    if (!libDir.exists()) {
+      return null
+    }
+    return libDir.listJars() + libDir.resolve(MODULES_DIR).listJars()
+  }
+
   private fun getJarContentModules(jarPath: Path): List<ContentModule> = withPluginJar(jarPath) { jar ->
     jar.resolveDescriptors { it.isDescriptor() }
       .map { resolveContentModule(jarPath, it) }
+  } ?: emptyList()
+
+  private fun getJarDescriptorNames(jarPath: Path): List<String> = withPluginJar(jarPath) { jar ->
+    jar.resolveDescriptors { it.isDescriptor() }
+      .map { it.fileName.toString() }
   } ?: emptyList()
 
   private fun resolveContentModule(jarPath: Path, descriptorPath: Path): ContentModule {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ContentModuleDescriptorResolutionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ContentModuleDescriptorResolutionTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2000-2025 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.plugin.structure.intellij.plugin
+
+import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import com.jetbrains.plugin.structure.intellij.resources.DefaultResourceResolver
+import com.jetbrains.plugin.structure.jar.JarFileSystemProvider
+import com.jetbrains.plugin.structure.jar.SingletonCachingJarFileSystemProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.FileSystem
+import java.nio.file.Path
+
+/**
+ * Verifies how a content module descriptor that resides in a JAR of the plugin `lib` directory is resolved.
+ *
+ * Such a descriptor is searched for in the whole `lib` directory, as its declaration in `plugin.xml` does not
+ * indicate which JAR provides it.
+ */
+class ContentModuleDescriptorResolutionTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `content module descriptor available in a single JAR is resolved with the plugin classpath`() {
+    val pluginPath = buildPlugin("single-provider", moduleNames = listOf("example.module"), moduleJarNames = listOf("modules.jar"), auxiliaryJarCount = 3)
+
+    val plugin = createPlugin(pluginPath)
+
+    val moduleDescriptor = plugin.modulesDescriptors.single()
+    assertEquals("example.module", moduleDescriptor.name)
+    /*
+    The module is loaded via the plugin `lib` directory, hence it is aware of the whole plugin classpath.
+    Resolving it directly from its own JAR would leave the classpath empty.
+    */
+    assertTrue(moduleDescriptor.module.classpath.entries.isNotEmpty())
+  }
+
+  @Test
+  fun `content module descriptor available in multiple JARs is reported as ambiguous and is not resolved`() {
+    val pluginPath = buildPlugin(
+      "multiple-providers",
+      moduleNames = listOf("example.module"),
+      moduleJarNames = listOf("modules-a.jar", "modules-b.jar"),
+      auxiliaryJarCount = 3
+    )
+
+    val creationResult = createManager(SingletonCachingJarFileSystemProvider).createPlugin(pluginPath, false)
+    assertTrue("Expected a successfully created plugin but got $creationResult", creationResult is PluginCreationSuccess)
+    creationResult as PluginCreationSuccess
+
+    assertTrue("Expected an unresolved module but got ${creationResult.plugin.modulesDescriptors}", creationResult.plugin.modulesDescriptors.isEmpty())
+
+    val ambiguityWarnings = creationResult.warnings.filter { it.message.contains("Found multiple plugin descriptors") }
+    assertEquals("Expected a single ambiguity warning but got ${creationResult.warnings}", 1, ambiguityWarnings.size)
+    assertTrue(ambiguityWarnings.single().message.contains("example.module"))
+  }
+
+  @Test
+  fun `content module descriptors are not searched for in every JAR of the plugin`() {
+    val moduleNames = (1..10).map { "example.module$it" }
+
+    val fewJars = countJarFileSystems("few-auxiliary-jars", moduleNames, auxiliaryJarCount = 5)
+    val manyJars = countJarFileSystems("many-auxiliary-jars", moduleNames, auxiliaryJarCount = 45)
+
+    /*
+    A JAR that provides no descriptor of this plugin is opened a constant number of times per plugin:
+    to resolve the plugin descriptor, to index the `lib` directory and to resolve the plugin classpath.
+    Adding such JARs must not cost anything per content module, as it did when every content module was
+    searched for in every JAR of the `lib` directory.
+    */
+    val addedJars = 45 - 5
+    val growthPerAddedJar = (manyJars - fewJars).toDouble() / addedJars
+    assertTrue(
+      "Opening $addedJars more JARs that provide no descriptor grew the number of opened JAR file systems " +
+        "from $fewJars to $manyJars, which is ${"%.1f".format(growthPerAddedJar)} per added JAR. " +
+        "It must not scale with the ${moduleNames.size} content modules of the plugin.",
+      growthPerAddedJar < 6
+    )
+  }
+
+  private fun countJarFileSystems(pluginName: String, moduleNames: List<String>, auxiliaryJarCount: Int): Int {
+    val pluginPath = buildPlugin(pluginName, moduleNames, moduleJarNames = listOf("modules.jar"), auxiliaryJarCount = auxiliaryJarCount)
+    val countingProvider = CountingJarFileSystemProvider(SingletonCachingJarFileSystemProvider)
+
+    val plugin = createPlugin(pluginPath, countingProvider)
+    assertEquals(moduleNames.size, plugin.modulesDescriptors.size)
+
+    return countingProvider.getFileSystemCalls
+  }
+
+  private fun createPlugin(pluginPath: Path, fileSystemProvider: JarFileSystemProvider = SingletonCachingJarFileSystemProvider): IdePlugin {
+    val creationResult = createManager(fileSystemProvider).createPlugin(pluginPath, false)
+    assertTrue("Expected a successfully created plugin but got $creationResult", creationResult is PluginCreationSuccess)
+    return (creationResult as PluginCreationSuccess).plugin
+  }
+
+  private fun createManager(fileSystemProvider: JarFileSystemProvider) =
+    IdePluginManager.createManager(DefaultResourceResolver, temporaryFolder.newFolder().toPath(), fileSystemProvider)
+
+  /**
+   * Builds a plugin directory where each of [moduleJarNames] provides a descriptor of every module of
+   * [moduleNames], accompanied by [auxiliaryJarCount] JARs that provide no descriptor at all.
+   */
+  private fun buildPlugin(
+    pluginName: String,
+    moduleNames: List<String>,
+    moduleJarNames: List<String>,
+    auxiliaryJarCount: Int
+  ): Path = buildDirectory(temporaryFolder.newFolder(pluginName).toPath()) {
+    dir("lib") {
+      zip("main.jar") {
+        dir("META-INF") {
+          file("plugin.xml", pluginXml(moduleNames))
+        }
+      }
+      moduleJarNames.forEach { moduleJarName ->
+        zip(moduleJarName) {
+          moduleNames.forEach { moduleName ->
+            file("$moduleName.xml", "<idea-plugin />")
+          }
+        }
+      }
+      repeat(auxiliaryJarCount) { index ->
+        zip("auxiliary$index.jar") {
+          file("auxiliary.txt", "Not a plugin descriptor")
+        }
+      }
+    }
+  }
+
+  private fun pluginXml(moduleNames: List<String>): String {
+    val modules = moduleNames.joinToString(separator = "\n      ") { """<module name="$it"/>""" }
+    return """
+      <idea-plugin>
+        <id>com.example.plugin</id>
+        <name>Example</name>
+        <version>1.0</version>
+        <vendor>JetBrains</vendor>
+        <description>A plugin with content modules declared in JARs of the lib directory.</description>
+        <idea-version since-build="241.0"/>
+        <dependencies>
+          <plugin id="com.intellij.modules.platform"/>
+        </dependencies>
+        <content>
+          $modules
+        </content>
+      </idea-plugin>
+    """.trimIndent()
+  }
+
+  private class CountingJarFileSystemProvider(private val delegate: JarFileSystemProvider) : JarFileSystemProvider {
+    var getFileSystemCalls = 0
+      private set
+
+    override fun getFileSystem(jarPath: Path): FileSystem {
+      getFileSystemCalls += 1
+      return delegate.getFileSystem(jarPath)
+    }
+
+    override fun getFileSystem(jarPath: Path, configuration: JarFileSystemProvider.Configuration): FileSystem {
+      getFileSystemCalls += 1
+      return delegate.getFileSystem(jarPath, configuration)
+    }
+  }
+}

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
@@ -59,6 +59,41 @@ class ContentModuleScannerTest {
   }
 
   @Test
+  fun `descriptor index maps a descriptor file name to every JAR that provides it`() {
+    val root = temporaryFolder.root.toPath()
+
+    val pluginPath = buildDirectory(temporaryFolder.newFolder("scala").toPath()) {
+      dir("lib") {
+        zip("scala.jar") {
+          dir("META-INF") {
+            file("plugin.xml", "<idea-plugin />")
+          }
+          file("intellij.scala.xml", "<idea-plugin />")
+        }
+        zip("scala-shadowed.jar") {
+          file("intellij.scala.xml", "<idea-plugin />")
+        }
+        zip("scala-auxiliary.jar") {
+          file("logback.xml", "<configuration />")
+        }
+      }
+    }
+
+    val descriptorIndex = ContentModuleScanner(jarFileSystemProvider).getDescriptorIndex(pluginPath)
+
+    val indexedJarPaths = descriptorIndex.mapValues { (_, jarPaths) ->
+      jarPaths.map { root.relativize(it).invariantSeparatorsPathString }.sorted()
+    }
+    assertEquals(
+      mapOf(
+        "plugin.xml" to listOf("scala/lib/scala.jar"),
+        "intellij.scala.xml" to listOf("scala/lib/scala-shadowed.jar", "scala/lib/scala.jar")
+      ),
+      indexedJarPaths
+    )
+  }
+
+  @Test
   fun `no content modules are found in a corrupted artifact`() {
     val pluginPath = buildDirectory(temporaryFolder.newFolder("corrupted").toPath()) {
       dir("lib") {


### PR DESCRIPTION
Cache `lib/` scan results in `FileBasedModuleDescriptorResolver` to fix content-module resolution bottleneck                                                                                        
                                                                                                                                                                                                  
Junie (plugin 1072850) declares 64 content modules, none of which use the fast path (lib/modules/<name>.jar) -- they all land in a single JAR under `lib/`. This caused `FileBasedModuleDescriptorResolver.getModuleCreator` to fall through to `LibDirectoryPluginLoader` for every module, which sequentially opens all JARs in lib/ to find the one containing the descriptor. With 243 JARs in Junie's `lib/`, that's 15,552 JAR operations per plugin parse - adding ~2 minutes to structure parsing in the Marketplace's PluginStructureParser.
                                                                                                                                                                                                  
`ContentModuleScanner` already scans all JARs in `lib/` and `lib/modules/` and builds a _moduleId -> artifactPath_ map; it was previously used only for classpath setup. This change reuses it inside `FileBasedModuleDescriptorResolver`: on the first miss of the `lib/modules/<name>.jar` fast path, the resolver calls `ContentModuleScanner` once and caches the result in a map keyed by plugin artifact path. Subsequent modules resolve via O(1) map lookup.