### PR TITLE
fix(memory): Don't retain verification results in `LoggingPluginVerificationReportageAggregator`

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregator.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/reporting/LoggingPluginVerificationReportageAggregator.kt
@@ -2,8 +2,10 @@ package com.jetbrains.pluginverifier.reporting
 
 import com.jetbrains.pluginverifier.PluginVerificationResult
 import com.jetbrains.pluginverifier.reporting.common.LogReporter
+import com.jetbrains.pluginverifier.repository.PluginInfo
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.io.path.absolute
 
 /**
@@ -11,6 +13,8 @@ import kotlin.io.path.absolute
  * If it is modified, please adjust it in the Plugin DevKit as well.
  */
 private const val VERIFICATION_REPORTS = "Verification reports for %s saved to %s"
+
+private data class ReportLocation(val plugin: PluginInfo, val targetDirectory: Path)
 
 /**
  * Stateful aggregator verification reports and their corresponding directories.
@@ -20,16 +24,16 @@ class LoggingPluginVerificationReportageAggregator(
   private val messageReporters: List<LogReporter<String>> = listOf(LogReporter(LoggerFactory.getLogger("verification")))
 ) : PluginVerificationReportageAggregator {
 
-  private val resultsInDirectories = mutableListOf<Pair<PluginVerificationResult, Path>>()
+  private val reportLocations = ConcurrentLinkedQueue<ReportLocation>()
 
   override fun handleVerificationResult(result: PluginVerificationResult, targetDirectory: Path) {
-    resultsInDirectories.add(result to targetDirectory)
+    reportLocations.add(ReportLocation(result.plugin, targetDirectory))
   }
 
   fun handleAggregatedReportage() {
     messageReporters.forEach { reporter ->
-      for ((result, targetDirectory) in resultsInDirectories) {
-        val message = VERIFICATION_REPORTS.format(result.plugin, targetDirectory.absolute())
+      for ((plugin, targetDirectory) in reportLocations) {
+        val message = VERIFICATION_REPORTS.format(plugin, targetDirectory.absolute())
         reporter.report(message)
       }
     }


### PR DESCRIPTION
`LoggingPluginVerificationReportageAggregator` keeps every `PluginVerificationResult` until verification is complete, even though the final aggregated output only needs the plugin and the directory where its report was written.

A verification result may retain dependency graphs, compatibility problems, usages and other analysis data, so keeping all results alive unnecessarily increases memory usage on large verification runs.

Store only the plugin and report directory instead, allowing the rest of each verification result to be garbage-collected after it has been reported.


