### PR TITLE
WI-85126 suppress internal api usages errors for LaravelIdeaCompatibilityTest

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/filtering/InternalApiUsageFilter.kt
@@ -13,11 +13,16 @@ import com.jetbrains.pluginverifier.verifiers.VerificationContext
 class InternalApiUsageFilter : ApiUsageFilter {
   override fun shouldReport(apiUsage: ApiUsage, context: VerificationContext): ApiUsageFilter.Result {
     return when {
-      apiUsage is InternalApiUsage
-        && context is PluginVerificationContext
-        && PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
+      apiUsage !is InternalApiUsage || context !is PluginVerificationContext ->
+        ApiUsageFilter.Result.Report
+      PluginVendors.isDevelopedByJetBrains(context.idePlugin) ->
         ApiUsageFilter.Result.Ignore("Internal API usage from JetBrains plugins is allowed.")
-      else -> ApiUsageFilter.Result.Report
+      context.idePlugin.pluginId == LARAVEL_IDEA_PLUGIN_ID ->
+        ApiUsageFilter.Result.Ignore("Internal API usage from Laravel Idea is allowed.")
+      else ->
+        ApiUsageFilter.Result.Report
     }
   }
 }
+
+private const val LARAVEL_IDEA_PLUGIN_ID = "com.laravel_idea.plugin"

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/InternalApiUsagePluginTest.kt
@@ -107,6 +107,38 @@ class InternalApiUsagePluginTest {
   }
 
   @Test
+  fun `Laravel Idea plugin class uses an internal API`() {
+    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.laravel_idea.plugin", "Laravel Idea"))
+
+    val verificationResult = VerificationRunner().runPluginVerification(
+      ide,
+      idePlugin,
+      apiUsageFilters = listOf(InternalApiUsageFilter())
+    ) as PluginVerificationResult.Verified
+
+    assertEquals(0, verificationResult.internalApiUsages.size)
+    assertEquals(3, verificationResult.ignoredInternalApiUsages.size)
+    assertEquals(
+      setOf("Internal API usage from Laravel Idea is allowed."),
+      verificationResult.ignoredInternalApiUsages.values.toSet()
+    )
+  }
+
+  @Test
+  fun `another plugin from the Laravel Idea vendor cannot use an internal API`() {
+    val (idePlugin, ide) = prepareIde(IdeaPluginSpec("com.example.plugin", "Laravel Idea"))
+
+    val verificationResult = VerificationRunner().runPluginVerification(
+      ide,
+      idePlugin,
+      apiUsageFilters = listOf(InternalApiUsageFilter())
+    ) as PluginVerificationResult.Verified
+
+    assertEquals(3, verificationResult.internalApiUsages.size)
+    assertEquals(0, verificationResult.ignoredInternalApiUsages.size)
+  }
+
+  @Test
   fun `in the same plugin, a class overrides an internal API method of another class`() {
     val (idePlugin, ide) = prepareServiceAndOverrider(IdeaPluginSpec("com.example.somePlugin", "Some Vendor"))
 


### PR DESCRIPTION
Laravel Idea is a plugin that lives outside the monorepo but is bundled with PhpStorm. It uses the Internal FUS API, which prevents LaravelIdeaCompatibilityTest from passing.