### PR TITLE
Use local plugin repositories in online `check-trunk-api` mode

### DIFF
--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/DependencyFinders.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/DependencyFinders.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tasks
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.pluginverifier.dependencies.resolution.*
+import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Creates [DependencyFinder] that searches dependencies using the following order:
+ * 1) Bundled with [releaseOrTrunkIde]
+ * 2) Available in the local repository [localPluginRepository].
+ * 3) Compatible with the **release** IDE
+ */
+@ApiStatus.Internal
+fun createDependencyFinder(
+  releaseOrTrunkIde: Ide,
+  releaseIde: Ide,
+  pluginRepository: PluginRepository,
+  localPluginRepository: PluginRepository,
+  pluginDetailsCache: PluginDetailsCache
+): DependencyFinder {
+  val bundledFinder = BundledPluginDependencyFinder(releaseOrTrunkIde)
+
+  val localRepositoryDependencyFinder = RepositoryDependencyFinder(
+    localPluginRepository,
+    LastVersionSelector(),
+    pluginDetailsCache
+  )
+
+  val releaseDependencyFinder = RepositoryDependencyFinder(
+    pluginRepository,
+    LastCompatibleVersionSelector(releaseIde.version),
+    pluginDetailsCache
+  )
+
+  return CompositeDependencyFinder(
+    listOf(
+      bundledFinder,
+      localRepositoryDependencyFinder,
+      releaseDependencyFinder
+    )
+  )
+}
+

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/RepositoryUtils.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/RepositoryUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.tasks
+
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
+import com.jetbrains.pluginverifier.options.CmdOpts
+import com.jetbrains.pluginverifier.options.PluginParsingConfigurationResolution
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.empty.EmptyPluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
+import org.jetbrains.annotations.ApiStatus
+import java.nio.file.Path
+
+@ApiStatus.Internal
+fun createRepository(repositoryRoot: String?, opts: CmdOpts, archiveManager: PluginArchiveManager): PluginRepository {
+  if (repositoryRoot == null) return EmptyPluginRepository
+  return LocalPluginRepositoryFactory.createLocalPluginRepository(
+    Path.of(repositoryRoot),
+    forcePluginCompatibility = opts.offlineMode && opts.forceOfflineCompatibility,
+    archiveManager,
+    problemRemapper = PluginParsingConfigurationResolution.of(opts)
+  )
+}
+

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
@@ -12,12 +12,10 @@ import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.pluginverifier.PluginVerificationDescriptor
 import com.jetbrains.pluginverifier.PluginVerificationTarget
-import com.jetbrains.pluginverifier.dependencies.resolution.*
 import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.misc.retry
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
-import com.jetbrains.pluginverifier.options.PluginParsingConfigurationResolution
 import com.jetbrains.pluginverifier.options.PluginsSet
 import com.jetbrains.pluginverifier.options.filter.PluginFilter
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
@@ -26,15 +24,14 @@ import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.files.FileLock
 import com.jetbrains.pluginverifier.repository.files.IdleFileLock
-import com.jetbrains.pluginverifier.repository.repositories.empty.EmptyPluginRepository
-import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.marketplace.UpdateInfo
 import com.jetbrains.pluginverifier.resolution.DefaultClassResolverProvider
 import com.jetbrains.pluginverifier.tasks.TaskParametersBuilder
+import com.jetbrains.pluginverifier.tasks.createDependencyFinder
+import com.jetbrains.pluginverifier.tasks.createRepository
 import com.sampullara.cli.Args
 import com.sampullara.cli.Argument
-import java.nio.file.Path
 import java.nio.file.Paths
 
 class CheckTrunkApiParamsBuilder(
@@ -83,8 +80,8 @@ class CheckTrunkApiParamsBuilder(
     val externalClassesPackageFilter = OptionsParser.getExternalClassesPackageFilter(opts)
     val problemsFilters = OptionsParser.getProblemsFilters(opts)
 
-    val releaseLocalRepository = createRepository(apiOpts.releaseLocalPluginRepositoryRoot, opts)
-    val trunkLocalRepository = createRepository(apiOpts.trunkLocalPluginRepositoryRoot, opts)
+    val releaseLocalRepository = createRepository(apiOpts.releaseLocalPluginRepositoryRoot, opts, archiveManager)
+    val trunkLocalRepository = createRepository(apiOpts.trunkLocalPluginRepositoryRoot, opts, archiveManager)
 
     val message = "Requesting a list of plugins compatible with the release IDE ${releaseIdeDescriptor.ideVersion}"
     reportage.logVerificationStage(message)
@@ -142,7 +139,13 @@ class CheckTrunkApiParamsBuilder(
       )
     }
 
-    val releaseFinder = createDependencyFinder(releaseIdeDescriptor.ide, releaseIdeDescriptor.ide, releaseLocalRepository, pluginDetailsCache)
+    val releaseFinder = createDependencyFinder(
+      releaseIdeDescriptor.ide,
+      releaseIdeDescriptor.ide,
+      pluginRepository,
+      releaseLocalRepository,
+      pluginDetailsCache
+    )
     val releaseResolverProvider = DefaultClassResolverProvider(
       releaseFinder,
       releaseIdeDescriptor,
@@ -153,7 +156,13 @@ class CheckTrunkApiParamsBuilder(
       PluginVerificationDescriptor.IDE(releaseIdeDescriptor, releaseResolverProvider, it)
     }
 
-    val trunkFinder = createDependencyFinder(trunkIdeDescriptor.ide, releaseIdeDescriptor.ide, trunkLocalRepository, pluginDetailsCache)
+    val trunkFinder = createDependencyFinder(
+      trunkIdeDescriptor.ide,
+      releaseIdeDescriptor.ide,
+      pluginRepository,
+      trunkLocalRepository,
+      pluginDetailsCache
+    )
     val trunkResolverProvider = DefaultClassResolverProvider(
       trunkFinder,
       trunkIdeDescriptor,
@@ -184,41 +193,6 @@ class CheckTrunkApiParamsBuilder(
       releaseVerificationTarget,
       trunkVerificationTarget,
       opts.excludeExternalBuildClassesSelector
-    )
-  }
-
-  /**
-   * Creates [DependencyFinder] that searches dependencies using the following order:
-   * 1) Bundled with [releaseOrTrunkIde]
-   * 2) Available in the local repository [localPluginRepository].
-   * 3) Compatible with the **release** IDE
-   */
-  private fun createDependencyFinder(
-    releaseOrTrunkIde: Ide,
-    releaseIde: Ide,
-    localPluginRepository: PluginRepository,
-    pluginDetailsCache: PluginDetailsCache
-  ): DependencyFinder {
-    val bundledFinder = BundledPluginDependencyFinder(releaseOrTrunkIde)
-
-    val localRepositoryDependencyFinder = RepositoryDependencyFinder(
-      localPluginRepository,
-      LastVersionSelector(),
-      pluginDetailsCache
-    )
-
-    val releaseDependencyFinder = RepositoryDependencyFinder(
-      pluginRepository,
-      LastCompatibleVersionSelector(releaseIde.version),
-      pluginDetailsCache
-    )
-
-    return CompositeDependencyFinder(
-      listOf(
-        bundledFinder,
-        localRepositoryDependencyFinder,
-        releaseDependencyFinder
-      )
     )
   }
 
@@ -257,16 +231,6 @@ class CheckTrunkApiParamsBuilder(
     return latestCompatibleVersions
   }
 
-  private fun createRepository(repositoryRoot: String?, opts: CmdOpts): PluginRepository {
-    if (repositoryRoot == null) return EmptyPluginRepository
-    val repositoryRootPath = Path.of(repositoryRoot)
-    return LocalPluginRepositoryFactory.createLocalPluginRepository(
-      repositoryRoot = repositoryRootPath,
-      forcePluginCompatibility = opts.offlineMode && opts.forceOfflineCompatibility,
-      archiveManager = archiveManager,
-      problemRemapper = PluginParsingConfigurationResolution.of(opts)
-    )
-  }
 }
 
 class CheckTrunkApiOpts {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
@@ -17,9 +17,9 @@ import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.misc.retry
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.options.OptionsParser
+import com.jetbrains.pluginverifier.options.PluginParsingConfigurationResolution
 import com.jetbrains.pluginverifier.options.PluginsSet
 import com.jetbrains.pluginverifier.options.filter.PluginFilter
-import com.jetbrains.pluginverifier.options.repository.LocalPluginRepositoryProvider
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.reporting.PluginVerificationReportage
 import com.jetbrains.pluginverifier.repository.PluginInfo
@@ -27,6 +27,7 @@ import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.files.FileLock
 import com.jetbrains.pluginverifier.repository.files.IdleFileLock
 import com.jetbrains.pluginverifier.repository.repositories.empty.EmptyPluginRepository
+import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginRepositoryFactory
 import com.jetbrains.pluginverifier.repository.repositories.local.LocalPluginInfo
 import com.jetbrains.pluginverifier.repository.repositories.marketplace.UpdateInfo
 import com.jetbrains.pluginverifier.resolution.DefaultClassResolverProvider
@@ -259,11 +260,12 @@ class CheckTrunkApiParamsBuilder(
   private fun createRepository(repositoryRoot: String?, opts: CmdOpts): PluginRepository {
     if (repositoryRoot == null) return EmptyPluginRepository
     val repositoryRootPath = Path.of(repositoryRoot)
-    val provision = LocalPluginRepositoryProvider.getLocalPluginRepository(opts, repositoryRootPath, archiveManager)
-    return when (provision) {
-      is LocalPluginRepositoryProvider.Result.Provided -> provision.pluginRepository
-      LocalPluginRepositoryProvider.Result.Unavailable -> EmptyPluginRepository
-    }
+    return LocalPluginRepositoryFactory.createLocalPluginRepository(
+      repositoryRoot = repositoryRootPath,
+      forcePluginCompatibility = opts.offlineMode && opts.forceOfflineCompatibility,
+      archiveManager = archiveManager,
+      problemRemapper = PluginParsingConfigurationResolution.of(opts)
+    )
   }
 }
 

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilderTest.kt
@@ -1,0 +1,144 @@
+package com.jetbrains.pluginverifier.tasks.checkTrunkApi
+
+import com.jetbrains.plugin.structure.ide.Ide
+import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
+import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
+import com.jetbrains.pluginverifier.options.CmdOpts
+import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
+import com.jetbrains.pluginverifier.repository.PluginInfo
+import com.jetbrains.pluginverifier.repository.PluginRepository
+import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
+import com.jetbrains.pluginverifier.tests.mocks.MockIde
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginRepositoryAdapter
+import com.jetbrains.pluginverifier.tests.mocks.MockPluginVerificationReportage
+import com.jetbrains.pluginverifier.tests.mocks.createMockPluginInfo
+import com.jetbrains.pluginverifier.tests.mocks.createPluginArchiveManager
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class CheckTrunkApiParamsBuilderTest {
+  @Rule
+  @JvmField
+  val temporaryFolder = TemporaryFolder()
+
+  private lateinit var pluginArchiveManager: PluginArchiveManager
+  private lateinit var pluginDetailsCache: RecordingPluginDetailsCache
+  private lateinit var pluginRepository: PluginRepository
+  private lateinit var paramsBuilder: CheckTrunkApiParamsBuilder
+
+  @Before
+  fun setUp() {
+    pluginArchiveManager = temporaryFolder.createPluginArchiveManager()
+    pluginDetailsCache = RecordingPluginDetailsCache()
+
+    val marketplaceFoo = createMockPluginInfo("foo", "9.0-marketplace")
+    val marketplaceBar = createMockPluginInfo("bar", "2.0-marketplace")
+    pluginRepository = object : MockPluginRepositoryAdapter() {
+      override fun getLastCompatibleVersionOfPlugin(ideVersion: IdeVersion, pluginId: String): PluginInfo? = when (pluginId) {
+        "foo" -> marketplaceFoo
+        "bar" -> marketplaceBar
+        else -> null
+      }
+    }
+
+    paramsBuilder = CheckTrunkApiParamsBuilder(
+      pluginRepository,
+      MockPluginVerificationReportage(),
+      pluginDetailsCache,
+      pluginArchiveManager
+    )
+  }
+
+  @Test
+  fun `online check trunk prefers local plugins and falls back to public repository`() {
+    val localRepositoryRoot = temporaryFolder.newFolder("local-plugins")
+    createLocalPlugin(localRepositoryRoot, "foo", "1.0-local")
+
+    val opts = CmdOpts().apply {
+      offlineMode = false
+    }
+    val localRepository = createRepository(localRepositoryRoot, opts)
+
+    // This assertion is the direct regression check: before the fix, online mode
+    // replaced -rjbp/-tjbp with EmptyPluginRepository.
+    assertEquals("1.0-local", localRepository.getAllVersionsOfPlugin("foo").single().version)
+
+    val ide = MockIde(IdeVersion.createIdeVersion("IU-262.1"))
+    val finder = createDependencyFinder(ide, localRepository)
+
+    finder.findPluginDependency("foo", isModule = false).close()
+    finder.findPluginDependency("bar", isModule = false).close()
+
+    // foo exists in both repositories, so the local artifact must win.
+    // bar does not exist locally, so resolution must continue to the public repository.
+    assertEquals(
+      listOf("1.0-local", "2.0-marketplace"),
+      pluginDetailsCache.requestedPlugins.map { it.version }
+    )
+  }
+
+  private fun createRepository(repositoryRoot: File, opts: CmdOpts): PluginRepository {
+    val method = CheckTrunkApiParamsBuilder::class.java.getDeclaredMethod(
+      "createRepository",
+      String::class.java,
+      CmdOpts::class.java
+    )
+    method.isAccessible = true
+    return method.invoke(paramsBuilder, repositoryRoot.absolutePath, opts) as PluginRepository
+  }
+
+  private fun createDependencyFinder(ide: Ide, localRepository: PluginRepository): DependencyFinder {
+    val method = CheckTrunkApiParamsBuilder::class.java.getDeclaredMethod(
+      "createDependencyFinder",
+      Ide::class.java,
+      Ide::class.java,
+      PluginRepository::class.java,
+      PluginDetailsCache::class.java
+    )
+    method.isAccessible = true
+    return method.invoke(paramsBuilder, ide, ide, localRepository, pluginDetailsCache) as DependencyFinder
+  }
+
+  private fun createLocalPlugin(repositoryRoot: File, pluginId: String, version: String) {
+    val metaInf = File(repositoryRoot, "$pluginId/META-INF")
+    check(metaInf.mkdirs())
+    File(metaInf, "plugin.xml").writeText(
+      """
+        <idea-plugin>
+          <id>$pluginId</id>
+          <name>$pluginId</name>
+          <version>$version</version>
+          <vendor email="test@jetbrains.com" url="https://www.jetbrains.com">JetBrains</vendor>
+          <description>This is a sufficiently long plugin description for the verifier test.</description>
+          <change-notes>These are sufficiently long change notes for the verifier test.</change-notes>
+          <idea-version since-build="262.1" until-build="262.*"/>
+          <depends>com.intellij.modules.platform</depends>
+        </idea-plugin>
+      """.trimIndent()
+    )
+  }
+
+  @After
+  fun tearDown() {
+    pluginArchiveManager.close()
+  }
+
+  private class RecordingPluginDetailsCache : PluginDetailsCache {
+    val requestedPlugins = mutableListOf<PluginInfo>()
+
+    override val statistics: CacheStatistics = CacheStatistics()
+
+    override fun getPluginDetailsCacheEntry(pluginInfo: PluginInfo): PluginDetailsCache.Result {
+      requestedPlugins += pluginInfo
+      return PluginDetailsCache.Result.FileNotFound("File is not needed for dependency selection test")
+    }
+
+    override fun close() = Unit
+  }
+}

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilderTest.kt
@@ -1,17 +1,16 @@
 package com.jetbrains.pluginverifier.tasks.checkTrunkApi
 
-import com.jetbrains.plugin.structure.ide.Ide
 import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
-import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
 import com.jetbrains.pluginverifier.options.CmdOpts
 import com.jetbrains.pluginverifier.plugin.PluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.PluginRepository
 import com.jetbrains.pluginverifier.repository.cache.CacheStatistics
+import com.jetbrains.pluginverifier.tasks.createDependencyFinder
+import com.jetbrains.pluginverifier.tasks.createRepository
 import com.jetbrains.pluginverifier.tests.mocks.MockIde
 import com.jetbrains.pluginverifier.tests.mocks.MockPluginRepositoryAdapter
-import com.jetbrains.pluginverifier.tests.mocks.MockPluginVerificationReportage
 import com.jetbrains.pluginverifier.tests.mocks.createMockPluginInfo
 import com.jetbrains.pluginverifier.tests.mocks.createPluginArchiveManager
 import org.junit.After
@@ -30,7 +29,6 @@ class CheckTrunkApiParamsBuilderTest {
   private lateinit var pluginArchiveManager: PluginArchiveManager
   private lateinit var pluginDetailsCache: RecordingPluginDetailsCache
   private lateinit var pluginRepository: PluginRepository
-  private lateinit var paramsBuilder: CheckTrunkApiParamsBuilder
 
   @Before
   fun setUp() {
@@ -47,12 +45,6 @@ class CheckTrunkApiParamsBuilderTest {
       }
     }
 
-    paramsBuilder = CheckTrunkApiParamsBuilder(
-      pluginRepository,
-      MockPluginVerificationReportage(),
-      pluginDetailsCache,
-      pluginArchiveManager
-    )
   }
 
   @Test
@@ -63,14 +55,14 @@ class CheckTrunkApiParamsBuilderTest {
     val opts = CmdOpts().apply {
       offlineMode = false
     }
-    val localRepository = createRepository(localRepositoryRoot, opts)
+    val localRepository = createRepository(localRepositoryRoot.absolutePath, opts, pluginArchiveManager)
 
     // This assertion is the direct regression check: before the fix, online mode
     // replaced -rjbp/-tjbp with EmptyPluginRepository.
     assertEquals("1.0-local", localRepository.getAllVersionsOfPlugin("foo").single().version)
 
     val ide = MockIde(IdeVersion.createIdeVersion("IU-262.1"))
-    val finder = createDependencyFinder(ide, localRepository)
+    val finder = createDependencyFinder(ide, ide, pluginRepository, localRepository, pluginDetailsCache)
 
     finder.findPluginDependency("foo", isModule = false).close()
     finder.findPluginDependency("bar", isModule = false).close()
@@ -81,28 +73,6 @@ class CheckTrunkApiParamsBuilderTest {
       listOf("1.0-local", "2.0-marketplace"),
       pluginDetailsCache.requestedPlugins.map { it.version }
     )
-  }
-
-  private fun createRepository(repositoryRoot: File, opts: CmdOpts): PluginRepository {
-    val method = CheckTrunkApiParamsBuilder::class.java.getDeclaredMethod(
-      "createRepository",
-      String::class.java,
-      CmdOpts::class.java
-    )
-    method.isAccessible = true
-    return method.invoke(paramsBuilder, repositoryRoot.absolutePath, opts) as PluginRepository
-  }
-
-  private fun createDependencyFinder(ide: Ide, localRepository: PluginRepository): DependencyFinder {
-    val method = CheckTrunkApiParamsBuilder::class.java.getDeclaredMethod(
-      "createDependencyFinder",
-      Ide::class.java,
-      Ide::class.java,
-      PluginRepository::class.java,
-      PluginDetailsCache::class.java
-    )
-    method.isAccessible = true
-    return method.invoke(paramsBuilder, ide, ide, localRepository, pluginDetailsCache) as DependencyFinder
   }
 
   private fun createLocalPlugin(repositoryRoot: File, pluginId: String, version: String) {


### PR DESCRIPTION
**Description**

`check-trunk-api` accepts `-rjbp` and `-tjbp` repositories with locally built JetBrains plugins, but currently these repositories are ignored unless Plugin Verifier is running in offline mode.

This makes them unavailable during the normal online `check-trunk-api` workflow, where Marketplace is still needed to obtain 3rd-party plugins and dependencies not present locally.

Create the `check-trunk-api` local repositories independently of the global offline mode. Dependency resolution can then prefer locally built JetBrains plugins and fall back to Marketplace when a dependency is missing locally.

Plugins present in the local JetBrains repositories remain excluded from the verification target: `check-trunk-api` verifies whether trunk introduces new problems in 3rd-party plugins rather than verifying the JetBrains plugins themselves.

Added a test covering local dependency resolution with Marketplace fallback in online mode.
