### PR TITLE
Ignore OS and CPU architecture modules during plugin verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 - Close `ZipFile` handles eagerly in `ZipFileHandler` to release archive files after use to restore compatibility with Windows ([#1521](https://github.com/JetBrains/intellij-plugin-verifier/pull/1521), [#1549](https://github.com/JetBrains/intellij-plugin-verifier/pull/1549))
 
-- Plugin Verifier no longer checks that operating system (`com.intellij.modules.os.*`) and CPU architecture (`com.intellij.modules.arch.*`) constraint modules are present in the verification IDE. The declarations remain available as plugin dependencies so Marketplace can use them when calculating OS and architecture compatibility.
+- Add `-ignore-os-arch` to skip checking that operating system (`com.intellij.modules.os.*`) and CPU architecture (`com.intellij.modules.arch.*`) constraint modules are present in the verification IDE. The checks are enabled by default; the declarations remain available as plugin dependencies so Marketplace can use them when calculating OS and architecture compatibility.
 
 ## 1.408 - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Releases prior to January 2023 are tracked on the project GitHub [Releases Page]
 
 - Close `ZipFile` handles eagerly in `ZipFileHandler` to release archive files after use to restore compatibility with Windows ([#1521](https://github.com/JetBrains/intellij-plugin-verifier/pull/1521), [#1549](https://github.com/JetBrains/intellij-plugin-verifier/pull/1549))
 
+- Plugin Verifier no longer checks that operating system (`com.intellij.modules.os.*`) and CPU architecture (`com.intellij.modules.arch.*`) constraint modules are present in the verification IDE. The declarations remain available as plugin dependencies so Marketplace can use them when calculating OS and architecture compatibility.
+
 ## 1.408 - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ Here is the full syntax of the command:
     The prefixes of classes from the external libraries.
     The Plugin Verifier will not report 'No such class' for classes of these packages.
 
+* `-ignore-os-arch`
+
+    Ignore missing operating system (`com.intellij.modules.os.*`) and CPU architecture (`com.intellij.modules.arch.*`) constraint modules during verification.
+    These checks are enabled by default.
+
 * `-plugins-to-check-all-builds (-p-all)`
 
     The plugin IDs to check with the IDE.

--- a/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
+++ b/intellij-plugin-structure/structure-ide-classes/src/main/java/com/jetbrains/plugin/structure/ide/classes/resolver/CachingPluginDependencyResolverProvider.kt
@@ -23,10 +23,11 @@ class CachingPluginDependencyResolverProvider(
   pluginProvider: PluginProvider,
   private val secondaryPluginResolverProvider: PluginResolverProvider? = null,
   ideModulePredicate: IdeModulePredicate = NegativeIdeModulePredicate,
-  private val dependenciesModifier: DependenciesModifier = PassThruDependenciesModifier
+  private val dependenciesModifier: DependenciesModifier = PassThruDependenciesModifier,
+  dependencyFilter: (PluginDependency) -> Boolean = { true }
 ) : PluginResolverProvider {
 
-  private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate)
+  private val dependencyTree = DependencyTree(pluginProvider, ideModulePredicate, dependencyFilter)
 
   private val cache = Caffeine.newBuilder()
     .maximumSize(DEFAULT_CACHE_SIZE)

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTree.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTree.kt
@@ -25,7 +25,11 @@ typealias MissingDependencyListener = (IdePlugin, PluginDependency) -> Unit
 
 private val EMPTY_MISSING_DEPENDENCY_LISTENER: MissingDependencyListener = { _, _ -> }
 
-class DependencyTree(private val pluginProvider: PluginProvider, private val ideModulePredicate: IdeModulePredicate = NegativeIdeModulePredicate) {
+class DependencyTree(
+  private val pluginProvider: PluginProvider,
+  private val ideModulePredicate: IdeModulePredicate = NegativeIdeModulePredicate,
+  private val dependencyFilter: (PluginDependency) -> Boolean = { true }
+) {
 
   fun getDependencyTreeResolution(
     plugin: IdePlugin,
@@ -227,7 +231,8 @@ class DependencyTree(private val pluginProvider: PluginProvider, private val ide
   }
 
   private fun ignore(plugin: IdePlugin, dependency: PluginDependency): Boolean {
-    return dependency.isModule && plugin.hasDefinedModuleWithId(dependency.id)
+    return !dependencyFilter(dependency) ||
+      (dependency.isModule && plugin.hasDefinedModuleWithId(dependency.id))
   }
 
   private fun missingId(plugin: IdePlugin): String {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTreeTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/dependencies/DependencyTreeTest.kt
@@ -131,6 +131,21 @@ class DependencyTreeTest {
   }
 
   @Test
+  fun `platform constraints remain part of dependency resolution by default`() {
+    val platformConstraints: List<PluginDependency> = listOf(
+      PluginV1Dependency.Mandatory("com.intellij.modules.os.mac"),
+      PluginV1Dependency.Mandatory("com.intellij.modules.arch.arm64")
+    )
+    val osArchConstrainedPlugin = MockIdePlugin(
+      pluginId = "com.example.OsArch",
+      dependencies = platformConstraints
+    )
+
+    val resolution = DependencyTree(ide).getDependencyTreeResolution(osArchConstrainedPlugin)
+    assertEquals(mapOf(osArchConstrainedPlugin to platformConstraints.toSet()), resolution.missingDependencies)
+  }
+
+  @Test
   fun `plugin has no dependencies`() {
     val noDependenciesPlugin = MockIdePlugin(pluginId = "com.example.NoDependencies")
 

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/options/CmdOpts.kt
@@ -51,6 +51,12 @@ open class CmdOpts(
   var externalClassesPrefixes: Array<String> = arrayOf(),
 
   @set:Argument(
+    "ignore-os-arch",
+    description = "Ignore missing operating system and CPU architecture constraint modules during verification."
+  )
+  var ignoreOsArch: Boolean = false,
+
+  @set:Argument(
     "exclude-external-build-classes-selector", alias = "ex-selector", description = "Specify this flag if the Plugin Verifier must exclude selector for classes " +
     "used for the external build processes such as JPS classes bundled into the Kotlin plugin (`/lib/jps`).")
   var excludeExternalBuildClassesSelector: Boolean = false,

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkIde/CheckIdeParamsBuilder.kt
@@ -49,6 +49,7 @@ class CheckIdeParamsBuilder(
         ideDescriptor,
         externalClassesPackageFilter,
         archiveManager = archiveManager,
+        ignoreOsArch = opts.ignoreOsArch,
       )
 
       val verificationDescriptors = pluginsSet.pluginsToCheck.map {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkPlugin/CheckPluginParamsBuilder.kt
@@ -73,7 +73,8 @@ class CheckPluginParamsBuilder(
         dependencyFinder,
         ideDescriptor,
         externalClassesPackageFilter,
-        archiveManager = archiveManager
+        archiveManager = archiveManager,
+        ignoreOsArch = opts.ignoreOsArch
       )
 
       pluginsSet.pluginsToCheck.map {

--- a/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
+++ b/intellij-plugin-verifier/verifier-cli/src/main/java/com/jetbrains/pluginverifier/tasks/checkTrunkApi/CheckTrunkApiParamsBuilder.kt
@@ -150,7 +150,8 @@ class CheckTrunkApiParamsBuilder(
       releaseFinder,
       releaseIdeDescriptor,
       externalClassesPackageFilter,
-      archiveManager = archiveManager
+      archiveManager = archiveManager,
+      ignoreOsArch = opts.ignoreOsArch
     )
     val releaseVerificationDescriptors = releasePluginsSet.pluginsToCheck.map {
       PluginVerificationDescriptor.IDE(releaseIdeDescriptor, releaseResolverProvider, it)
@@ -167,7 +168,8 @@ class CheckTrunkApiParamsBuilder(
       trunkFinder,
       trunkIdeDescriptor,
       externalClassesPackageFilter,
-      archiveManager = archiveManager
+      archiveManager = archiveManager,
+      ignoreOsArch = opts.ignoreOsArch
     )
     val trunkVerificationDescriptors = trunkPluginsSet.pluginsToCheck.map {
       PluginVerificationDescriptor.IDE(trunkIdeDescriptor, trunkResolverProvider, it)

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
@@ -19,7 +19,10 @@ private const val INTELLIJ_MODULE_PREFIX = "com.intellij.modules."
 /**
  * Builds the dependencies graph using the [dependencyFinder].
  */
-class DependenciesGraphBuilder(private val dependencyFinder: DependencyFinder) {
+class DependenciesGraphBuilder(
+  private val dependencyFinder: DependencyFinder,
+  private val ignoreOsArch: Boolean = false
+) {
 
   private companion object {
     const val CORE_IDE_PLUGIN_ID = "com.intellij"
@@ -66,9 +69,9 @@ class DependenciesGraphBuilder(private val dependencyFinder: DependencyFinder) {
       dependencies += getRecursiveOptionalDependencies(vertex.plugin).map { PluginDependencyImpl(it.id, true, it.isModule) }
 
       for (pluginDependency in dependencies) {
-        // OS and architecture dependencies are Marketplace compatibility metadata. Do not resolve them into the
+        // OS and architecture dependencies are Marketplace compatibility metadata. They can be excluded from the
         // verification graph because the verifier IDE only contains modules matching its own platform.
-        if (pluginDependency.isPlatformConstraint) continue
+        if (ignoreOsArch && pluginDependency.isPlatformConstraint) continue
 
         val resolvedDependency = resolveDependency(pluginProvider, vertex, pluginDependency, graph, missingDependencies)
           ?: continue

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/DependenciesGraphBuilder.kt
@@ -66,6 +66,10 @@ class DependenciesGraphBuilder(private val dependencyFinder: DependencyFinder) {
       dependencies += getRecursiveOptionalDependencies(vertex.plugin).map { PluginDependencyImpl(it.id, true, it.isModule) }
 
       for (pluginDependency in dependencies) {
+        // OS and architecture dependencies are Marketplace compatibility metadata. Do not resolve them into the
+        // verification graph because the verifier IDE only contains modules matching its own platform.
+        if (pluginDependency.isPlatformConstraint) continue
+
         val resolvedDependency = resolveDependency(pluginProvider, vertex, pluginDependency, graph, missingDependencies)
           ?: continue
 

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/PlatformConstraint.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/PlatformConstraint.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.dependencies
+
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
+import com.jetbrains.plugin.structure.intellij.plugin.enums.CpuArch
+import com.jetbrains.plugin.structure.intellij.plugin.enums.OS
+
+internal val PluginDependency.isPlatformConstraint: Boolean
+  get() = OS.getByModule(id) != null || CpuArch.getByModule(id) != null

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -45,7 +45,8 @@ class DefaultClassResolverProvider(
   private val externalClassesPackageFilter: PackageFilter,
   private val additionalClassResolvers: List<Resolver> = emptyList(),
   private val pluginDetailsBasedResolverProvider: PluginDetailsBasedResolverProvider = DefaultPluginDetailsBasedResolverProvider(),
-  archiveManager: PluginArchiveManager
+  archiveManager: PluginArchiveManager,
+  private val ignoreOsArch: Boolean = false
 ) : ClassResolverProvider {
 
   private val secondaryResolver = ideDescriptor.ideResolver as? ProductInfoClassResolver
@@ -74,8 +75,9 @@ class DefaultClassResolverProvider(
       secondaryResolver,
       ideModulePredicate,
       dependenciesModifier,
-      // Excludes OS and architecture constraint modules from verification-only dependency resolution
-      dependencyFilter = { !it.isPlatformConstraint }
+      // OS and architecture constraint modules are Marketplace compatibility metadata. They can be ignored when
+      // requested because the verifier IDE only contains modules matching its own platform.
+      dependencyFilter = { !ignoreOsArch || !it.isPlatformConstraint }
     )
   }
 
@@ -103,7 +105,8 @@ class DefaultClassResolverProvider(
         || ideResolver !is DependencyTreeAwareResolver
         ) {
         val (depGraph, dependenciesResults) =
-          DependenciesGraphBuilder(dependencyFinder).buildDependenciesGraph(checkedPluginDetails.idePlugin, ideDescriptor.ide)
+          DependenciesGraphBuilder(dependencyFinder, ignoreOsArch)
+            .buildDependenciesGraph(checkedPluginDetails.idePlugin, ideDescriptor.ide)
         closeableResources += dependenciesResults
 
         // Resolve dependencies via DependencyFinder mechanism.

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/resolution/DefaultClassResolverProvider.kt
@@ -14,9 +14,9 @@ import com.jetbrains.plugin.structure.ide.classes.resolver.CachingPluginDependen
 import com.jetbrains.plugin.structure.ide.classes.resolver.CachingPluginDependencyResolverProvider.DependencyTreeAwareResolver
 import com.jetbrains.plugin.structure.ide.classes.resolver.ProductInfoClassResolver
 import com.jetbrains.plugin.structure.intellij.classes.plugin.ClassSearchContext
+import com.jetbrains.plugin.structure.intellij.plugin.CompositeDependenciesModifier
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
-import com.jetbrains.plugin.structure.intellij.plugin.CompositeDependenciesModifier
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.CorePluginDependencyContributor
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.DefaultIdeModulePredicate
 import com.jetbrains.plugin.structure.intellij.plugin.dependencies.IdeModulePredicate
@@ -28,6 +28,7 @@ import com.jetbrains.pluginverifier.createPluginResolver
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraph
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraphBuilder
 import com.jetbrains.pluginverifier.dependencies.DependenciesGraphProvider
+import com.jetbrains.pluginverifier.dependencies.isPlatformConstraint
 import com.jetbrains.pluginverifier.dependencies.resolution.DependencyFinder
 import com.jetbrains.pluginverifier.dependencies.resolution.IdeThenDelegatePluginProvider
 import com.jetbrains.pluginverifier.dependencies.resolution.getDetails
@@ -68,7 +69,14 @@ class DefaultClassResolverProvider(
       CorePluginDependencyContributor(ideDescriptor.ide),
       LegacyPluginDependencyContributor(ideDescriptor.ide, legacyPluginVerifier)
     )
-    CachingPluginDependencyResolverProvider(pluginProvider, secondaryResolver, ideModulePredicate, dependenciesModifier)
+    CachingPluginDependencyResolverProvider(
+      pluginProvider,
+      secondaryResolver,
+      ideModulePredicate,
+      dependenciesModifier,
+      // Excludes OS and architecture constraint modules from verification-only dependency resolution
+      dependencyFilter = { !it.isPlatformConstraint }
+    )
   }
 
   private val bundledPluginClassResolverProvider = BundledPluginClassResolverProvider()

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
@@ -10,6 +10,7 @@ import com.jetbrains.plugin.structure.ide.classes.IdeResolverCreator
 import com.jetbrains.plugin.structure.intellij.platform.ProductInfoParser
 import com.jetbrains.plugin.structure.intellij.plugin.ModuleV2Dependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginArchiveManager
+import com.jetbrains.plugin.structure.intellij.plugin.PluginDependency
 import com.jetbrains.plugin.structure.intellij.plugin.PluginDependencyImpl
 import com.jetbrains.pluginverifier.ide.IdeDescriptor
 import com.jetbrains.pluginverifier.jdk.DefaultJdkDescriptorProvider
@@ -86,6 +87,40 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
     val classResolver = resolverProvider.provide(plugin.getDetails())
     // class from app.jar from mock IDE
     assertTrue(classResolver.allResolver.containsClass("com/intellij/tasks/Task"))
+  }
+
+  @Test
+  fun `platform constraints are not looked up when building the verification classpath`() {
+    val ide = buildIdeWithBundledPlugins(
+      version = "IU-243.21565.193",
+      productInfo = productInfoJsonIU243,
+      hasModuleDescriptors = true
+    )
+    val ideDescriptor = IdeDescriptor.create(ide.idePath, defaultJdkPath = null, ideFileLock = null)
+    val failingDependencyFinder = object : DependencyFinder {
+      override val presentableName = "Failing dependency finder"
+
+      override fun findPluginDependency(dependencyId: String, isModule: Boolean): DependencyFinder.Result =
+        error("Dependency '$dependencyId' must not be looked up")
+
+      override fun findPluginDependency(dependency: PluginDependency) =
+        findPluginDependency(dependency.id, dependency.isModule)
+    }
+    val resolverProvider = DefaultClassResolverProvider(
+      failingDependencyFinder,
+      ideDescriptor,
+      packageFilter,
+      archiveManager = archiveManager
+    )
+    val platformConstraints = listOf(
+      PluginDependencyImpl("com.intellij.modules.os.windows", false, true),
+      PluginDependencyImpl("com.intellij.modules.arch.arm64", false, true)
+    )
+    val constrainedPlugin = plugin.copy(dependencies = platformConstraints)
+
+    val classResolver = resolverProvider.provide(constrainedPlugin.getDetails())
+
+    assertTrue(classResolver.dependenciesGraph.missingDependencies.isEmpty())
   }
 
   @Test

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/dependencies/resolution/DefaultClassResolverProviderTest.kt
@@ -110,7 +110,8 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
       failingDependencyFinder,
       ideDescriptor,
       packageFilter,
-      archiveManager = archiveManager
+      archiveManager = archiveManager,
+      ignoreOsArch = true
     )
     val platformConstraints = listOf(
       PluginDependencyImpl("com.intellij.modules.os.windows", false, true),
@@ -121,6 +122,34 @@ class DefaultClassResolverProviderTest : BaseBytecodeTest() {
     val classResolver = resolverProvider.provide(constrainedPlugin.getDetails())
 
     assertTrue(classResolver.dependenciesGraph.missingDependencies.isEmpty())
+  }
+
+  @Test
+  fun `platform constraints are reported as missing by default`() {
+    val ide = buildIdeWithBundledPlugins(
+      version = "IU-243.21565.193",
+      productInfo = productInfoJsonIU243,
+      hasModuleDescriptors = true
+    )
+    val ideDescriptor = IdeDescriptor.create(ide.idePath, defaultJdkPath = null, ideFileLock = null)
+    val resolverProvider = DefaultClassResolverProvider(
+      dependencyFinder,
+      ideDescriptor,
+      packageFilter,
+      archiveManager = archiveManager
+    )
+    val platformConstraints = listOf(
+      PluginDependencyImpl("com.intellij.modules.os.windows", false, true),
+      PluginDependencyImpl("com.intellij.modules.arch.arm64", false, true)
+    )
+    val constrainedPlugin = plugin.copy(dependencies = platformConstraints)
+
+    val classResolver = resolverProvider.provide(constrainedPlugin.getDetails())
+
+    assertEquals(
+      setOf("com.intellij.modules.os.windows", "com.intellij.modules.arch.arm64"),
+      classResolver.dependenciesGraph.getDirectMissingDependencies().map { it.dependency.id }.toSet()
+    )
   }
 
   @Test

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/CmdOptsTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/options/CmdOptsTest.kt
@@ -1,6 +1,8 @@
 package com.jetbrains.pluginverifier.options
 
 import com.sampullara.cli.Args
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
 
@@ -11,5 +13,15 @@ class CmdOptsTest {
     val opts = CmdOpts()
     Args.parse(opts, args, false)
     assertEquals("unsupported", opts.suppressInternalApiUsageWarnings)
+  }
+
+  @Test
+  fun `ignore os arch flag is disabled by default and can be enabled`() {
+    val defaultOpts = CmdOpts()
+    assertFalse(defaultOpts.ignoreOsArch)
+
+    val opts = CmdOpts()
+    Args.parse(opts, arrayOf("-ignore-os-arch"), false)
+    assertTrue(opts.ignoreOsArch)
   }
 }

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
@@ -21,6 +21,7 @@ import com.jetbrains.pluginverifier.plugin.SizeLimitedPluginDetailsCache
 import com.jetbrains.pluginverifier.repository.PluginInfo
 import com.jetbrains.pluginverifier.repository.files.FileLock
 import com.jetbrains.pluginverifier.repository.files.IdleFileLock
+import com.jetbrains.pluginverifier.tests.mocks.MockDependencyFinder
 import com.jetbrains.pluginverifier.tests.mocks.MockIde
 import com.jetbrains.pluginverifier.tests.mocks.MockIdePlugin
 import com.jetbrains.pluginverifier.tests.mocks.MockPluginRepositoryAdapter
@@ -128,6 +129,23 @@ class IdeDependencyFinderTest {
     assertEquals(setOf("myPlugin", "test", "moduleContainer", "somePlugin", "com.intellij", MOCK_IDE_MODULE_ID), deps.toSet())
 
     assertEquals(setOf(MissingDependency(externalModuleDependency, "Failed to fetch plugin.")), dependenciesGraph.getDirectMissingDependencies())
+  }
+
+  @Test
+  fun `os and arch constraints are not reported as missing dependencies`() {
+    val startPlugin = MockIdePlugin(
+      pluginId = "myPlugin",
+      pluginVersion = "1.0",
+      dependencies = listOf(
+        PluginDependencyImpl("com.intellij.modules.os.mac", false, true),
+        PluginDependencyImpl("com.intellij.modules.arch.arm64", false, true)
+      )
+    )
+
+    val ide = MockIde(IdeVersion.createIdeVersion("IU-262.8665.81"))
+    val (dependenciesGraph, _) = DependenciesGraphBuilder(MockDependencyFinder()).buildDependenciesGraph(startPlugin, ide)
+
+    assertEquals(emptySet<MissingDependency>(), dependenciesGraph.getDirectMissingDependencies())
   }
 
   private fun configureTestIdeDependencyFinder(ide: Ide): DependencyFinder {

--- a/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
+++ b/intellij-plugin-verifier/verifier-test/src/test/java/com/jetbrains/pluginverifier/tests/dependencies/IdeDependencyFinderTest.kt
@@ -132,7 +132,7 @@ class IdeDependencyFinderTest {
   }
 
   @Test
-  fun `os and arch constraints are not reported as missing dependencies`() {
+  fun `os and arch constraints are reported as missing dependencies by default`() {
     val startPlugin = MockIdePlugin(
       pluginId = "myPlugin",
       pluginVersion = "1.0",
@@ -144,6 +144,29 @@ class IdeDependencyFinderTest {
 
     val ide = MockIde(IdeVersion.createIdeVersion("IU-262.8665.81"))
     val (dependenciesGraph, _) = DependenciesGraphBuilder(MockDependencyFinder()).buildDependenciesGraph(startPlugin, ide)
+
+    assertEquals(
+      setOf("com.intellij.modules.os.mac", "com.intellij.modules.arch.arm64"),
+      dependenciesGraph.getDirectMissingDependencies().map { it.dependency.id }.toSet()
+    )
+  }
+
+  @Test
+  fun `os and arch constraints can be ignored`() {
+    val startPlugin = MockIdePlugin(
+      pluginId = "myPlugin",
+      pluginVersion = "1.0",
+      dependencies = listOf(
+        PluginDependencyImpl("com.intellij.modules.os.mac", false, true),
+        PluginDependencyImpl("com.intellij.modules.arch.arm64", false, true)
+      )
+    )
+
+    val ide = MockIde(IdeVersion.createIdeVersion("IU-262.8665.81"))
+    val (dependenciesGraph, _) = DependenciesGraphBuilder(
+      MockDependencyFinder(),
+      ignoreOsArch = true
+    ).buildDependenciesGraph(startPlugin, ide)
 
     assertEquals(emptySet<MissingDependency>(), dependenciesGraph.getDirectMissingDependencies())
   }


### PR DESCRIPTION
# Summary

Adds support for handling operating system and CPU architecture module dependencies during plugin verification.

OS/arch module dependencies, such as `com.intellij.modules.os.*` and `com.intellij.modules.arch.*`, are now recognized as platform compatibility constraints. They are preserved as plugin dependencies so JetBrains Marketplace can use them to determine whether a plugin is compatible with a particular IDE distribution, operating system, and CPU architecture.

By default, Plugin Verifier continues to check these dependencies and reports them when they are missing. This keeps incorrect or contradictory platform declarations visible to plugin authors and helps diagnose cases where a plugin is not available or does not run for some users.

# CLI Switch `-ignore-os-arch`
For JetBrains Marketplace verification scenarios, this PR introduces a new `-ignore-os-arch` option. 

When enabled, Plugin Verifier ignores missing OS/arch constraint modules during dependency resolution. This is useful because Marketplace verification always runs in a Linux environment, where platform-specific constraints for other OS/architecture combinations should not cause verification failures.

