### PR TITLE
Split dependency and plugin resolver caches

### DIFF
--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -72,16 +72,11 @@ class CachingPluginDependencyResolverProvider(
     }
   }
 
+  /**
+   * This method should be never called. `PluginResolverProvider` should be refactored.
+   */
   override fun contains(pluginId: PluginId): Boolean {
-    pluginResolverCache.asMap().keys.firstOrNull { it.resolverName == pluginId }?.let { key ->
-      return pluginResolverCache.getIfPresent(key) != null
-    }
-
-    dependencyResolverCache.asMap().keys.firstOrNull { it.id == pluginId }?.let { key ->
-      return dependencyResolverCache.getIfPresent(key) != null
-    }
-
-    return false
+    throw UnsupportedOperationException("This should not be called")
   }
 
   /**

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -19,6 +19,17 @@ private const val DEFAULT_CACHE_SIZE = 1024L
 
 private const val UNKNOWN_DEPENDENCY_ID = "Unknown ID"
 
+private data class PluginArtifactKey(
+  val id: String,
+  val version: String?,
+  val originalFile: java.nio.file.Path?
+)
+
+private data class PluginResolverKey(
+  val plugin: PluginArtifactKey,
+  val resolverName: String
+)
+
 class CachingPluginDependencyResolverProvider(
   pluginProvider: PluginProvider,
   private val secondaryPluginResolverProvider: PluginResolverProvider? = null,
@@ -29,10 +40,15 @@ class CachingPluginDependencyResolverProvider(
 
   private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate, dependencyFilter)
 
-  private val cache = Caffeine.newBuilder()
+  private val dependencyResolverCache = Caffeine.newBuilder()
     .maximumSize(DEFAULT_CACHE_SIZE)
     .recordStats()
-    .build<String, Resolver>()
+    .build<PluginArtifactKey, Resolver>()
+
+  private val pluginResolverCache = Caffeine.newBuilder()
+    .maximumSize(DEFAULT_CACHE_SIZE)
+    .recordStats()
+    .build<PluginResolverKey, NamedResolver>()
 
   /**
    * Provide a unified resolver for all transitive dependencies of this plugin.
@@ -43,21 +59,41 @@ class CachingPluginDependencyResolverProvider(
    * and includes only those that are declared as dependencies in the plugin.
    */
   override fun getResolver(plugin: IdePlugin): Resolver {
-    val id = plugin.id ?: return EMPTY_RESOLVER
+    plugin.id ?: return EMPTY_RESOLVER
     getFromSecondaryCache(plugin)?.let {
-      return it.also {
-        cache.put(id, it)
-      }
+      return it
     }
+    val cacheKey = plugin.artifactKey()
     // Invocation of `getIfPresent` is intentional!
-    // Using `get` would lead to a recursive update triggered by `doGetResolver`.
-    val resolver = cache.getIfPresent(id)
+    // Using `get` would lead to a recursive update triggered by `createResolver`.
+    val resolver = dependencyResolverCache.getIfPresent(cacheKey)
     return resolver ?: createResolver(plugin).also {
-      cache.put(id, it)
+      dependencyResolverCache.put(cacheKey, it)
     }
   }
 
-  override fun contains(pluginId: PluginId) = cache.getIfPresent(pluginId) != null
+  override fun contains(pluginId: PluginId): Boolean {
+    pluginResolverCache.asMap().keys.firstOrNull { it.resolverName == pluginId }?.let { key ->
+      return pluginResolverCache.getIfPresent(key) != null
+    }
+
+    dependencyResolverCache.asMap().keys.firstOrNull { it.id == pluginId }?.let { key ->
+      return dependencyResolverCache.getIfPresent(key) != null
+    }
+
+    return false
+  }
+
+  /**
+   * Returns the resolver containing the plugin's own classes if it is already available.
+   * Unlike [getResolver], this method never returns a dependency-closure resolver.
+   */
+  fun getCachedPluginResolver(plugin: IdePlugin): Resolver? {
+    getFromSecondaryCache(plugin)?.let {
+      return it
+    }
+    return pluginResolverCache.getIfPresent(plugin.resolverCacheKey())
+  }
 
   private fun createResolver(plugin: IdePlugin): Resolver {
     val dependencyTreeResolution = dependencyTree
@@ -71,16 +107,22 @@ class CachingPluginDependencyResolverProvider(
       .mapNotNull { dep -> dep.pluginId?.let { it.intern() to dep } }
       .distinctBy { it.first }
       .associate { (id, dep) ->
-        val dependencyResolver = cache.getIfPresent(id)
+        val dependencyPlugin = dep.plugin
+        if (dependencyPlugin == null) {
+          return@associate id to EmptyResolver(dep.id)
+        }
+        val resolverCacheKey = dependencyPlugin.resolverCacheKey()
+        val dependencyResolver = pluginResolverCache.getIfPresent(resolverCacheKey)
         if (dependencyResolver != null) {
           return@associate id to dependencyResolver
         }
         // it's OK to synchronize on plugin id (String) since we've interned it.
-        // Synchronizing to prevent creating different resolvers for the same plugin in `createResolverTree`
+        // Synchronizing to prevent creating different resolvers for the same plugin in `createResolverTree`.
+        // Different plugin versions may serialize on the same lock, but they use distinct cache keys.
         synchronized(id) {
-          val dependencyResolver = cache.getIfPresent(id)
-          if (dependencyResolver != null) {
-            id to dependencyResolver
+          val resolver = pluginResolverCache.getIfPresent(resolverCacheKey)
+          if (resolver != null) {
+            id to resolver
           } else {
             id to dep.createResolverTree()
           }
@@ -92,9 +134,9 @@ class CachingPluginDependencyResolverProvider(
   private fun Dependency.createResolverTree(): NamedResolver {
     return plugin?.createResolverTree()
       ?.let { (r, resolversToCache) ->
-        pluginId?.let { cache.put(it, r) }
+        pluginResolverCache.put(plugin.resolverCacheKey(r.name), r)
         resolversToCache.forEach {
-          cache.put(it.name, it)
+          pluginResolverCache.put(plugin.resolverCacheKey(it.name), it)
         }
         r
       } ?: EmptyResolver(id)
@@ -110,7 +152,7 @@ class CachingPluginDependencyResolverProvider(
     }
 
   fun getStats(): CacheStats? {
-    return cache.stats()
+    return dependencyResolverCache.stats().plus(pluginResolverCache.stats())
   }
 
   private val IdePlugin.id: String?
@@ -137,7 +179,7 @@ class CachingPluginDependencyResolverProvider(
     val cpResolvers = classpath.entries.map { cpEntry ->
       val origin = IdeFileOrigin.BundledPlugin(cpEntry.path, idePlugin = this)
       val cpEntryResolverName = resolverPrefix + cpEntry.path.fileName.toString()
-      val cpEntryResolver = cache.getIfPresent(cpEntryResolverName)
+      val cpEntryResolver = pluginResolverCache.getIfPresent(resolverCacheKey(cpEntryResolverName))
       if (cpEntryResolver is NamedResolver) {
         return@map cpEntryResolver
       }
@@ -174,6 +216,12 @@ class CachingPluginDependencyResolverProvider(
   private fun Resolver.asNamed(fallbackName: String): NamedResolver {
     return this as? NamedResolver ?: CompositeResolver.create(listOf(this), fallbackName)
   }
+
+  private fun IdePlugin.artifactKey(): PluginArtifactKey =
+    PluginArtifactKey(id ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
+
+  private fun IdePlugin.resolverCacheKey(resolverName: String = newResolverName()): PluginResolverKey =
+    PluginResolverKey(artifactKey(), resolverName)
 
   private fun IdePlugin.newResolverName(): String = id ?: UNNAMED_RESOLVER
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -132,14 +132,15 @@ class CachingPluginDependencyResolverProvider(
   }
 
   private fun Dependency.createResolverTree(): NamedResolver {
-    return plugin?.createResolverTree()
-      ?.let { (r, resolversToCache) ->
-        pluginResolverCache.put(plugin.resolverCacheKey(r.name), r)
+    val dependencyPlugin = plugin ?: return EmptyResolver(id)
+    return dependencyPlugin.createResolverTree()
+      .let { (r, resolversToCache) ->
+        pluginResolverCache.put(dependencyPlugin.resolverCacheKey(), r)
         resolversToCache.forEach {
-          pluginResolverCache.put(plugin.resolverCacheKey(it.name), it)
+          pluginResolverCache.put(dependencyPlugin.resolverCacheKey(it.name), it)
         }
         r
-      } ?: EmptyResolver(id)
+      }
   }
 
   private val Dependency.id: String

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -19,6 +19,17 @@ private const val DEFAULT_CACHE_SIZE = 1024L
 
 private const val UNKNOWN_DEPENDENCY_ID = "Unknown ID"
 
+private data class PluginArtifactKey(
+  val id: String,
+  val version: String?,
+  val originalFile: java.nio.file.Path?
+)
+
+private data class PluginResolverKey(
+  val plugin: PluginArtifactKey,
+  val resolverName: String
+)
+
 class CachingPluginDependencyResolverProvider(
   pluginProvider: PluginProvider,
   private val secondaryPluginResolverProvider: PluginResolverProvider? = null,
@@ -28,10 +39,15 @@ class CachingPluginDependencyResolverProvider(
 
   private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate)
 
-  private val cache = Caffeine.newBuilder()
+  private val dependencyResolverCache = Caffeine.newBuilder()
     .maximumSize(DEFAULT_CACHE_SIZE)
     .recordStats()
-    .build<String, Resolver>()
+    .build<PluginArtifactKey, Resolver>()
+
+  private val pluginResolverCache = Caffeine.newBuilder()
+    .maximumSize(DEFAULT_CACHE_SIZE)
+    .recordStats()
+    .build<PluginResolverKey, NamedResolver>()
 
   /**
    * Provide a unified resolver for all transitive dependencies of this plugin.
@@ -42,21 +58,41 @@ class CachingPluginDependencyResolverProvider(
    * and includes only those that are declared as dependencies in the plugin.
    */
   override fun getResolver(plugin: IdePlugin): Resolver {
-    val id = plugin.id ?: return EMPTY_RESOLVER
+    plugin.id ?: return EMPTY_RESOLVER
     getFromSecondaryCache(plugin)?.let {
-      return it.also {
-        cache.put(id, it)
-      }
+      return it
     }
+    val cacheKey = plugin.artifactKey()
     // Invocation of `getIfPresent` is intentional!
-    // Using `get` would lead to a recursive update triggered by `doGetResolver`.
-    val resolver = cache.getIfPresent(id)
+    // Using `get` would lead to a recursive update triggered by `createResolver`.
+    val resolver = dependencyResolverCache.getIfPresent(cacheKey)
     return resolver ?: createResolver(plugin).also {
-      cache.put(id, it)
+      dependencyResolverCache.put(cacheKey, it)
     }
   }
 
-  override fun contains(pluginId: PluginId) = cache.getIfPresent(pluginId) != null
+  override fun contains(pluginId: PluginId): Boolean {
+    pluginResolverCache.asMap().keys.firstOrNull { it.resolverName == pluginId }?.let { key ->
+      return pluginResolverCache.getIfPresent(key) != null
+    }
+
+    dependencyResolverCache.asMap().keys.firstOrNull { it.id == pluginId }?.let { key ->
+      return dependencyResolverCache.getIfPresent(key) != null
+    }
+
+    return false
+  }
+
+  /**
+   * Returns the resolver containing the plugin's own classes if it is already available.
+   * Unlike [getResolver], this method never returns a dependency-closure resolver.
+   */
+  fun getCachedPluginResolver(plugin: IdePlugin): Resolver? {
+    getFromSecondaryCache(plugin)?.let {
+      return it
+    }
+    return pluginResolverCache.getIfPresent(plugin.resolverCacheKey())
+  }
 
   private fun createResolver(plugin: IdePlugin): Resolver {
     val dependencyTreeResolution = dependencyTree
@@ -70,16 +106,22 @@ class CachingPluginDependencyResolverProvider(
       .mapNotNull { dep -> dep.pluginId?.let { it.intern() to dep } }
       .distinctBy { it.first }
       .associate { (id, dep) ->
-        val dependencyResolver = cache.getIfPresent(id)
+        val dependencyPlugin = dep.plugin
+        if (dependencyPlugin == null) {
+          return@associate id to EmptyResolver(dep.id)
+        }
+        val resolverCacheKey = dependencyPlugin.resolverCacheKey()
+        val dependencyResolver = pluginResolverCache.getIfPresent(resolverCacheKey)
         if (dependencyResolver != null) {
           return@associate id to dependencyResolver
         }
         // it's OK to synchronize on plugin id (String) since we've interned it.
-        // Synchronizing to prevent creating different resolvers for the same plugin in `createResolverTree`
+        // Synchronizing to prevent creating different resolvers for the same plugin in `createResolverTree`.
+        // Different plugin versions may serialize on the same lock, but they use distinct cache keys.
         synchronized(id) {
-          val dependencyResolver = cache.getIfPresent(id)
-          if (dependencyResolver != null) {
-            id to dependencyResolver
+          val resolver = pluginResolverCache.getIfPresent(resolverCacheKey)
+          if (resolver != null) {
+            id to resolver
           } else {
             id to dep.createResolverTree()
           }
@@ -89,14 +131,15 @@ class CachingPluginDependencyResolverProvider(
   }
 
   private fun Dependency.createResolverTree(): NamedResolver {
-    return plugin?.createResolverTree()
-      ?.let { (r, resolversToCache) ->
-        cache.put(this.pluginId, r)
+    val dependencyPlugin = plugin ?: return EmptyResolver(id)
+    return dependencyPlugin.createResolverTree()
+      .let { (r, resolversToCache) ->
+        pluginResolverCache.put(dependencyPlugin.resolverCacheKey(r.name), r)
         resolversToCache.forEach {
-          cache.put(it.name, it)
+          pluginResolverCache.put(dependencyPlugin.resolverCacheKey(it.name), it)
         }
         r
-      } ?: EmptyResolver(id)
+      }
   }
 
   private val Dependency.id: String
@@ -109,7 +152,7 @@ class CachingPluginDependencyResolverProvider(
     }
 
   fun getStats(): CacheStats? {
-    return cache.stats()
+    return dependencyResolverCache.stats().plus(pluginResolverCache.stats())
   }
 
   private val IdePlugin.id: String?
@@ -136,7 +179,7 @@ class CachingPluginDependencyResolverProvider(
     val cpResolvers = classpath.entries.map { cpEntry ->
       val origin = IdeFileOrigin.BundledPlugin(cpEntry.path, idePlugin = this)
       val cpEntryResolverName = resolverPrefix + cpEntry.path.fileName.toString()
-      val cpEntryResolver = cache.getIfPresent(cpEntryResolverName)
+      val cpEntryResolver = pluginResolverCache.getIfPresent(resolverCacheKey(cpEntryResolverName))
       if (cpEntryResolver is NamedResolver) {
         return@map cpEntryResolver
       }
@@ -173,6 +216,12 @@ class CachingPluginDependencyResolverProvider(
   private fun Resolver.asNamed(fallbackName: String): NamedResolver {
     return this as? NamedResolver ?: CompositeResolver.create(listOf(this), fallbackName)
   }
+
+  private fun IdePlugin.artifactKey(): PluginArtifactKey =
+    PluginArtifactKey(id ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
+
+  private fun IdePlugin.resolverCacheKey(resolverName: String = newResolverName()): PluginResolverKey =
+    PluginResolverKey(artifactKey(), resolverName)
 
   private fun IdePlugin.newResolverName(): String = id ?: UNNAMED_RESOLVER
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -86,7 +86,7 @@ class CachingPluginDependencyResolverProvider(
 
   /**
    * Returns the resolver containing the plugin's own classes if it is already available.
-   * Unlike [getResolver], this method never returns a dependency-closure resolver.
+   * Unlike [getResolver], this method never returns a [DependencyTreeAwareResolver].
    */
   fun getCachedPluginResolver(plugin: IdePlugin): Resolver? {
     getFromSecondaryCache(plugin)?.let {

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -71,16 +71,11 @@ class CachingPluginDependencyResolverProvider(
     }
   }
 
+  /**
+   * This method should be never called. `PluginResolverProvider` should be refactored.
+   */
   override fun contains(pluginId: PluginId): Boolean {
-    pluginResolverCache.asMap().keys.firstOrNull { it.resolverName == pluginId }?.let { key ->
-      return pluginResolverCache.getIfPresent(key) != null
-    }
-
-    dependencyResolverCache.asMap().keys.firstOrNull { it.id == pluginId }?.let { key ->
-      return dependencyResolverCache.getIfPresent(key) != null
-    }
-
-    return false
+    throw UnsupportedOperationException("This should not be called")
   }
 
   /**

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -11,6 +11,7 @@ import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode
 import com.jetbrains.plugin.structure.ide.classes.IdeFileOrigin
 import com.jetbrains.plugin.structure.intellij.plugin.*
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.*
+import org.jetbrains.annotations.TestOnly
 
 /**
  * See also cache size in [CacheResolver].
@@ -71,6 +72,14 @@ class CachingPluginDependencyResolverProvider(
       dependencyResolverCache.put(cacheKey, it)
     }
   }
+
+  @TestOnly
+  fun dependencyResolverCacheContains(pluginId: PluginId): Boolean =
+    dependencyResolverCache.asMap().keys.any { it.id == pluginId }
+
+  @TestOnly
+  fun pluginResolverCacheContains(resolverName: String): Boolean =
+    pluginResolverCache.asMap().keys.any { it.resolverName == resolverName }
 
   /**
    * This method should be never called. `PluginResolverProvider` should be refactored.
@@ -268,4 +277,3 @@ class CachingPluginDependencyResolverProvider(
     }
   }
 }
-

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -40,8 +40,9 @@ class CachingPluginDependencyResolverProvider(
 
   private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate)
 
+  // Dependency resolvers retain substantially more state than plugin resolvers.
   private val dependencyResolverCache = Caffeine.newBuilder()
-    .maximumSize(DEFAULT_CACHE_SIZE)
+    .maximumSize(DEFAULT_CACHE_SIZE / 4)
     .recordStats()
     .build<PluginArtifactKey, Resolver>()
 

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -214,7 +214,7 @@ class CachingPluginDependencyResolverProvider(
   }
 
   private fun IdePlugin.artifactKey(): PluginArtifactKey =
-    PluginArtifactKey(id ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
+    PluginArtifactKey(id?.intern() ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
 
   private fun IdePlugin.resolverCacheKey(resolverName: String = newResolverName()): PluginResolverKey =
     PluginResolverKey(artifactKey(), resolverName)

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -134,7 +134,7 @@ class CachingPluginDependencyResolverProvider(
     val dependencyPlugin = plugin ?: return EmptyResolver(id)
     return dependencyPlugin.createResolverTree()
       .let { (r, resolversToCache) ->
-        pluginResolverCache.put(dependencyPlugin.resolverCacheKey(r.name), r)
+        pluginResolverCache.put(dependencyPlugin.resolverCacheKey(), r)
         resolversToCache.forEach {
           pluginResolverCache.put(dependencyPlugin.resolverCacheKey(it.name), it)
         }

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -213,7 +213,7 @@ class CachingPluginDependencyResolverProvider(
   }
 
   private fun IdePlugin.artifactKey(): PluginArtifactKey =
-    PluginArtifactKey(id ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
+    PluginArtifactKey(id?.intern() ?: UNNAMED_RESOLVER, pluginVersion, originalFile)
 
   private fun IdePlugin.resolverCacheKey(resolverName: String = newResolverName()): PluginResolverKey =
     PluginResolverKey(artifactKey(), resolverName)

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -85,7 +85,7 @@ class CachingPluginDependencyResolverProvider(
 
   /**
    * Returns the resolver containing the plugin's own classes if it is already available.
-   * Unlike [getResolver], this method never returns a dependency-closure resolver.
+   * Unlike [getResolver], this method never returns a [DependencyTreeAwareResolver].
    */
   fun getCachedPluginResolver(plugin: IdePlugin): Resolver? {
     getFromSecondaryCache(plugin)?.let {

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -11,6 +11,7 @@ import com.jetbrains.plugin.structure.classes.resolvers.Resolver.ReadMode
 import com.jetbrains.plugin.structure.ide.classes.IdeFileOrigin
 import com.jetbrains.plugin.structure.intellij.plugin.*
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.*
+import org.jetbrains.annotations.TestOnly
 
 /**
  * See also cache size in [CacheResolver].
@@ -70,6 +71,14 @@ class CachingPluginDependencyResolverProvider(
       dependencyResolverCache.put(cacheKey, it)
     }
   }
+
+  @TestOnly
+  fun dependencyResolverCacheContains(pluginId: PluginId): Boolean =
+    dependencyResolverCache.asMap().keys.any { it.id == pluginId }
+
+  @TestOnly
+  fun pluginResolverCacheContains(resolverName: String): Boolean =
+    pluginResolverCache.asMap().keys.any { it.resolverName == resolverName }
 
   /**
    * This method should be never called. `PluginResolverProvider` should be refactored.
@@ -267,4 +276,3 @@ class CachingPluginDependencyResolverProvider(
     }
   }
 }
-

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -41,8 +41,9 @@ class CachingPluginDependencyResolverProvider(
 
   private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate, dependencyFilter)
 
+  // Dependency resolvers retain substantially more state than plugin resolvers.
   private val dependencyResolverCache = Caffeine.newBuilder()
-    .maximumSize(DEFAULT_CACHE_SIZE)
+    .maximumSize(DEFAULT_CACHE_SIZE / 4)
     .recordStats()
     .build<PluginArtifactKey, Resolver>()
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -375,6 +375,90 @@ class CachingPluginDependencyResolverProviderTest {
   }
 
   @Test
+  fun `dependency closure and plugin classpath resolvers use different cache entries`() {
+    val betaFiles = buildZipFile(temporaryFolder.newTemporaryFile("cache-collision/beta.jar")) {
+      dirs("com/example/beta") {
+        file("BetaAction.class", createEmptyClass("com/example/beta/BetaAction"))
+      }
+    }
+    val betaPlugin = MockIdePlugin(
+      pluginId = "com.example.Beta",
+      pluginVersion = "1.0",
+      originalFile = betaFiles,
+      classpath = Classpath.of(listOf(betaFiles))
+    )
+    val alphaPlugin = MockIdePlugin(
+      pluginId = "com.example.Alpha",
+      dependencies = dependency("com.example.Beta")
+    )
+    val ideVersion = IdeVersion.createIdeVersion("IU-243.12818.47")
+    val ide = MockIde(ideVersion, ideRoot, bundledPlugins = listOf(betaPlugin))
+    val betaAction = "com/example/beta/BetaAction"
+
+    val dependencyClosureFirst = CachingPluginDependencyResolverProvider(ide)
+    dependencyClosureFirst.getResolver(betaPlugin)
+    assertTrue(dependencyClosureFirst.getResolver(alphaPlugin).containsClass(betaAction))
+
+    val pluginClasspathFirst = CachingPluginDependencyResolverProvider(ide)
+    pluginClasspathFirst.getResolver(alphaPlugin)
+    assertFalse(pluginClasspathFirst.getResolver(betaPlugin).containsClass(betaAction))
+  }
+
+  @Test
+  fun `dependency closure cache distinguishes plugin versions`() {
+    val pluginV1 = MockIdePlugin(
+      pluginId = "com.example.Versioned",
+      pluginVersion = "1.0",
+      dependencies = dependency("com.intellij.modules.json")
+    )
+    val pluginV2 = MockIdePlugin(
+      pluginId = "com.example.Versioned",
+      pluginVersion = "2.0",
+      dependencies = dependency("com.intellij.java")
+    )
+    val ideVersion = IdeVersion.createIdeVersion("IU-243.12818.47")
+    val ide = MockIde(ideVersion, ideRoot, bundledPlugins = listOf(ideaCorePlugin, javaPlugin, jsonPlugin))
+    val resolverProvider = CachingPluginDependencyResolverProvider(ide)
+
+    val resolverV1 = resolverProvider.getResolver(pluginV1)
+    assertTrue(resolverV1.containsClass("com/intellij/json/JsonNamesValidator"))
+    assertFalse(resolverV1.containsClass("com/intellij/openapi/actionSystem/DataKeys"))
+
+    val resolverV2 = resolverProvider.getResolver(pluginV2)
+    assertTrue(resolverV2.containsClass("com/intellij/openapi/actionSystem/DataKeys"))
+    assertFalse(resolverV2.containsClass("com/intellij/json/JsonNamesValidator"))
+  }
+
+  @Test
+  fun `dependency closure cache distinguishes artifacts with same id and version`() {
+    val pluginArtifact1 = temporaryFolder.newTemporaryFile("same-version/plugin-1.zip")
+    val pluginArtifact2 = temporaryFolder.newTemporaryFile("same-version/plugin-2.zip")
+    val plugin1 = MockIdePlugin(
+      pluginId = "com.example.SameVersion",
+      pluginVersion = "1.0",
+      originalFile = pluginArtifact1,
+      dependencies = dependency("com.intellij.modules.json")
+    )
+    val plugin2 = MockIdePlugin(
+      pluginId = "com.example.SameVersion",
+      pluginVersion = "1.0",
+      originalFile = pluginArtifact2,
+      dependencies = dependency("com.intellij.java")
+    )
+    val ideVersion = IdeVersion.createIdeVersion("IU-243.12818.47")
+    val ide = MockIde(ideVersion, ideRoot, bundledPlugins = listOf(ideaCorePlugin, javaPlugin, jsonPlugin))
+    val resolverProvider = CachingPluginDependencyResolverProvider(ide)
+
+    val resolver1 = resolverProvider.getResolver(plugin1)
+    assertTrue(resolver1.containsClass("com/intellij/json/JsonNamesValidator"))
+    assertFalse(resolver1.containsClass("com/intellij/openapi/actionSystem/DataKeys"))
+
+    val resolver2 = resolverProvider.getResolver(plugin2)
+    assertTrue(resolver2.containsClass("com/intellij/openapi/actionSystem/DataKeys"))
+    assertFalse(resolver2.containsClass("com/intellij/json/JsonNamesValidator"))
+  }
+
+  @Test
   fun `plugin depends on JSON that is in the secondary cache, but not fully`() {
     val ideRoot = temporaryFolder.newFolder("idea-" + UUID.randomUUID().toString()).toPath()
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -177,7 +177,6 @@ class CachingPluginDependencyResolverProviderTest {
 
     val resolverProvider = CachingPluginDependencyResolverProvider(ide)
     val resolver = resolverProvider.getResolver(plugin)
-    val corePluginCacheHit = 0L
     with(resolverProvider.getStats()) {
       assertNotNull(this); this!!
       /*
@@ -185,7 +184,7 @@ class CachingPluginDependencyResolverProviderTest {
         Cache was not even hit, since the resolver for the second invocation is already in the list
         of modules since the first invocation
        */
-      assertEquals(corePluginCacheHit, hitCount())
+      assertEquals(0, hitCount())
       /*
         1) "com.example.somePlugin" (plugin itself),
         2) "com.intellij" unlocked
@@ -201,8 +200,11 @@ class CachingPluginDependencyResolverProviderTest {
        */
       assertEquals(7,  missCount())
     }
+    listOf("com.example.somePlugin")
+      .forEach {
+        assertTrue("Dependency resolver must cache $it", resolverProvider.dependencyResolverCacheContains(it))
+      }
     listOf(
-      "com.example.somePlugin",
       "com.intellij",
       "com.intellij/product.jar",
       "com.intellij.modules.json",
@@ -210,13 +212,13 @@ class CachingPluginDependencyResolverProviderTest {
       "com.intellij.modules.platform",
       "com.intellij.modules.lang")
       .forEach {
-        assertTrue("Resolver must cache $it", resolverProvider.contains(it))
+        assertTrue("Plugin resolver must cache $it", resolverProvider.pluginResolverCacheContains(it))
       }
 
     with(resolverProvider.getStats()) {
       assertNotNull(this); this!!
-      // 7 elements from several lines above checking `resolverProvider.contains`
-      assertEquals(7, hitCount())
+      // Inspecting the cache contents above does not affect cache statistics.
+      assertEquals(0, hitCount())
     }
 
     with(resolver) {
@@ -228,10 +230,8 @@ class CachingPluginDependencyResolverProviderTest {
 
     with(resolverProvider.getStats()) {
       assertNotNull(this); this!!
-      /*
-        Existing 7 checks from the previous half of the test, plus one for "com.intellij"
-       */
-      assertEquals(8, hitCount())
+      // The resolver for "com.intellij" is already cached.
+      assertEquals(1, hitCount())
       /*
         Existing 7 from the previous half of the test, plus:
         8) "com.example.BetterJava" (plugin itself)

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -401,6 +401,9 @@ class CachingPluginDependencyResolverProviderTest {
 
     val pluginClasspathFirst = CachingPluginDependencyResolverProvider(ide)
     pluginClasspathFirst.getResolver(alphaPlugin)
+    val cachedBetaResolver = pluginClasspathFirst.getCachedPluginResolver(betaPlugin)
+    assertNotNull(cachedBetaResolver)
+    assertTrue(cachedBetaResolver!!.containsClass(betaAction))
     assertFalse(pluginClasspathFirst.getResolver(betaPlugin).containsClass(betaAction))
   }
 
@@ -431,8 +434,9 @@ class CachingPluginDependencyResolverProviderTest {
 
   @Test
   fun `dependency closure cache distinguishes artifacts with same id and version`() {
-    val pluginArtifact1 = temporaryFolder.newTemporaryFile("same-version/plugin-1.zip")
-    val pluginArtifact2 = temporaryFolder.newTemporaryFile("same-version/plugin-2.zip")
+    val artifactsDir = temporaryFolder.newFolder("same-version").toPath()
+    val pluginArtifact1 = artifactsDir.resolve("plugin-1.zip")
+    val pluginArtifact2 = artifactsDir.resolve("plugin-2.zip")
     val plugin1 = MockIdePlugin(
       pluginId = "com.example.SameVersion",
       pluginVersion = "1.0",

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProviderTest.kt
@@ -375,7 +375,7 @@ class CachingPluginDependencyResolverProviderTest {
   }
 
   @Test
-  fun `dependency closure and plugin classpath resolvers use different cache entries`() {
+  fun `transitive dependency resolver and plugin classpath resolver use different cache entries`() {
     val betaFiles = buildZipFile(temporaryFolder.newTemporaryFile("cache-collision/beta.jar")) {
       dirs("com/example/beta") {
         file("BetaAction.class", createEmptyClass("com/example/beta/BetaAction"))
@@ -395,9 +395,9 @@ class CachingPluginDependencyResolverProviderTest {
     val ide = MockIde(ideVersion, ideRoot, bundledPlugins = listOf(betaPlugin))
     val betaAction = "com/example/beta/BetaAction"
 
-    val dependencyClosureFirst = CachingPluginDependencyResolverProvider(ide)
-    dependencyClosureFirst.getResolver(betaPlugin)
-    assertTrue(dependencyClosureFirst.getResolver(alphaPlugin).containsClass(betaAction))
+    val transitiveDependencyFirst = CachingPluginDependencyResolverProvider(ide)
+    transitiveDependencyFirst.getResolver(betaPlugin)
+    assertTrue(transitiveDependencyFirst.getResolver(alphaPlugin).containsClass(betaAction))
 
     val pluginClasspathFirst = CachingPluginDependencyResolverProvider(ide)
     pluginClasspathFirst.getResolver(alphaPlugin)
@@ -408,7 +408,7 @@ class CachingPluginDependencyResolverProviderTest {
   }
 
   @Test
-  fun `dependency closure cache distinguishes plugin versions`() {
+  fun `transitive dependency resolver cache distinguishes plugin versions`() {
     val pluginV1 = MockIdePlugin(
       pluginId = "com.example.Versioned",
       pluginVersion = "1.0",
@@ -433,7 +433,7 @@ class CachingPluginDependencyResolverProviderTest {
   }
 
   @Test
-  fun `dependency closure cache distinguishes artifacts with same id and version`() {
+  fun `transitive dependency resolver cache distinguishes artifacts with same id and version`() {
     val artifactsDir = temporaryFolder.newFolder("same-version").toPath()
     val pluginArtifact1 = artifactsDir.resolve("plugin-1.zip")
     val pluginArtifact2 = artifactsDir.resolve("plugin-2.zip")

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
@@ -108,13 +108,13 @@ fun DependenciesGraph.toResolved(batchContext: PluginVerifierBatchContext? = nul
     ResolvedDependencyNode(node.id.dedup(), node.version.dedup(), aliases, isProductModule).dedup()
   }
 
-  val resolvedEdges = edges.mapTo(hashSetOf()) { edge ->
+  val resolvedEdges = java.util.Set.copyOf(edges.map { edge ->
     ResolvedDependencyEdge(
       nodeMap.getValue(edge.from),
       nodeMap.getValue(edge.to),
       ResolvedPluginDependency(edge.dependency.id.dedup(), edge.dependency.isOptional, edge.dependency.isModule).dedup()
     ).dedup()
-  }.dedup()
+  }).dedup()
 
   val resolvedMissingDeps = missingDependencies.entries.associate { (node, missing) ->
     nodeMap.getValue(node) to missing.mapTo(hashSetOf()) { md ->

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -132,9 +132,9 @@ class DefaultClassResolverProvider(
   }
 
   private fun createPluginResolver(pluginDependency: PluginDetails): Resolver = with(pluginDependency.pluginInfo) {
-    // reuse cached resolvers from IDE
-    if (pluginResolverProvider.contains(pluginId)) {
-      return pluginResolverProvider.getResolver(pluginDependency.idePlugin)
+    // Reuse only a cached resolver of the plugin's own classes, never its dependency closure.
+    pluginResolverProvider.getCachedPluginResolver(pluginDependency.idePlugin)?.let {
+      return it
     }
 
     return when (this) {

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -143,9 +143,9 @@ class DefaultClassResolverProvider(
   }
 
   private fun createPluginResolver(pluginDependency: PluginDetails): Resolver = with(pluginDependency.pluginInfo) {
-    // reuse cached resolvers from IDE
-    if (pluginResolverProvider.contains(pluginId)) {
-      return pluginResolverProvider.getResolver(pluginDependency.idePlugin)
+    // Reuse only a cached resolver of the plugin's own classes, never its dependency closure.
+    pluginResolverProvider.getCachedPluginResolver(pluginDependency.idePlugin)?.let {
+      return it
     }
 
     return when (this) {


### PR DESCRIPTION
**Description**

`CachingPluginDependencyResolverProvider` currently stores dependency-closure resolvers and plugin classpath resolvers in the same cache. These resolvers have different semantics: a dependency resolver contains the plugin's dependencies, while a plugin resolver contains the plugin's own classes.

Using the same cache entry for both can make resolution depend on which resolver was created first.

This change separates the two caches and makes their keys identify the actual plugin artifact by ID, version, and original path. `DefaultClassResolverProvider` now explicitly requests the cached plugin resolver instead of reusing the dependency resolver cache.

Added regression tests for separate dependency/plugin resolver entries, different plugin versions, and different artifacts with the same ID and version.
