### PR TITLE
Fix Rider 2023.3 IDE loading in IdeManagerImpl

### DIFF
--- a/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
+++ b/intellij-plugin-structure/structure-ide/src/main/java/com/jetbrains/plugin/structure/ide/IdeManagerImpl.kt
@@ -128,20 +128,35 @@ class IdeManagerImpl : AbstractIdeManager() {
     platformResourceResolver: ResourceResolver,
     ideVersion: IdeVersion
   ): List<IdePlugin> {
-    val platformPlugins = arrayListOf<IdePlugin>()
-    val descriptorPaths = listOf(IdePluginManager.PLUGIN_XML, product.platformPrefix + "Plugin.xml")
+    val primaryDescriptorPaths = listOf(IdePluginManager.PLUGIN_XML, product.platformPrefix + "Plugin.xml")
+    val fallbackDescriptorPaths = listOf(PLATFORM_PLUGIN_XML)
 
-    for (jarFile in jarFiles) {
-      val descriptorPath = jarFileSystemProvider.getFileSystem(jarFile).use { jarFs ->
-        descriptorPaths.find { jarFs.getPath(IdePluginManager.META_INF).resolve(it).exists() }
-      }
-      if (descriptorPath != null) {
-        platformPlugins += createBundledPluginExceptionally(idePath, jarFile, platformResourceResolver, descriptorPath, ideVersion)
+    val platformPlugins = arrayListOf<IdePlugin>()
+    val seenPluginIds = hashSetOf<String?>()
+
+    fun loadPlatformPluginsFrom(descriptorPaths: List<String>) {
+      for (jarFile in jarFiles) {
+        val descriptorPath = jarFileSystemProvider.getFileSystem(jarFile).use { jarFs ->
+          descriptorPaths.find { jarFs.getPath(IdePluginManager.META_INF).resolve(it).exists() }
+        } ?: continue
+        val plugin = createBundledPluginExceptionally(idePath, jarFile, platformResourceResolver, descriptorPath, ideVersion)
+        if (seenPluginIds.add(plugin.pluginId)) {
+          platformPlugins += plugin
+        }
       }
     }
 
-    if (platformPlugins.none { it.pluginId == "com.intellij" }) {
-      throw InvalidIdeException(idePath, "Platform plugins are not found. They must be declared in one of ${descriptorPaths.joinToString()}")
+    loadPlatformPluginsFrom(primaryDescriptorPaths)
+    if (CORE_IDE_PLUGIN_ID !in seenPluginIds) {
+      loadPlatformPluginsFrom(fallbackDescriptorPaths)
+    }
+
+    if (CORE_IDE_PLUGIN_ID !in seenPluginIds) {
+      throw InvalidIdeException(
+        idePath,
+        "Platform plugins are not found. They must be declared in one of " +
+          (primaryDescriptorPaths + fallbackDescriptorPaths).joinToString()
+      )
     }
 
     return platformPlugins
@@ -174,6 +189,14 @@ class IdeManagerImpl : AbstractIdeManager() {
   companion object {
 
     private val LOG = LoggerFactory.getLogger(IdeManagerImpl::class.java)
+
+    // PlatformLangPlugin.xml is never the real IDE's core plugin descriptor — it is always
+    // xi:included into one. Used as a fallback when the aggregating core descriptor resolves
+    // to a non-com.intellij ID (e.g. Rider 2023.3 where RiderPlugin.xml yields
+    // com.jetbrains.rider.languages due to JAXB's last-<id>-wins behavior).
+    internal const val PLATFORM_PLUGIN_XML = "PlatformLangPlugin.xml"
+
+    private const val CORE_IDE_PLUGIN_ID = "com.intellij"
 
     fun isDistributionIde(ideaDir: Path) = ideaDir.resolve("lib").isDirectory &&
       !ideaDir.resolve(".idea").isDirectory

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagerImplTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/IdeManagerImplTest.kt
@@ -1,0 +1,241 @@
+package com.jetbrains.plugin.structure.ide
+
+import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class IdeManagerImplTest {
+
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  // ── error cases ──────────────────────────────────────────────────────────────
+
+  @Test
+  fun `Rider IDE without any platform plugin descriptor throws InvalidIdeException`() {
+    val ideRoot = temporaryFolder.newFolder("RD-233.15026.35").toPath()
+    buildDirectory(ideRoot) {
+      file("build.txt", "RD-233.15026.35")
+      dir("lib") {
+        zip("app-client.jar") {
+          dir("META-INF") {
+            file("some-other.xml", "<root/>")
+          }
+        }
+      }
+    }
+
+    val exception = assertThrows(InvalidIdeException::class.java) {
+      IdeManagerImpl().createIde(ideRoot)
+    }
+    val expectedReason =
+      "Platform plugins are not found. They must be declared in one of plugin.xml, RiderPlugin.xml, PlatformLangPlugin.xml"
+    assertEquals(expectedReason, exception.reason)
+    assertTrue(
+      "Exception message should embed the IDE path",
+      exception.message?.contains("RD-233.15026.35") == true
+    )
+  }
+
+  // ── sanity: direct declaration works ─────────────────────────────────────────
+
+  @Test
+  fun `Rider IDE with RiderPlugin xml directly declaring com_intellij loads successfully`() {
+    val ideRoot = temporaryFolder.newFolder("RD-233-valid").toPath()
+    buildDirectory(ideRoot) {
+      file("build.txt", "RD-233.15026.35")
+      dir("lib") {
+        zip("app-client.jar") {
+          dir("META-INF") {
+            file("RiderPlugin.xml", """
+              <idea-plugin>
+                <id>com.intellij</id>
+                <name>IDEA CORE</name>
+                <module value="com.intellij.modules.rider"/>
+              </idea-plugin>
+            """.trimIndent())
+          }
+        }
+      }
+    }
+
+    val ide = IdeManagerImpl().createIde(ideRoot)
+    assertTrue(ide.bundledPlugins.any { it.pluginId == "com.intellij" })
+  }
+
+  // ── regression: Rider 2023.3 structure ──────────────────────────────────────
+
+  /**
+   * Rider 2023.3 regression: product.jar/RiderPlugin.xml resolves to id=com.jetbrains.rider.languages
+   * (not com.intellij), so the fallback to PlatformLangPlugin.xml in app-client.jar must fire.
+   *
+   * Both plugins must be present in the resulting IDE.
+   */
+  @Test
+  fun `Rider 233 resolves com_intellij from PlatformLangPlugin xml when RiderPlugin xml has a different id`() {
+    val ideRoot = buildRider233Directory(
+      riderPluginXmlContent = """
+        <idea-plugin>
+          <id>com.jetbrains.rider.languages</id>
+          <name>Rider Languages</name>
+          <module value="com.intellij.modules.rider"/>
+        </idea-plugin>
+      """.trimIndent()
+    )
+
+    val ide = IdeManagerImpl().createIde(ideRoot)
+    val pluginIds = ide.bundledPlugins.map { it.pluginId }
+    assertTrue("Expected 'com.intellij' among platform plugins: $pluginIds",
+      pluginIds.contains("com.intellij"))
+    assertTrue("Expected 'com.jetbrains.rider.languages' among platform plugins: $pluginIds",
+      pluginIds.contains("com.jetbrains.rider.languages"))
+  }
+
+  // ── deduplication: IDEA 2024.3 structure ────────────────────────────────────
+
+  /**
+   * In IntelliJ IDEA 2024.3+, both product.jar/plugin.xml and app-client.jar/PlatformLangPlugin.xml
+   * declare id=com.intellij. The PlatformLangPlugin.xml is a lang-subset that gets xi:included into
+   * the real core descriptor; it must NOT appear as a separate plugin in the IDE.
+   *
+   * The marker module com.intellij.modules.idea is declared only in product.jar/plugin.xml,
+   * so its presence proves the real descriptor won (and was not discarded in favour of the subset).
+   */
+  @Test
+  fun `com_intellij is loaded exactly once and from the real descriptor not from PlatformLangPlugin xml`() {
+    val ideRoot = temporaryFolder.newFolder("IU-243-dedup").toPath()
+    buildDirectory(ideRoot) {
+      file("build.txt", "IU-243.0.0")
+      dir("lib") {
+        zip("product.jar") {
+          dir("META-INF") {
+            file("plugin.xml", """
+              <idea-plugin>
+                <id>com.intellij</id>
+                <name>IDEA CORE</name>
+                <module value="com.intellij.modules.platform"/>
+                <module value="com.intellij.modules.idea"/>
+              </idea-plugin>
+            """.trimIndent())
+          }
+        }
+        zip("app-client.jar") {
+          dir("META-INF") {
+            file("PlatformLangPlugin.xml", """
+              <idea-plugin>
+                <id>com.intellij</id>
+                <name>IDEA CORE (lang subset)</name>
+                <module value="com.intellij.modules.platform"/>
+              </idea-plugin>
+            """.trimIndent())
+          }
+        }
+      }
+    }
+
+    val ide = IdeManagerImpl().createIde(ideRoot)
+    val corePlugins = ide.bundledPlugins.filter { it.pluginId == "com.intellij" }
+    assertEquals("com.intellij must be loaded exactly once", 1, corePlugins.size)
+    assertTrue(
+      "The real descriptor (product.jar/plugin.xml) must win over PlatformLangPlugin.xml; " +
+        "com.intellij.modules.idea is declared only in the former",
+      corePlugins.single().definedModules.contains("com.intellij.modules.idea")
+    )
+  }
+
+  // ── dispatch routing ─────────────────────────────────────────────────────────
+
+  /**
+   * DispatchingIdeManager must select IdeManagerImpl (not ProductInfoBasedIdeManager)
+   * for an IDE that has product-info.json without a layout field and build < 242.
+   */
+  @Test
+  fun `DispatchingIdeManager routes Rider 233 structure through IdeManagerImpl`() {
+    val ideRoot = buildRider233Directory(
+      riderPluginXmlContent = """
+        <idea-plugin>
+          <id>com.jetbrains.rider.languages</id>
+          <name>Rider Languages</name>
+          <module value="com.intellij.modules.rider"/>
+        </idea-plugin>
+      """.trimIndent()
+    )
+
+    val ide = DispatchingIdeManager().createIde(ideRoot)
+    assertFalse("IDE must not be ProductInfoBasedIde for a Rider 233 structure",
+      ide is ProductInfoBasedIde)
+    assertTrue(ide.bundledPlugins.any { it.pluginId == "com.intellij" })
+  }
+
+  /**
+   * DispatchingIdeManager selects ProductInfoBasedIdeManager for an IDE with a layout field
+   * and build >= 243.
+   */
+  @Test
+  fun `DispatchingIdeManager routes modern IDE through ProductInfoBasedIdeManager`() {
+    // Use MockIdeBuilder which creates a full IU-242+ layout with product-info.json
+    val ideRoot = MockIdeBuilder(temporaryFolder, folderSuffix = "-dispatch").buildIdeaDirectory()
+    val ide = DispatchingIdeManager().createIde(ideRoot)
+    assertTrue("Modern IDE must be ProductInfoBasedIde", ide is ProductInfoBasedIde)
+  }
+
+  // ── private helpers ──────────────────────────────────────────────────────────
+
+  /**
+   * Builds a Rider 233-like IDE directory:
+   * - build.txt = RD-233.15026.35
+   * - product-info.json present but without "layout" (causes IdeManagerImpl routing)
+   * - lib/product.jar with META-INF/RiderPlugin.xml containing [riderPluginXmlContent]
+   * - lib/app-client.jar with META-INF/PlatformLangPlugin.xml declaring id=com.intellij
+   */
+  private fun buildRider233Directory(riderPluginXmlContent: String): java.nio.file.Path {
+    val ideRoot = temporaryFolder.newFolder("RD-233-layout").toPath()
+    buildDirectory(ideRoot) {
+      file("build.txt", "RD-233.15026.35")
+      file("product-info.json", RIDER_233_PRODUCT_INFO_JSON)
+      dir("lib") {
+        zip("product.jar") {
+          dir("META-INF") {
+            file("RiderPlugin.xml", riderPluginXmlContent)
+          }
+        }
+        zip("app-client.jar") {
+          dir("META-INF") {
+            file("PlatformLangPlugin.xml", """
+              <idea-plugin>
+                <id>com.intellij</id>
+                <name>IDEA CORE</name>
+                <module value="com.intellij.modules.platform"/>
+                <module value="com.intellij.modules.lang"/>
+              </idea-plugin>
+            """.trimIndent())
+          }
+        }
+      }
+    }
+    return ideRoot
+  }
+
+  private val RIDER_233_PRODUCT_INFO_JSON = """
+    {
+      "name": "JetBrains Rider",
+      "version": "2023.3.6",
+      "versionSuffix": "",
+      "buildNumber": "233.15026.35",
+      "productCode": "RD",
+      "dataDirectoryName": "Rider2023.3",
+      "svgIconPath": "bin/rider.svg",
+      "productVendor": "JetBrains",
+      "launch": [],
+      "bundledPlugins": [],
+      "modules": [],
+      "fileExtensions": []
+    }
+  """.trimIndent()
+}


### PR DESCRIPTION
## Problem

https://youtrack.jetbrains.com/issue/MP-8080/RD-233.15026.35-extracted-ide-is-invalid-Platform-plugins-are-not-found.-They-must-be-declared-in-one-of-plugin.xml

`IdeManagerImpl.readPlatformPlugins` scans `lib/*.jar` for platform plugin descriptors and requires at least one to produce `pluginId == "com.intellij"`. For Rider 2023.3 (build `RD-233.15026.35`) this check throws:

```
InvalidIdeException: IDE by path '...' is invalid: Platform plugins are not found.
They must be declared in one of plugin.xml, RiderPlugin.xml
```

### Why Rider 233 breaks

The Rider 233 `lib/` directory has two relevant jars:

| Jar | File | Plugin ID produced |
|-----|------|--------------------|
| `product.jar` | `META-INF/RiderPlugin.xml` | `com.jetbrains.rider.languages` ❌ |
| `app-client.jar` | `META-INF/PlatformLangPlugin.xml` | `com.intellij` ✅ |

`RiderPlugin.xml` is a pure aggregator — it declares no `<id>` of its own and consists entirely of `<xi:include>` elements. Two of those includes contribute an `<id>`:

1. `<xi:include href="/META-INF/PlatformLangPlugin.xml"/>` → `<id>com.intellij</id>`
2. `<xi:include href="/languages.xml"/>` → `<id>com.jetbrains.rider.languages</id>`

JAXB unmarshals `<id>` into a single `String` field and overwrites on each occurrence — last value wins. Because `languages.xml` is included after `PlatformLangPlugin.xml`, the resolved plugin ends up with id `com.jetbrains.rider.languages`, not `com.intellij`.

`ProductInfoBasedIdeManager` cannot handle this IDE either: Rider 233's `product-info.json` exists but has no `layout` field, and its build number `233 < 242` fails the version gate in `supports()`.

### Root cause of the regression

Commit `5e4c06738` ("PlatformLangPlugin.xml is never the real IDE's core plugin descriptor") removed `PlatformLangPlugin.xml` from the descriptor search list to fix a flaky IDEA 2024.3 test — the `com.intellij` plugin was being loaded twice, once from `product.jar/plugin.xml` and once from `app-client.jar/PlatformLangPlugin.xml`, and `Files.list` ordering determined which copy survived. That fix was correct for IDEA 2024.3, but it removed the only path to `com.intellij` for Rider 233.

## Fix

Replace the flat two-element descriptor list with a two-tier fallback in `IdeManagerImpl.readPlatformPlugins`:

**Primary pass** — `["plugin.xml", "{product}Plugin.xml"]` — unchanged behaviour for all currently working IDEs.

**Fallback pass** — `["PlatformLangPlugin.xml"]` — runs *only if* `com.intellij` was not found in the primary pass. For Rider 233 this fires and loads `app-client.jar/PlatformLangPlugin.xml` directly, producing `com.intellij`.

**ID deduplication via `HashSet`** — if both passes find a plugin with the same ID (as in IDEA 2024.3 where `product.jar/plugin.xml` already produced `com.intellij`), the second occurrence is skipped. The primary pass always wins, so the real full descriptor beats the lang subset regardless of `Files.list` order — fixing the flakiness that motivated the original commit.

## Tests added

`IdeManagerImplTest` (6 tests):

- **Rider 233 regression** — mock IDE with `product.jar/RiderPlugin.xml` (id=`com.jetbrains.rider.languages`) and `app-client.jar/PlatformLangPlugin.xml` (id=`com.intellij`); asserts both plugins are present after loading.
- **Deduplication** — mock IDE where both `product.jar/plugin.xml` and `app-client.jar/PlatformLangPlugin.xml` declare `com.intellij`; asserts exactly one `com.intellij` plugin is loaded and it comes from `product.jar` (verified via a marker module `com.intellij.modules.idea` absent from `PlatformLangPlugin.xml`).
- **Dispatch routing** — `DispatchingIdeManager` routes Rider 233 (no layout, build < 242) through `IdeManagerImpl`, and routes a modern IU-242+ IDE through `ProductInfoBasedIdeManager`.
- **Error case** — missing descriptor still throws `InvalidIdeException` with the correct message (now including `PlatformLangPlugin.xml`).
- **Sanity** — a Rider IDE with `RiderPlugin.xml` directly declaring `com.intellij` still loads correctly.
