### PR TITLE
MP-2974 Stop reporting unresolved optional dependencies in `Missing dependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Fixed
 
+- Stop reporting unresolved optional dependencies in the `Missing dependencies` section of _plain_ and _Markdown_ reports, matching _HTML_ and _TeamCity_ reports. Now, all reports list only missing MANDATORY dependencies. ([MP-2974](https://youtrack.jetbrains.com/issue/MP-2974))
+
 ## 1.409 - 2026-07-17
 
 ### Changed

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/markdown/MarkdownResultPrinter.kt
@@ -153,7 +153,7 @@ private operator fun Markdown.plus(result: PluginVerificationResult.Verified) {
 
 private fun Markdown.printVerificationResult(result: PluginVerificationResult.Verified) = with(result) {
   printVerificationResult("Plugin structure warnings", pluginStructureWarnings, PluginStructureWarning::describe)
-  printVerificationResult("Missing dependencies", dependenciesGraph.getDirectMissingDependencies(), ResolvedMissingDependency::describe)
+  printVerificationResult("Missing dependencies", directMissingMandatoryDependencies.toSet(), ResolvedMissingDependency::describe)
   printVerificationResult("Compatibility warnings", compatibilityWarnings, CompatibilityWarning::describe)
   printVerificationResult("Compatibility problems", compatibilityProblems, CompatibilityProblem::describe)
   printVerificationResult("Deprecated API usages", deprecatedUsages, DeprecatedApiUsage::describe)

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/stream/WriterResultPrinter.kt
@@ -75,10 +75,9 @@ class WriterResultPrinter(private val out: PrintWriter) : ResultPrinter {
       }
     }
 
-    val directMissingDependencies = dependenciesGraph.getDirectMissingDependencies()
-    if (directMissingDependencies.isNotEmpty()) {
+    if (directMissingMandatoryDependencies.isNotEmpty()) {
       appendLine("Missing dependencies: ")
-      for (missingDependency in directMissingDependencies) {
+      for (missingDependency in directMissingMandatoryDependencies) {
         appendLine("$INDENT${missingDependency.dependency}: ${missingDependency.missingReason}")
       }
     }

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/teamcity/TeamCityResultPrinter.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/output/teamcity/TeamCityResultPrinter.kt
@@ -204,27 +204,26 @@ class TeamCityResultPrinter(
   private fun getMessageCompatibilityProblemsAndMissingDependencies(
     plugin: PluginInfo,
     problems: Set<CompatibilityProblem>,
-    missingDependencies: List<ResolvedMissingDependency>
+    missingMandatoryDependencies: List<ResolvedMissingDependency>
   ): String? {
-    val mandatoryMissingDependencies = missingDependencies.filterNot { it.dependency.isOptional }
-    if (problems.isNotEmpty() || mandatoryMissingDependencies.isNotEmpty()) {
+    if (problems.isNotEmpty() || missingMandatoryDependencies.isNotEmpty()) {
       return buildString {
         appendLine(getPluginOverviewLink(plugin))
         if (problems.isNotEmpty()) {
           appendLine("$plugin has ${problems.size} compatibility " + "problem".pluralize(problems.size))
         }
 
-        if (missingDependencies.isNotEmpty()) {
+        if (missingMandatoryDependencies.isNotEmpty()) {
           if (problems.isNotEmpty()) {
             appendLine("Some problems might have been caused by missing dependencies: ")
           }
-          for (missingDependency in missingDependencies) {
+          for (missingDependency in missingMandatoryDependencies) {
             appendLine("Missing dependency ${missingDependency.dependency}: ${missingDependency.missingReason}")
           }
         }
 
         val notFoundClassesProblems = problems.filterIsInstance<ClassNotFoundProblem>()
-        val problemsContent = if (missingDependencies.isNotEmpty() && notFoundClassesProblems.size > 20) {
+        val problemsContent = if (missingMandatoryDependencies.isNotEmpty() && notFoundClassesProblems.size > 20) {
           getTooManyUnknownClassesProblems(notFoundClassesProblems, problems)
         } else {
           getProblemsContent(problems)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputPrintTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/BaseOutputPrintTest.kt
@@ -68,9 +68,17 @@ open class BaseOutputPrintTest<T : ResultPrinter>: BaseOutputTest() {
     testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph, experimentalApiUsages = mockExperimentalApiUsages()))
   }
 
-  open fun `when plugin has missing dependencies`(testRunner: VerifiedPluginHandler) {
+  open fun `when plugin has missing mandatory dependencies`(testRunner: VerifiedPluginHandler) {
+    testRunner.runTest(verifiedResultWithMissingDependency(isOptional = false))
+  }
+
+  open fun `when plugin has missing optional dependencies`(testRunner: VerifiedPluginHandler) {
+    testRunner.runTest(verifiedResultWithMissingDependency(isOptional = true))
+  }
+
+  private fun verifiedResultWithMissingDependency(isOptional: Boolean): PluginVerificationResult.Verified {
     val pluginDependency = ResolvedDependencyNode(PLUGIN_ID, PLUGIN_VERSION)
-    val expectedDependency = ResolvedMissingDependency(ResolvedPluginDependency("MissingPlugin", true, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
+    val expectedDependency = ResolvedMissingDependency(ResolvedPluginDependency("MissingPlugin", isOptional, false), "Dependency MissingPlugin is not found among the bundled plugins of IU-211.500")
 
     val dependenciesGraph = ResolvedDependenciesGraph(
       verifiedPlugin = pluginDependency,
@@ -79,7 +87,7 @@ open class BaseOutputPrintTest<T : ResultPrinter>: BaseOutputTest() {
       missingDependencies = mapOf(pluginDependency to setOf(expectedDependency))
     )
 
-    testRunner.runTest(PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph))
+    return PluginVerificationResult.Verified(pluginInfo, verificationTarget, dependenciesGraph)
   }
 
   open fun `when plugin is dynamic`(testRunner: VerifiedPluginHandler) {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputPrintTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/markdown/MarkdownOutputPrintTest.kt
@@ -135,16 +135,30 @@ class MarkdownOutputPrintTest : BaseOutputPrintTest<MarkdownResultPrinter>() {
     }
 
     @Test
-    fun `plugin has missing dependencies`() {
-      `when plugin has missing dependencies` {
+    fun `plugin has missing mandatory dependencies`() {
+      `when plugin has missing mandatory dependencies` {
+        val expected = """
+          # Plugin pluginId 1.0 against 232.0
+          
+          1 missing mandatory dependency
+          
+          ## Missing dependencies (1)
+          
+          * MissingPlugin: Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
+          
+          
+        """.trimIndent()
+        assertOutput(expected)
+      }
+    }
+
+    @Test
+    fun `plugin has missing optional dependencies`() {
+      `when plugin has missing optional dependencies` {
         val expected = """
           # Plugin pluginId 1.0 against 232.0
           
           Compatible
-          
-          ## Missing dependencies (1)
-          
-          * MissingPlugin (optional): Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
           
           
         """.trimIndent()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputPrintTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/output/stream/StreamOutputPrintTest.kt
@@ -104,13 +104,25 @@ class StreamOutputPrintTest : BaseOutputPrintTest<WriterResultPrinter>() {
   }
 
   @Test
-  fun `plugin has missing dependencies`() {
-    `when plugin has missing dependencies` {
+  fun `plugin has missing mandatory dependencies`() {
+    `when plugin has missing mandatory dependencies` {
+      val expected = """
+          Plugin pluginId 1.0 against 232.0: 1 missing mandatory dependency
+          Missing dependencies: 
+              MissingPlugin: Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
+     
+     
+      """.trimIndent()
+      assertOutput(expected)
+    }
+  }
+
+  @Test
+  fun `plugin has missing optional dependencies`() {
+    `when plugin has missing optional dependencies` {
       val expected = """
           Plugin pluginId 1.0 against 232.0: Compatible
-          Missing dependencies: 
-              MissingPlugin (optional): Dependency MissingPlugin is not found among the bundled plugins of IU-211.500
-
+     
      
       """.trimIndent()
       assertOutput(expected)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 rootProject.name = "IntelliJ Plugin Verifier"
 
 includeBuild("intellij-plugin-structure")


### PR DESCRIPTION
Fixes [MP-2974 Plugin Verifier: unresolved optional dependencies must not be highlighted as errors](https://youtrack.jetbrains.com/issue/MP-2974)

Missing optional dependencies have been removed from the HTML and TeamCity reports in commits a17fd3cf1999dbf67f9e7a3e256e48afcc3cf307 and 0af4289eeef89801b156edb9a5931c2898aea1a4, 7 years ago. This PR also removes them from the plain and Markdown reports.