### PR TITLE
MP-7604: Fix false positives for Kotlin default impls in ENABLE mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 ### Fixed
 
+- Fix false-positive Internal/Deprecated/Experimental/NonExtendable usages for Kotlin 2.2 default-method compatibility stubs ([MP-7604](https://youtrack.jetbrains.com/issue/MP-7604))
+
 ## 1.409 - 2026-07-17
 
 ### Changed

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/FilteringApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/usages/FilteringApiUsageProcessor.kt
@@ -10,6 +10,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileMember
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
 import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import com.jetbrains.pluginverifier.verifiers.resolution.isKotlinDefaultMethodCompatibilityStub
 import org.objectweb.asm.tree.AbstractInsnNode
 
 abstract class FilteringApiUsageProcessor(private val usageFilter: ApiUsageFilter) : ApiUsageProcessor {
@@ -31,6 +32,7 @@ abstract class FilteringApiUsageProcessor(private val usageFilter: ApiUsageFilte
     callerMethod: Method,
     context: VerificationContext
   ) {
+    if (callerMethod.isKotlinDefaultMethodCompatibilityStub(resolvedMethod)) return
     if (usageFilter.allow(resolvedMethod, instructionNode, callerMethod, context)) return
     doProcessMethodInvocation(methodReference, resolvedMethod, instructionNode, callerMethod, context)
   }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodOverridingVerifier.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/MethodOverridingVerifier.kt
@@ -12,6 +12,7 @@ import com.jetbrains.pluginverifier.verifiers.VerificationContext
 import com.jetbrains.pluginverifier.verifiers.resolution.ClassFile
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.MethodResolver
+import com.jetbrains.pluginverifier.verifiers.resolution.isKotlinDefaultMethodCompatibilityStub
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import com.jetbrains.pluginverifier.warnings.WarningRegistrar
 
@@ -28,6 +29,7 @@ class MethodOverridingVerifier(private val methodOverridingProcessors: List<Meth
       VerificationContextWithSilentProblemRegistrar(context)
     )
     if (overriddenMethod != null && method.containingClassFile.name != overriddenMethod.containingClassFile.name) {
+      if (method.isKotlinDefaultMethodCompatibilityStub(overriddenMethod)) return
       for (processor in methodOverridingProcessors) {
         processor.processMethodOverriding(method, overriddenMethod, context)
       }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/resolution/Methods.kt
@@ -7,7 +7,11 @@ import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FrameNode
+import org.objectweb.asm.tree.LabelNode
+import org.objectweb.asm.tree.LineNumberNode
 import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.VarInsnNode
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -153,3 +157,54 @@ fun sameParameters(method: Method, anotherMethod: Method): Boolean {
 
 fun FullyQualifiedClassName.toBinaryClassName(): BinaryClassName = replace('.', '/')
 fun BinaryClassName.toFullyQualifiedClassName(): FullyQualifiedClassName = replace('/', '.')
+
+// Indistinguishable from a hand-written `Interface.super.method(args)` override — accepted trade-off.
+fun Method.isKotlinDefaultMethodCompatibilityStub(overriddenMethod: Method): Boolean {
+  if (!overriddenMethod.containingClassFile.isInterface || overriddenMethod.isAbstract) {
+    return false
+  }
+  if (!matches(overriddenMethod)) {
+    return false
+  }
+
+  val realInstructions = instructions.filterNot {
+    it is LabelNode || it is LineNumberNode || it is FrameNode
+  }
+
+  val argumentTypes = Type.getArgumentTypes(overriddenMethod.descriptor)
+  var slot = 1
+  val expectedLoads = mutableListOf(Opcodes.ALOAD to 0)
+  for (argumentType in argumentTypes) {
+    expectedLoads += argumentType.getOpcode(Opcodes.ILOAD) to slot
+    slot += argumentType.size
+  }
+
+  //Take into account forwarding INVOKESPECIAL and final return
+  if (realInstructions.size != expectedLoads.size + 2) {
+    return false
+  }
+
+  for ((index, expectedLoad) in expectedLoads.withIndex()) {
+    val loadInsn = realInstructions[index] as? VarInsnNode ?: return false
+    val (expectedOpcode, expectedSlot) = expectedLoad
+    if (loadInsn.opcode != expectedOpcode || loadInsn.`var` != expectedSlot) {
+      return false
+    }
+  }
+
+  val invokeInsn = realInstructions[expectedLoads.size] as? MethodInsnNode ?: return false
+  if (invokeInsn.opcode != Opcodes.INVOKESPECIAL || !invokeInsn.itf || !invokeInsn.matches(overriddenMethod)) {
+    return false
+  }
+  // The check for containingClassFile.interfaces is needed when the default method is inherited indirectly,
+  // since invokespecial then targets the direct superinterface, not the originally declaring one
+  if (invokeInsn.owner != overriddenMethod.containingClassFile.name
+    && invokeInsn.owner !in containingClassFile.interfaces
+  ) {
+    return false
+  }
+
+  val returnInsn = realInstructions.last()
+  val expectedReturnOpcode = Type.getReturnType(overriddenMethod.descriptor).getOpcode(Opcodes.IRETURN)
+  return returnInsn.opcode == expectedReturnOpcode
+}

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/BaseInternalApiUsageProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/BaseInternalApiUsageProcessor.kt
@@ -17,6 +17,7 @@ import com.jetbrains.pluginverifier.verifiers.resolution.ClassUsageType
 import com.jetbrains.pluginverifier.verifiers.resolution.Field
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
 import com.jetbrains.pluginverifier.verifiers.resolution.MethodResolver
+import com.jetbrains.pluginverifier.verifiers.resolution.isKotlinDefaultMethodCompatibilityStub
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import com.jetbrains.pluginverifier.warnings.WarningRegistrar
 import org.objectweb.asm.tree.AbstractInsnNode
@@ -48,6 +49,8 @@ abstract class BaseInternalApiUsageProcessor(
   ) {
     val usageLocation = callerMethod.location
     if (isInternal(resolvedMethod, context, usageLocation)) {
+      if (callerMethod.isKotlinDefaultMethodCompatibilityStub(resolvedMethod)) return
+
       // Check if the method is an override, and if so check top declaration
       val canBeOverridden = !resolvedMethod.isStatic && !resolvedMethod.isPrivate
         && resolvedMethod.name != "<init>" && resolvedMethod.name != "<clinit>"

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/usages/internal/InternalMethodOverridingProcessor.kt
@@ -13,10 +13,6 @@ class InternalMethodOverridingProcessor(private val internalApiUsageRegistrar: I
   override fun processMethodOverriding(method: Method, overriddenMethod: Method, context: VerificationContext) {
     if (overriddenMethod.isInternalApi(context.classResolver, method.location)
       && overriddenMethod.hasDifferentOrigin(method)) {
-      // As of Kotlin 2.2, the Kotlin compiler generates a stub method on interface implementations
-      // that only calls the corresponding superclass/interface's method. These stub methods are not
-      // really differentiable from when a user would manually do such an override, so we can get
-      // false positives in this case.
       internalApiUsageRegistrar.registerInternalApiUsage(
         InternalMethodOverridden(
           overriddenMethod.location,

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -16,8 +16,15 @@ import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.filtering.InternalApiUsageFilter
 import com.jetbrains.pluginverifier.results.problems.CompatibilityProblem
 import com.jetbrains.pluginverifier.tests.mocks.IdeaPluginSpec
+import com.jetbrains.pluginverifier.usages.deprecated.DeprecatedApiUsage
+import com.jetbrains.pluginverifier.usages.experimental.ExperimentalApiUsage
+import com.jetbrains.pluginverifier.usages.internal.InternalApiUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalClassUsage
 import com.jetbrains.pluginverifier.usages.internal.InternalMethodUsage
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinAnnotatedDefaultMethodInterfaceDump
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinAnnotatedDefaultMethodStubDump
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinDefaultMethodInterfaceDump
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinDefaultMethodStubDump
 import com.jetbrains.pluginverifier.warnings.CompatibilityWarning
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.description.annotation.AnnotationDescription
@@ -117,6 +124,61 @@ class InternalApiUsagePluginTest {
       apiUsageFilters = listOf(apiUsageFilter)) as PluginVerificationResult.Verified
 
     assertEquals(0, verificationResult.internalApiUsages.size)
+  }
+
+  @Test
+  fun `Kotlin ENABLE-mode compiler-generated default-method stub override is not reported as an internal API usage`() {
+    val (idePlugin, ide) = prepareInterfaceAndKotlinStubImplementor(
+      IdeaPluginSpec("com.example.kotlinStubPlugin", "Some Vendor"),
+      interfaceClassName = "TestInterface",
+      interfaceClassBytes = KotlinDefaultMethodInterfaceDump.dump(),
+      implClassName = "TestImpl",
+      implClassBytes = KotlinDefaultMethodStubDump.dump()
+    )
+
+    val verificationResult = VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(emptySet<InternalApiUsage>(), verificationResult.internalApiUsages)
+  }
+
+  @Test
+  fun `Kotlin ENABLE-mode compiler-generated default-method stub is not reported as a deprecated or experimental API usage`() {
+    val (idePlugin, ide) = prepareInterfaceAndKotlinStubImplementor(
+      IdeaPluginSpec("com.example.kotlinAnnotatedStubPlugin", "Some Vendor"),
+      interfaceClassName = "AnnotatedDefaultMethodInterface",
+      interfaceClassBytes = KotlinAnnotatedDefaultMethodInterfaceDump.dump(),
+      implClassName = "AnnotatedDefaultMethodImpl",
+      implClassBytes = KotlinAnnotatedDefaultMethodStubDump.dump()
+    )
+
+    val verificationResult = VerificationRunner().runPluginVerification(ide, idePlugin) as PluginVerificationResult.Verified
+
+    assertEquals(emptySet<CompatibilityProblem>(), verificationResult.compatibilityProblems)
+    assertEquals(emptySet<ExperimentalApiUsage>(), verificationResult.experimentalApiUsages)
+    assertEquals(emptySet<DeprecatedApiUsage>(), verificationResult.deprecatedUsages)
+  }
+
+  private fun prepareInterfaceAndKotlinStubImplementor(
+    pluginSpec: IdeaPluginSpec,
+    interfaceClassName: String,
+    interfaceClassBytes: ByteArray,
+    implClassName: String,
+    implClassBytes: ByteArray
+  ): Pair<IdePlugin, Ide> {
+    val idePlugin = buildIdePlugin(pluginSpec) {
+      dirs("com/jetbrains/test") {
+        file("$implClassName.class", implClassBytes)
+      }
+    }
+
+    val ide = buildIdeWithBundledPlugins(javaPluginClassesBuilder = {
+      dirs("com/jetbrains/test") {
+        file("$interfaceClassName.class", interfaceClassBytes)
+      }
+    }, groovyPluginClassesBuilder = {})
+
+    return idePlugin to ide
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/MethodsTest.kt
@@ -5,6 +5,8 @@ import com.jetbrains.pluginverifier.jdk.JdkDescriptorCreator
 import com.jetbrains.pluginverifier.tests.findMockPluginJarPath
 import com.jetbrains.pluginverifier.verifiers.resolution.classDump.InnerClassExampleDump
 import com.jetbrains.pluginverifier.verifiers.resolution.classDump.JavaEnumExampleDump
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinDefaultMethodInterfaceDump
+import com.jetbrains.pluginverifier.verifiers.resolution.classDump.KotlinDefaultMethodStubDump
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.*
@@ -12,10 +14,16 @@ import org.junit.Test
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Opcodes.ASM7
+import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FrameNode
 import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.LabelNode
+import org.objectweb.asm.tree.LineNumberNode
+import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.VarInsnNode
 import java.nio.file.Path
 
 class MethodsTest {
@@ -242,6 +250,275 @@ class MethodsTest {
       assertEquals(1, annotations.size)
       assertEquals("Lorg/jetbrains/annotations/PropertyKey;", annotations[0].desc)
     }
+  }
+
+  @Test
+  fun `Kotlin ENABLE-mode dump fixtures parse and expose the expected methods`() {
+    val origin = object : FileOrigin {
+      override val parent = null
+    }
+
+    val interfaceClassNode = ClassNode(ASM7)
+    ClassReader(KotlinDefaultMethodInterfaceDump.dump()).accept(interfaceClassNode, 0)
+    val interfaceClassFile = ClassFileAsm(interfaceClassNode, origin)
+    assertEquals(setOf("entryPoint", "internalMethod"), interfaceClassFile.methods.map { it.name }.toSet())
+
+    val internalMethod = interfaceClassFile.methods.first { it.name == "internalMethod" }
+    assertTrue(internalMethod.annotations.any { it.desc == "Lorg/jetbrains/annotations/ApiStatus\$Internal;" })
+
+    val implClassNode = ClassNode(ASM7)
+    ClassReader(KotlinDefaultMethodStubDump.dump()).accept(implClassNode, 0)
+    val implClassFile = ClassFileAsm(implClassNode, origin)
+    assertEquals(setOf("<init>", "entryPoint", "internalMethod"), implClassFile.methods.map { it.name }.toSet())
+
+    val stubMethod = implClassFile.methods.first { it.name == "internalMethod" }
+    val realInstructions = stubMethod.instructions.filterNot {
+      it is LabelNode || it is LineNumberNode || it is FrameNode
+    }
+    assertEquals(3, realInstructions.size)
+    assertEquals(Opcodes.ALOAD, (realInstructions[0] as VarInsnNode).opcode)
+    val invoke = realInstructions[1] as MethodInsnNode
+    assertEquals(Opcodes.INVOKESPECIAL, invoke.opcode)
+    assertEquals("com/jetbrains/test/TestInterface", invoke.owner)
+    assertEquals("internalMethod", invoke.name)
+    assertTrue(invoke.itf)
+    assertEquals(Opcodes.RETURN, realInstructions[2].opcode)
+  }
+
+  @Test
+  fun `real Kotlin 2_2 ENABLE-mode compiler stub overriding an internal default method is detected as a compatibility stub`() {
+    val origin = object : FileOrigin {
+      override val parent = null
+    }
+
+    val interfaceClassNode = ClassNode(ASM7)
+    ClassReader(KotlinDefaultMethodInterfaceDump.dump()).accept(interfaceClassNode, 0)
+    val internalMethod = ClassFileAsm(interfaceClassNode, origin).methods.first { it.name == "internalMethod" }
+
+    val implClassNode = ClassNode(ASM7)
+    ClassReader(KotlinDefaultMethodStubDump.dump()).accept(implClassNode, 0)
+    val stubMethod = ClassFileAsm(implClassNode, origin).methods.first { it.name == "internalMethod" }
+
+    assertTrue(stubMethod.isKotlinDefaultMethodCompatibilityStub(internalMethod))
+  }
+
+  @Test
+  fun `compiler stub overriding a two-parameter default method with a wide-type parameter is detected as a compatibility stub`() {
+    val descriptor = "(JLjava/lang/String;)J"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/StubInterface",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "combine",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.LCONST_0), InsnNode(Opcodes.LRETURN)),
+      overridingClassName = "mock/plugin/stub/StubImpl",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        VarInsnNode(Opcodes.LLOAD, 1),
+        VarInsnNode(Opcodes.ALOAD, 3),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/StubInterface", "combine", descriptor, true),
+        InsnNode(Opcodes.LRETURN)
+      )
+    )
+
+    assertTrue(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `override with additional logic beyond the forwarding call is not a compatibility stub`() {
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/StubInterface2",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "greet",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/StubImpl2",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/StubInterface2", "greet", descriptor, true),
+        InsnNode(Opcodes.NOP),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `override that calls a different method than the overridden one is not a compatibility stub`() {
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/StubInterface3",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "greet",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/StubImpl3",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/StubInterface3", "somethingElse", descriptor, true),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `override of a non-interface (abstract class) method is never a compatibility stub`() {
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/AbstractBase",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT,
+      methodName = "greet",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/BaseImpl",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/AbstractBase", "greet", descriptor, false),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `compiler stub inheriting the default method indirectly forwards to the direct superinterface and is detected as a compatibility stub`() {
+    // Kotlin 2.2.0 emits `INVOKESPECIAL B.f()` for `interface A { fun f() {} }; interface B : A; class Impl : B` —
+    // when the default method is inherited indirectly, invokespecial targets the direct superinterface, not the
+    // originally declaring one.
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/GrandParentInterface",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "f",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/IndirectImpl",
+      overridingClassInterfaces = listOf("mock/plugin/stub/ParentInterface"),
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/ParentInterface", "f", descriptor, true),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertTrue(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `forwarding call to an interface that is not a superinterface of the caller is not a compatibility stub`() {
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/UnrelatedInterface",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "f",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/UnrelatedImpl",
+      overridingClassInterfaces = listOf("mock/plugin/stub/SomeOtherInterface"),
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/SomeThirdInterface", "f", descriptor, true),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `a stub-shaped method whose own name differs from the invoked method is not a compatibility stub`() {
+    val descriptor = "()V"
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/StubInterface4",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "internalMethod",
+      descriptor = descriptor,
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/StubImpl4",
+      // `void refresh() { StubInterface4.super.internalMethod(); }` — a deliberate internal-API use
+      overridingMethodName = "refresh",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/StubInterface4", "internalMethod", descriptor, true),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  @Test
+  fun `a stub-shaped method whose own descriptor differs from the invoked method is not a compatibility stub`() {
+    val (overriddenMethod, overridingMethod) = buildOverriddenAndOverridingMethod(
+      overriddenClassName = "mock/plugin/stub/StubInterface5",
+      overriddenClassAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT or Opcodes.ACC_INTERFACE,
+      methodName = "internalMethod",
+      descriptor = "()V",
+      overriddenMethodInstructions = listOf(InsnNode(Opcodes.RETURN)),
+      overridingClassName = "mock/plugin/stub/StubImpl5",
+      // `void internalMethod(int unused) { StubInterface5.super.internalMethod(); }` — an overload, not an override
+      overridingDescriptor = "(I)V",
+      overridingMethodInstructions = listOf(
+        VarInsnNode(Opcodes.ALOAD, 0),
+        MethodInsnNode(Opcodes.INVOKESPECIAL, "mock/plugin/stub/StubInterface5", "internalMethod", "()V", true),
+        InsnNode(Opcodes.RETURN)
+      )
+    )
+
+    assertFalse(overridingMethod.isKotlinDefaultMethodCompatibilityStub(overriddenMethod))
+  }
+
+  private fun buildOverriddenAndOverridingMethod(
+    overriddenClassName: String,
+    overriddenClassAccess: Int,
+    methodName: String,
+    descriptor: String,
+    overriddenMethodInstructions: List<AbstractInsnNode>,
+    overridingClassName: String,
+    overridingMethodInstructions: List<AbstractInsnNode>,
+    overridingClassInterfaces: List<String> = listOf(overriddenClassName),
+    overridingMethodName: String = methodName,
+    overridingDescriptor: String = descriptor
+  ): Pair<Method, Method> {
+    val origin = object : FileOrigin {
+      override val parent = null
+    }
+
+    val overriddenClassNode = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = overriddenClassAccess
+      name = overriddenClassName
+      superName = "java/lang/Object"
+      methods.add(MethodNode().apply {
+        access = Opcodes.ACC_PUBLIC
+        name = methodName
+        desc = descriptor
+        overriddenMethodInstructions.forEach { instructions.add(it) }
+      })
+    }
+    val overriddenMethod = ClassFileAsm(overriddenClassNode, origin).methods.first { it.name == methodName }
+
+    val overridingClassNode = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC
+      name = overridingClassName
+      superName = "java/lang/Object"
+      interfaces = overridingClassInterfaces.toMutableList()
+      methods.add(MethodNode().apply {
+        access = Opcodes.ACC_PUBLIC
+        name = overridingMethodName
+        desc = overridingDescriptor
+        overridingMethodInstructions.forEach { instructions.add(it) }
+      })
+    }
+    val overridingMethod = ClassFileAsm(overridingClassNode, origin).methods.first { it.name == overridingMethodName }
+
+    return overriddenMethod to overridingMethod
   }
 
   @Throws(AssertionError::class)

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodInterfaceDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodInterfaceDump.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
+
+import org.objectweb.asm.*;
+
+/**
+ * ASM dump of the Kotlin 2.2.0 (default JvmDefaultMode ENABLE) compiled output of:
+ * <pre>
+ * interface AnnotatedDefaultMethodInterface {
+ *     &#64;ApiStatus.Experimental fun experimentalMethod() {}
+ *     &#64;Deprecated("Use something else") fun deprecatedMethod() {}
+ * }
+ * </pre>
+ * The &#64;Internal counterpart is {@code KotlinDefaultMethodInterfaceDump}; this one covers the
+ * experimental and deprecated usage detectors instead.
+ * <p>
+ * Paired with {@code KotlinAnnotatedDefaultMethodStubDump}, the implementor that doesn't override either method.
+ * Synthetic {@code access$experimentalMethod$jd}/{@code access$deprecatedMethod$jd} accessors and the
+ * {@code kotlin.Metadata} {@code d1}/{@code d2} payloads are elided as irrelevant to what this fixture tests.
+ */
+public class KotlinAnnotatedDefaultMethodInterfaceDump implements Opcodes {
+
+    public static byte[] dump() throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(V17, ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE, "com/jetbrains/test/AnnotatedDefaultMethodInterface", null, "java/lang/Object", null);
+
+        classWriter.visitSource("Annotated.kt", null);
+
+        {
+            annotationVisitor0 = classWriter.visitAnnotation("Lkotlin/Metadata;", true);
+            annotationVisitor0.visit("mv", new int[]{2, 2, 0});
+            annotationVisitor0.visit("k", Integer.valueOf(1));
+            annotationVisitor0.visit("xi", Integer.valueOf(48));
+            annotationVisitor0.visitEnd();
+        }
+        classWriter.visitInnerClass("com/jetbrains/test/AnnotatedDefaultMethodInterface$DefaultImpls", "com/jetbrains/test/AnnotatedDefaultMethodInterface", "DefaultImpls", ACC_PUBLIC | ACC_FINAL | ACC_STATIC);
+
+        classWriter.visitInnerClass("org/jetbrains/annotations/ApiStatus$Experimental", "org/jetbrains/annotations/ApiStatus", "Experimental", ACC_PUBLIC | ACC_STATIC | ACC_ANNOTATION | ACC_ABSTRACT | ACC_INTERFACE);
+
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "experimentalMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus$Experimental;", false);
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(8, label0);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/AnnotatedDefaultMethodInterface;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(0, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC | ACC_DEPRECATED, "deprecatedMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lkotlin/Deprecated;", true);
+                annotationVisitor0.visit("message", "Use something else");
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(12, label0);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/AnnotatedDefaultMethodInterface;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(0, 1);
+            methodVisitor.visitEnd();
+        }
+        classWriter.visitEnd();
+
+        return classWriter.toByteArray();
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodInterfaceDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodInterfaceDump.java
@@ -14,12 +14,6 @@ import org.objectweb.asm.*;
  *     &#64;Deprecated("Use something else") fun deprecatedMethod() {}
  * }
  * </pre>
- * The &#64;Internal counterpart is {@code KotlinDefaultMethodInterfaceDump}; this one covers the
- * experimental and deprecated usage detectors instead.
- * <p>
- * Paired with {@code KotlinAnnotatedDefaultMethodStubDump}, the implementor that doesn't override either method.
- * Synthetic {@code access$experimentalMethod$jd}/{@code access$deprecatedMethod$jd} accessors and the
- * {@code kotlin.Metadata} {@code d1}/{@code d2} payloads are elided as irrelevant to what this fixture tests.
  */
 public class KotlinAnnotatedDefaultMethodInterfaceDump implements Opcodes {
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodStubDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodStubDump.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
+
+import org.objectweb.asm.*;
+
+/**
+ * ASM dump of {@code class AnnotatedDefaultMethodImpl : AnnotatedDefaultMethodInterface} (no override)
+ * compiled the same way as {@code KotlinAnnotatedDefaultMethodInterfaceDump}. Both compatibility stubs
+ * forward to the interface's default impl, so besides the "method overridden" false positive they also
+ * trip the experimental and deprecated <em>invocation</em> detectors on the forwarding INVOKESPECIAL.
+ * <p>
+ * The {@code kotlin.Metadata} {@code d1}/{@code d2} payloads are elided as irrelevant to what this
+ * fixture tests.
+ */
+public class KotlinAnnotatedDefaultMethodStubDump implements Opcodes {
+
+    public static byte[] dump() throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(V17, ACC_PUBLIC | ACC_FINAL | ACC_SUPER, "com/jetbrains/test/AnnotatedDefaultMethodImpl", null, "java/lang/Object", new String[]{"com/jetbrains/test/AnnotatedDefaultMethodInterface"});
+
+        classWriter.visitSource("Annotated.kt", null);
+
+        {
+            annotationVisitor0 = classWriter.visitAnnotation("Lkotlin/Metadata;", true);
+            annotationVisitor0.visit("mv", new int[]{2, 2, 0});
+            annotationVisitor0.visit("k", Integer.valueOf(1));
+            annotationVisitor0.visit("xi", Integer.valueOf(48));
+            annotationVisitor0.visitEnd();
+        }
+        classWriter.visitInnerClass("org/jetbrains/annotations/ApiStatus$Experimental", "org/jetbrains/annotations/ApiStatus", "Experimental", ACC_PUBLIC | ACC_STATIC | ACC_ANNOTATION | ACC_ABSTRACT | ACC_INTERFACE);
+
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/AnnotatedDefaultMethodImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "experimentalMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus$Experimental;", false);
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "com/jetbrains/test/AnnotatedDefaultMethodInterface", "experimentalMethod", "()V", true);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/AnnotatedDefaultMethodImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC | ACC_DEPRECATED, "deprecatedMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lkotlin/Deprecated;", true);
+                annotationVisitor0.visit("message", "Use something else");
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "com/jetbrains/test/AnnotatedDefaultMethodInterface", "deprecatedMethod", "()V", true);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/AnnotatedDefaultMethodImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        classWriter.visitEnd();
+
+        return classWriter.toByteArray();
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodStubDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinAnnotatedDefaultMethodStubDump.java
@@ -7,13 +7,8 @@ package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
 import org.objectweb.asm.*;
 
 /**
- * ASM dump of {@code class AnnotatedDefaultMethodImpl : AnnotatedDefaultMethodInterface} (no override)
- * compiled the same way as {@code KotlinAnnotatedDefaultMethodInterfaceDump}. Both compatibility stubs
- * forward to the interface's default impl, so besides the "method overridden" false positive they also
- * trip the experimental and deprecated <em>invocation</em> detectors on the forwarding INVOKESPECIAL.
- * <p>
- * The {@code kotlin.Metadata} {@code d1}/{@code d2} payloads are elided as irrelevant to what this
- * fixture tests.
+ * ASM dump of the Kotlin 2.2.0 (default JvmDefaultMode ENABLE) compiled output of:
+ * {@code class AnnotatedDefaultMethodImpl : AnnotatedDefaultMethodInterface} (no override)
  */
 public class KotlinAnnotatedDefaultMethodStubDump implements Opcodes {
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodInterfaceDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodInterfaceDump.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
+
+import org.objectweb.asm.*;
+
+/**
+ * ASM dump of the Kotlin 2.2.0 (default JvmDefaultMode ENABLE) compiled output of:
+ * <pre>
+ * interface TestInterface {
+ *     fun entryPoint() { internalMethod() }
+ *     &#64;ApiStatus.Internal fun internalMethod() {}
+ * }
+ * </pre>
+ * Paired with {@code KotlinDefaultMethodStubDump}, the implementor that doesn't override either method.
+ * <p>
+ * The compiler also emits synthetic {@code access$entryPoint$jd}/{@code access$internalMethod$jd} accessors,
+ * which are elided here: they are only ever called from the {@code TestInterface$DefaultImpls} class (also
+ * elided) and play no part in the stub detection this fixture exercises.
+ */
+public class KotlinDefaultMethodInterfaceDump implements Opcodes {
+
+    public static byte[] dump() throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(V17, ACC_PUBLIC | ACC_ABSTRACT | ACC_INTERFACE, "com/jetbrains/test/TestInterface", null, "java/lang/Object", null);
+
+        classWriter.visitSource("Test.kt", null);
+
+        {
+            annotationVisitor0 = classWriter.visitAnnotation("Lkotlin/Metadata;", true);
+            annotationVisitor0.visit("mv", new int[]{2, 2, 0});
+            annotationVisitor0.visit("k", Integer.valueOf(1));
+            annotationVisitor0.visit("xi", Integer.valueOf(48));
+            annotationVisitor0.visitEnd();
+        }
+        classWriter.visitInnerClass("com/jetbrains/test/TestInterface$DefaultImpls", "com/jetbrains/test/TestInterface", "DefaultImpls", ACC_PUBLIC | ACC_FINAL | ACC_STATIC);
+
+        classWriter.visitInnerClass("org/jetbrains/annotations/ApiStatus$Internal", "org/jetbrains/annotations/ApiStatus", "Internal", ACC_PUBLIC | ACC_STATIC | ACC_ANNOTATION | ACC_ABSTRACT | ACC_INTERFACE);
+
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "entryPoint", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(7, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKEINTERFACE, "com/jetbrains/test/TestInterface", "internalMethod", "()V", true);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLineNumber(8, label1);
+            methodVisitor.visitInsn(RETURN);
+            Label label2 = new Label();
+            methodVisitor.visitLabel(label2);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/TestInterface;", null, label0, label2, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "internalMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus$Internal;", false);
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(12, label0);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/TestInterface;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(0, 1);
+            methodVisitor.visitEnd();
+        }
+        classWriter.visitEnd();
+
+        return classWriter.toByteArray();
+    }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodInterfaceDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodInterfaceDump.java
@@ -14,11 +14,6 @@ import org.objectweb.asm.*;
  *     &#64;ApiStatus.Internal fun internalMethod() {}
  * }
  * </pre>
- * Paired with {@code KotlinDefaultMethodStubDump}, the implementor that doesn't override either method.
- * <p>
- * The compiler also emits synthetic {@code access$entryPoint$jd}/{@code access$internalMethod$jd} accessors,
- * which are elided here: they are only ever called from the {@code TestInterface$DefaultImpls} class (also
- * elided) and play no part in the stub detection this fixture exercises.
  */
 public class KotlinDefaultMethodInterfaceDump implements Opcodes {
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodStubDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodStubDump.java
@@ -7,10 +7,8 @@ package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
 import org.objectweb.asm.*;
 
 /**
- * ASM dump of {@code class TestImpl : TestInterface} (no override) compiled the same way as
- * {@code KotlinDefaultMethodInterfaceDump}. The compiler still emits real {@code entryPoint()}/
- * {@code internalMethod()} methods here that only forward to the interface's default impl — the
- * ENABLE-mode compatibility stub MP-7604 is about.
+ * ASM dump of the Kotlin 2.2.0 (default JvmDefaultMode ENABLE) compiled output of:
+ * {@code class TestImpl : TestInterface} (no override)
  */
 public class KotlinDefaultMethodStubDump implements Opcodes {
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodStubDump.java
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/verifiers/resolution/classDump/KotlinDefaultMethodStubDump.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.resolution.classDump;
+
+import org.objectweb.asm.*;
+
+/**
+ * ASM dump of {@code class TestImpl : TestInterface} (no override) compiled the same way as
+ * {@code KotlinDefaultMethodInterfaceDump}. The compiler still emits real {@code entryPoint()}/
+ * {@code internalMethod()} methods here that only forward to the interface's default impl — the
+ * ENABLE-mode compatibility stub MP-7604 is about.
+ */
+public class KotlinDefaultMethodStubDump implements Opcodes {
+
+    public static byte[] dump() throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(V17, ACC_PUBLIC | ACC_FINAL | ACC_SUPER, "com/jetbrains/test/TestImpl", null, "java/lang/Object", new String[]{"com/jetbrains/test/TestInterface"});
+
+        classWriter.visitSource("Test.kt", null);
+
+        {
+            annotationVisitor0 = classWriter.visitAnnotation("Lkotlin/Metadata;", true);
+            annotationVisitor0.visit("mv", new int[]{2, 2, 0});
+            annotationVisitor0.visit("k", Integer.valueOf(1));
+            annotationVisitor0.visit("xi", Integer.valueOf(48));
+            annotationVisitor0.visitEnd();
+        }
+        classWriter.visitInnerClass("org/jetbrains/annotations/ApiStatus$Internal", "org/jetbrains/annotations/ApiStatus", "Internal", ACC_PUBLIC | ACC_STATIC | ACC_ANNOTATION | ACC_ABSTRACT | ACC_INTERFACE);
+
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/TestImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "entryPoint", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "com/jetbrains/test/TestInterface", "entryPoint", "()V", true);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/TestImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "internalMethod", "()V", null, null);
+            {
+                annotationVisitor0 = methodVisitor.visitAnnotation("Lorg/jetbrains/annotations/ApiStatus$Internal;", false);
+                annotationVisitor0.visitEnd();
+            }
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(15, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "com/jetbrains/test/TestInterface", "internalMethod", "()V", true);
+            methodVisitor.visitInsn(RETURN);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLocalVariable("this", "Lcom/jetbrains/test/TestImpl;", null, label0, label1, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+        classWriter.visitEnd();
+
+        return classWriter.toByteArray();
+    }
+}


### PR DESCRIPTION
Fixes the remaining part of https://youtrack.jetbrains.com/issue/MP-7604/Plugin-verifier-violations-for-Kotlin-2.2.0-default-impls.

A previous fix (https://github.com/JetBrains/intellij-plugin-verifier/pull/1405) handled the case of invocations of the compiler-generated $DefaultImpls class.

This fix handles the remaining case, where in ENABLE mode, the compiler adds methods to implementing classes that don't override the interface's default method themselves. Those methods would then be reported as overriding or invoking an @Internal/@Deprecated/@Experimental/@NonExtendable interface method. Here we add a way to recognize such methods and prevent them from being reported.