### PR TITLE
Validate sinceBuild and untilBuild components more granularly

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/IdeaVersionBean.java
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/beans/IdeaVersionBean.java
@@ -6,7 +6,11 @@ package com.jetbrains.plugin.structure.intellij.beans;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
 
+
 public class IdeaVersionBean {
-  @XmlAttribute(name = "since-build") public String sinceBuild;
-  @XmlAttribute(name = "until-build") public String untilBuild;
+  public static final String SINCE_BUILD_ATTRIBUTE_NAME = "since-build";
+  public static final String UNTIL_BUILD_ATTRIBUTE_NAME = "until-build";
+
+  @XmlAttribute(name = SINCE_BUILD_ATTRIBUTE_NAME) public String sinceBuild;
+  @XmlAttribute(name = UNTIL_BUILD_ATTRIBUTE_NAME) public String untilBuild;
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/PluginBeanValidator.kt
@@ -8,7 +8,6 @@ import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.intellij.beans.*
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.verifiers.*
-import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
@@ -28,7 +27,7 @@ private val PLUGIN_NAME_RESTRICTED_WORDS = setOf(
 
 class PluginBeanValidator {
   private val pluginIdVerifier = PluginIdVerifier()
-  private val pluginUntilBuildVerifier = PluginUntilBuildVerifier()
+  private val pluginSinceUntilRangeVerifier = PluginSinceUntilRangeVerifier()
   private val pluginProductReleaseVersionVerifier = ProductReleaseVersionVerifier()
 
   fun validate(pluginBean: PluginBean, validationContext: ValidationContext, validateDescriptor: Boolean) {
@@ -44,8 +43,7 @@ class PluginBeanValidator {
       validateDescription(bean.description)
       validateChangeNotes(bean.changeNotes)
       validateVendor(bean.vendor)
-      validateIdeaVersion(bean.ideaVersion)
-      pluginUntilBuildVerifier.verify(bean, descriptorPath, ::registerProblem)
+      pluginSinceUntilRangeVerifier.verify(bean, descriptorPath, ::registerProblem)
       validateProductDescriptor(bean, bean.productDescriptor)
     }
     validateDependencies(bean.dependencies)
@@ -143,40 +141,6 @@ class PluginBeanValidator {
       registerProblem(PropertyWithDefaultValue(descriptorPath, PropertyWithDefaultValue.DefaultProperty.VENDOR_EMAIL, vendorBean.email))
     }
     validatePropertyLength("vendor email", vendorBean.email, MAX_PROPERTY_LENGTH)
-  }
-
-  private fun ValidationContext.validateIdeaVersion(versionBean: IdeaVersionBean?) {
-    if (versionBean == null) {
-      registerProblem(PropertyNotSpecified("idea-version", descriptorPath))
-      return
-    }
-
-    val sinceBuild = versionBean.sinceBuild
-    validateSinceBuild(sinceBuild)
-  }
-
-  private fun ValidationContext.validateSinceBuild(sinceBuild: String?) {
-    if (sinceBuild == null) {
-      registerProblem(SinceBuildNotSpecified(descriptorPath))
-    } else {
-      val sinceBuildParsed = IdeVersion.createIdeVersionIfValid(sinceBuild)
-      if (sinceBuildParsed == null) {
-        registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
-      } else {
-        if (sinceBuild.endsWith(".*")) {
-          registerProblem(SinceBuildCannotContainWildcard(descriptorPath, sinceBuildParsed))
-        }
-        if (sinceBuildParsed.baselineVersion < 130) {
-          registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
-        }
-        if (sinceBuildParsed.baselineVersion > 999) {
-          registerProblem(ErroneousSinceBuild(descriptorPath, sinceBuildParsed))
-        }
-        if (sinceBuildParsed.productCode.isNotEmpty()) {
-          registerProblem(ProductCodePrefixInBuild(descriptorPath))
-        }
-      }
-    }
   }
 
   private fun ValidationContext.validateProductDescriptor(plugin: PluginBean, productDescriptor: ProductDescriptorBean?) {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -107,7 +107,7 @@ class InvalidUntilBuildWithJustBranch(
 class InvalidUntilBuildWithMagicNumber(
   descriptorPath: String,
   untilBuild: String,
-  magicNumber: String
+  magicNumber: Int
 ) : InvalidUntilBuild(
   descriptorPath = descriptorPath,
   untilBuild,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -61,8 +61,7 @@ class InvalidSinceBuild(
   sinceBuild: String
 ) : InvalidDescriptorProblem(
   descriptorPath = descriptorPath,
-  detailedMessage = "The <since-build> parameter ($sinceBuild) format is invalid. Ensure it is greater than <130> " +
-                    "and represents the actual build numbers."
+  detailedMessage = "The <since-build> parameter ($sinceBuild) format is invalid. Ensure it represents the actual build numbers."
 ) {
   override val level
     get() = Level.ERROR
@@ -163,6 +162,25 @@ class ErroneousSinceBuild(
 ) {
   override val hint = ProblemSolutionHint(
     example = "since-build=\"182.4132.789\"",
+    documentationUrl = "https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html"
+  )
+
+  override val level: Level
+    get() = Level.ERROR
+}
+
+class IdeBuildComponentsOutOfRange(
+  ideVersion: IdeVersion,
+  failedComponent: Int,
+  range: IntRange,
+  attributeName: String,
+  descriptorPath: String
+) : InvalidDescriptorProblem(
+  descriptorPath = descriptorPath,
+  detailedMessage = "The `$failedComponent` component of the <$attributeName> parameter ($ideVersion) is out of range [${range.first}; ${range.last}]."
+) {
+  override val hint = ProblemSolutionHint(
+    example = "$attributeName=\"182.4132.789\"",
     documentationUrl = "https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html"
   )
 

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/PluginCreationResultResolver.kt
@@ -68,6 +68,7 @@ class IntelliJPluginCreationResultResolver : PluginCreationResultResolver {
     InvalidUntilBuildWithMagicNumber::class,
     SinceBuildGreaterThanUntilBuild::class,
     ErroneousSinceBuild::class,
+    IdeBuildComponentsOutOfRange::class,
     ProductCodePrefixInBuild::class,
     XIncludeResolutionErrors::class,
     TooLongPropertyValue::class,

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -14,8 +14,6 @@ import com.jetbrains.plugin.structure.intellij.problems.ProductCodePrefixInBuild
 import com.jetbrains.plugin.structure.intellij.problems.SinceBuildCannotContainWildcard
 import com.jetbrains.plugin.structure.intellij.problems.SinceBuildNotSpecified
 import com.jetbrains.plugin.structure.intellij.problems.SuspiciousUntilBuild
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.INVALID
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.VALID
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.version.IdeVersionImpl
 
@@ -28,6 +26,7 @@ private const val SINCE_BASELINE_LOWER_BOUND = 130
 private const val SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND = 281
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_BASELINE = 162
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR = 2016
+private const val MAGIC_BASELINE_NUMBER = 999
 
 class PluginSinceUntilRangeVerifier {
   fun verify(
@@ -110,73 +109,52 @@ class PluginSinceUntilRangeVerifier {
     if (untilBuild == null) {
       return
     }
-    if (isJustASingleComponent(untilBuild)) {
-      if (isSpecialSingleComponent(untilBuild)) {
-        return
-      }
-      if (verifyMagicNumber(untilBuild, descriptorPath) == INVALID) {
-        return
-      }
-      registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
-      verifySingleComponentUntilBuild(untilBuild, descriptorPath)
+    val untilBuildParsed = IdeVersion.createIdeVersionIfValid(untilBuild)
+
+    if (untilBuildParsed == null) {
+      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
       return
     }
 
-    val untilBuildParsed = IdeVersion.createIdeVersionIfValid(untilBuild)
-    if (untilBuildParsed == null) {
-      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
-    } else {
-      verifyIdeBuildComponentsRanges(
-        ideVersion = untilBuildParsed,
-        baselineLowerBound = 0,
-        attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
-        descriptorPath = descriptorPath
-      )
-
-      verifyUntilBuildBaselineMagicNumbers(untilBuildParsed.baselineVersion, untilBuild, untilBuildParsed, descriptorPath)
-      if (untilBuildParsed.productCode.isNotEmpty()) {
-        registerProblem(ProductCodePrefixInBuild(descriptorPath))
+    if (untilBuildParsed.isJustASingleComponent()) {
+      if (untilBuildParsed.baselineVersion == MAGIC_BASELINE_NUMBER) {
+        registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
+        return // fast fail for magic number, no additional checks needed
       }
+
+      registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
+    }
+
+    verifyIdeBuildComponentsRanges(
+      ideVersion = untilBuildParsed,
+      baselineLowerBound = 0,
+      attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+      descriptorPath = descriptorPath
+    )
+    verifyUntilBuildBaselineMagicNumbers(untilBuildParsed, untilBuild, descriptorPath)
+
+    if (untilBuildParsed.productCode.isNotEmpty()) {
+      registerProblem(ProductCodePrefixInBuild(descriptorPath))
     }
   }
 
   private fun ProblemRegistrar.verifyUntilBuildBaselineMagicNumbers(
-    baseline: Int,
+    untilBuild: IdeVersion,
     untilBuildValue: String,
-    untilBuild: IdeVersion?,
     descriptorPath: String
   ) {
+    if (untilBuildValue == BUILD_NUMBER || untilBuildValue == SNAPSHOT) {
+      return
+    }
+    val baseline = untilBuild.baselineVersion
     if (baseline >= FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuildValue, untilBuild))
-    } else if (baseline == 999) {
-      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline.toString()))
+    } else if (baseline == MAGIC_BASELINE_NUMBER) {
+      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline))
     } else if (baseline >= SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND) {
       registerProblem(SuspiciousUntilBuild(untilBuildValue))
     } else {
       verifyInThreeReleasesPerYear(untilBuildValue, baselineVersion = baseline)
-    }
-  }
-
-  private fun ProblemRegistrar.verifyMagicNumber(untilBuildValue: String, descriptorPath: String): ValidationResult {
-    val untilBuild = untilBuildValue.toIntOrNull() ?: return ValidationResult.NOT_APPLICABLE
-    return if (untilBuild >= 999) {
-      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, untilBuildValue))
-      INVALID
-    } else {
-      VALID
-    }
-  }
-
-  private enum class ValidationResult {
-    VALID, INVALID, NOT_APPLICABLE
-  }
-
-  private fun ProblemRegistrar.verifySingleComponentUntilBuild(untilBuild: String, descriptorPath: String) {
-    try {
-      val untilBuildNumber = untilBuild.toInt()
-      verifyUntilBuildBaselineMagicNumbers(untilBuildNumber, untilBuild, untilBuild = null, descriptorPath)
-    } catch (e: NumberFormatException) {
-      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     }
   }
 
@@ -190,15 +168,8 @@ class PluginSinceUntilRangeVerifier {
     }
   }
 
-  private fun isSpecialSingleComponent(untilBuild: String): Boolean {
-    return BUILD_NUMBER == untilBuild || SNAPSHOT == untilBuild
-  }
-
-  private fun isJustASingleComponent(untilBuild: String): Boolean {
-    if (!untilBuild.contains('.') && untilBuild.isNotBlank()) {
-      return true
-    }
-    val components = untilBuild.split('.').size
-    return components == 1
+  private fun IdeVersion.isJustASingleComponent(): Boolean {
+    val meaningfulComponents = components.filter { it != 0 }
+    return meaningfulComponents.size == 1
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -1,29 +1,79 @@
 package com.jetbrains.plugin.structure.intellij.verifiers
 
+import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
+import com.jetbrains.plugin.structure.base.utils.CompatibilityUtils
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
+import com.jetbrains.plugin.structure.intellij.problems.ErroneousSinceBuild
+import com.jetbrains.plugin.structure.intellij.problems.InvalidSinceBuild
 import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuild
 import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch
 import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber
 import com.jetbrains.plugin.structure.intellij.problems.NonexistentReleaseInUntilBuild
 import com.jetbrains.plugin.structure.intellij.problems.ProductCodePrefixInBuild
+import com.jetbrains.plugin.structure.intellij.problems.SinceBuildCannotContainWildcard
+import com.jetbrains.plugin.structure.intellij.problems.SinceBuildNotSpecified
 import com.jetbrains.plugin.structure.intellij.problems.SuspiciousUntilBuild
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginUntilBuildVerifier.ValidationResult.INVALID
-import com.jetbrains.plugin.structure.intellij.verifiers.PluginUntilBuildVerifier.ValidationResult.VALID
+import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.INVALID
+import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.VALID
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 
 
 private const val BUILD_NUMBER = "__BUILD_NUMBER__"
 private const val SNAPSHOT = "SNAPSHOT"
 
+private const val SINCE_BASELINE_LOWER_BOUND = 130
+
 private const val SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND = 281
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_BASELINE = 162
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR = 2016
 
-class PluginUntilBuildVerifier {
-  fun verify(plugin: PluginBean,
-             descriptorPath: String,
-             problemRegistrar: ProblemRegistrar) = with(problemRegistrar) {
-    val untilBuild = plugin.ideaVersion?.untilBuild ?: return
+class PluginSinceUntilRangeVerifier {
+  fun verify(
+    plugin: PluginBean,
+    descriptorPath: String,
+    problemRegistrar: ProblemRegistrar
+  ) = with(problemRegistrar) {
+    val versionBean = plugin.ideaVersion
+    if (versionBean == null) {
+      registerProblem(PropertyNotSpecified("idea-version", descriptorPath))
+      return
+    }
+
+    verifySinceBuild(versionBean.sinceBuild, descriptorPath)
+    verifyUntilBuild(versionBean.untilBuild, descriptorPath)
+  }
+
+  private fun ProblemRegistrar.verifySinceBuild(sinceBuild: String?, descriptorPath: String) {
+    if (sinceBuild == null) {
+      registerProblem(SinceBuildNotSpecified(descriptorPath))
+    } else {
+      val sinceBuildParsed = IdeVersion.createIdeVersionIfValid(sinceBuild)
+      if (sinceBuildParsed == null) {
+        registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
+      } else {
+        if (sinceBuild.endsWith(".*")) {
+          registerProblem(SinceBuildCannotContainWildcard(descriptorPath, sinceBuildParsed))
+        }
+        if (sinceBuildParsed.baselineVersion < SINCE_BASELINE_LOWER_BOUND) {
+          registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
+        }
+        if (sinceBuildParsed.baselineVersion >= CompatibilityUtils.MAX_BRANCH_VALUE) {
+          registerProblem(ErroneousSinceBuild(descriptorPath, sinceBuildParsed))
+        }
+        if (sinceBuildParsed.build >= CompatibilityUtils.MAX_BUILD_VALUE) {
+          registerProblem(ErroneousSinceBuild(descriptorPath, sinceBuildParsed))
+        }
+        if (sinceBuildParsed.productCode.isNotEmpty()) {
+          registerProblem(ProductCodePrefixInBuild(descriptorPath))
+        }
+      }
+    }
+  }
+
+  private fun ProblemRegistrar.verifyUntilBuild(untilBuild: String?, descriptorPath: String) {
+    if (untilBuild == null) {
+      return
+    }
     if (isJustASingleComponent(untilBuild)) {
       if (isSpecialSingleComponent(untilBuild)) {
         return

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -13,6 +13,7 @@ private const val BUILD_NUMBER = "__BUILD_NUMBER__"
 private const val SNAPSHOT = "SNAPSHOT"
 
 private const val SINCE_BASELINE_LOWER_BOUND = 130
+private const val UNTIL_BASELINE_LOWER_BOUND = 130
 
 private const val SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND = 281
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_BASELINE = 162
@@ -107,20 +108,18 @@ class PluginSinceUntilRangeVerifier {
       return
     }
 
-    if (untilBuildParsed.isJustASingleComponent() || untilBuild.isZeroOnlySingleComponent()) {
+    if (untilBuildParsed.isJustASingleComponent()) {
       if (untilBuildParsed.baselineVersion == MAGIC_BASELINE_NUMBER) {
         registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
         return // fast fail for magic number, no additional checks needed
       }
 
       registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
-    } else if (untilBuildParsed.isZeroOnly()) {
-      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     }
 
     verifyIdeBuildComponentsRanges(
       ideVersion = untilBuildParsed,
-      baselineLowerBound = 0,
+      baselineLowerBound = UNTIL_BASELINE_LOWER_BOUND,
       attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
       descriptorPath = descriptorPath
     )
@@ -161,16 +160,8 @@ class PluginSinceUntilRangeVerifier {
     }
   }
 
-  private fun String.isZeroOnlySingleComponent(): Boolean {
-    return !contains('.') && isNotBlank() && all { it == '0' }
-  }
-
   private fun IdeVersion.isJustASingleComponent(): Boolean {
     val meaningfulComponents = components.filter { it != 0 }
     return meaningfulComponents.size == 1
-  }
-
-  private fun IdeVersion.isZeroOnly(): Boolean {
-    return components.all { it == 0 }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -15,7 +15,7 @@ import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 private const val BUILD_NUMBER = "__BUILD_NUMBER__"
 private const val SNAPSHOT = "SNAPSHOT"
 
-private const val SUSPICIOUS_BASELINE_LOWER_BOUND = 281
+private const val SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND = 281
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_BASELINE = 162
 private const val FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR = 2016
 
@@ -28,11 +28,11 @@ class PluginUntilBuildVerifier {
       if (isSpecialSingleComponent(untilBuild)) {
         return
       }
-      if (verifyMagicNumber(untilBuild, descriptorPath, problemRegistrar) == INVALID) {
+      if (verifyMagicNumber(untilBuild, descriptorPath) == INVALID) {
         return
       }
       registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
-      verifySingleComponentUntilBuild(untilBuild, descriptorPath, problemRegistrar)
+      verifySingleComponentUntilBuild(untilBuild, descriptorPath)
       return
     }
 
@@ -40,39 +40,31 @@ class PluginUntilBuildVerifier {
     if (untilBuildParsed == null) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     } else {
-      verifyBaseLineVersion(untilBuildParsed, untilBuild, descriptorPath, problemRegistrar)
+      verifyBaseLineVersion(untilBuildParsed.baselineVersion, untilBuild, untilBuildParsed, descriptorPath)
       if (untilBuildParsed.productCode.isNotEmpty()) {
         registerProblem(ProductCodePrefixInBuild(descriptorPath))
       }
     }
   }
 
-  private fun verifyBaseLineVersion(untilBuild: IdeVersion,
-                                    untilBuildValue: String,
-                                    descriptorPath: String,
-                                    problemRegistrar: ProblemRegistrar) = with(problemRegistrar) {
-    verifyBaseline(untilBuild.baselineVersion, untilBuildValue, untilBuild, descriptorPath, problemRegistrar)
-  }
-
-  private fun verifyBaseline(baseline: Int,
-                             untilBuildValue: String,
-                             untilBuild: IdeVersion?,
-                             descriptorPath: String,
-                             problemRegistrar: ProblemRegistrar) = with(problemRegistrar) {
+  private fun ProblemRegistrar.verifyBaseLineVersion(
+    baseline: Int,
+    untilBuildValue: String,
+    untilBuild: IdeVersion?,
+    descriptorPath: String
+  ) {
     if (baseline >= FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuildValue, untilBuild))
     } else if (baseline >= 999) {
       registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline.toString()))
-    } else if (baseline >= SUSPICIOUS_BASELINE_LOWER_BOUND) {
+    } else if (baseline >= SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND) {
       registerProblem(SuspiciousUntilBuild(untilBuildValue))
     } else {
-      verifyInThreeReleasesPerYear(untilBuildValue, baselineVersion = baseline, problemRegistrar)
+      verifyInThreeReleasesPerYear(untilBuildValue, baselineVersion = baseline)
     }
   }
 
-  private fun verifyMagicNumber(untilBuildValue: String,
-                                descriptorPath: String,
-                                problemRegistrar: ProblemRegistrar): ValidationResult = with(problemRegistrar) {
+  private fun ProblemRegistrar.verifyMagicNumber(untilBuildValue: String, descriptorPath: String): ValidationResult {
     val untilBuild = untilBuildValue.toIntOrNull() ?: return ValidationResult.NOT_APPLICABLE
     return if (untilBuild >= 999) {
       registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, untilBuildValue))
@@ -86,20 +78,16 @@ class PluginUntilBuildVerifier {
     VALID, INVALID, NOT_APPLICABLE
   }
 
-  private fun verifySingleComponentUntilBuild(untilBuild: String,
-                                              descriptorPath: String,
-                                              problemRegistrar: ProblemRegistrar) {
+  private fun ProblemRegistrar.verifySingleComponentUntilBuild(untilBuild: String, descriptorPath: String) {
     try {
       val untilBuildNumber = untilBuild.toInt()
-      verifyBaseline(untilBuildNumber, untilBuild, untilBuild = null, descriptorPath, problemRegistrar)
+      verifyBaseLineVersion(untilBuildNumber, untilBuild, untilBuild = null, descriptorPath)
     } catch (e: NumberFormatException) {
-      problemRegistrar.registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
+      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     }
   }
 
-  private fun verifyInThreeReleasesPerYear(untilBuildValue: String,
-                                           baselineVersion: Int,
-                                           problemRegistrar: ProblemRegistrar) = with(problemRegistrar) {
+  private fun ProblemRegistrar.verifyInThreeReleasesPerYear(untilBuildValue: String, baselineVersion: Int) {
     if (baselineVersion >= FIRST_YEARLY_BASED_RELEASE_NUMBER_BASELINE) {
       val lastDigit = baselineVersion % 10
       val releaseVersion = baselineVersion / 10

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -2,8 +2,9 @@ package com.jetbrains.plugin.structure.intellij.verifiers
 
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.utils.CompatibilityUtils
+import com.jetbrains.plugin.structure.intellij.beans.IdeaVersionBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
-import com.jetbrains.plugin.structure.intellij.problems.ErroneousSinceBuild
+import com.jetbrains.plugin.structure.intellij.problems.IdeBuildComponentsOutOfRange
 import com.jetbrains.plugin.structure.intellij.problems.InvalidSinceBuild
 import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuild
 import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch
@@ -16,6 +17,7 @@ import com.jetbrains.plugin.structure.intellij.problems.SuspiciousUntilBuild
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.INVALID
 import com.jetbrains.plugin.structure.intellij.verifiers.PluginSinceUntilRangeVerifier.ValidationResult.VALID
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
+import com.jetbrains.plugin.structure.intellij.version.IdeVersionImpl
 
 
 private const val BUILD_NUMBER = "__BUILD_NUMBER__"
@@ -54,19 +56,53 @@ class PluginSinceUntilRangeVerifier {
         if (sinceBuild.endsWith(".*")) {
           registerProblem(SinceBuildCannotContainWildcard(descriptorPath, sinceBuildParsed))
         }
-        if (sinceBuildParsed.baselineVersion < SINCE_BASELINE_LOWER_BOUND) {
-          registerProblem(InvalidSinceBuild(descriptorPath, sinceBuild))
-        }
-        if (sinceBuildParsed.baselineVersion >= CompatibilityUtils.MAX_BRANCH_VALUE) {
-          registerProblem(ErroneousSinceBuild(descriptorPath, sinceBuildParsed))
-        }
-        if (sinceBuildParsed.build >= CompatibilityUtils.MAX_BUILD_VALUE) {
-          registerProblem(ErroneousSinceBuild(descriptorPath, sinceBuildParsed))
-        }
         if (sinceBuildParsed.productCode.isNotEmpty()) {
           registerProblem(ProductCodePrefixInBuild(descriptorPath))
         }
+        verifyIdeBuildComponentsRanges(
+          ideVersion = sinceBuildParsed,
+          baselineLowerBound = SINCE_BASELINE_LOWER_BOUND,
+          attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = descriptorPath
+        )
       }
+    }
+  }
+
+  private fun ProblemRegistrar.verifyIdeBuildComponentsRanges(
+    ideVersion: IdeVersion,
+    baselineLowerBound: Int,
+    attributeName: String,
+    descriptorPath: String
+  ) {
+    val baselineRange = IntRange(baselineLowerBound, CompatibilityUtils.MAX_BRANCH_VALUE - 1)
+    if (ideVersion.baselineVersion !in baselineRange) {
+      registerProblem(IdeBuildComponentsOutOfRange(
+        ideVersion = ideVersion,
+        failedComponent = ideVersion.baselineVersion,
+        range = baselineRange,
+        attributeName = attributeName,
+        descriptorPath = descriptorPath
+      ))
+    }
+    if (ideVersion.build >= CompatibilityUtils.MAX_BUILD_VALUE && ideVersion.build != IdeVersionImpl.SNAPSHOT_VALUE) {
+      registerProblem(IdeBuildComponentsOutOfRange(
+        ideVersion = ideVersion,
+        failedComponent = ideVersion.build,
+        range = IntRange(0, CompatibilityUtils.MAX_BUILD_VALUE - 1),
+        attributeName = attributeName,
+        descriptorPath = descriptorPath
+      ))
+    }
+    val thirdComponent = ideVersion.components.getOrNull(2)
+    if (thirdComponent != null && thirdComponent >= CompatibilityUtils.MAX_COMPONENT_VALUE && thirdComponent != IdeVersionImpl.SNAPSHOT_VALUE) {
+      registerProblem(IdeBuildComponentsOutOfRange(
+        ideVersion = ideVersion,
+        failedComponent = thirdComponent,
+        range = IntRange(0, CompatibilityUtils.MAX_COMPONENT_VALUE - 1),
+        attributeName = attributeName,
+        descriptorPath = descriptorPath
+      ))
     }
   }
 
@@ -90,14 +126,21 @@ class PluginSinceUntilRangeVerifier {
     if (untilBuildParsed == null) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     } else {
-      verifyBaseLineVersion(untilBuildParsed.baselineVersion, untilBuild, untilBuildParsed, descriptorPath)
+      verifyIdeBuildComponentsRanges(
+        ideVersion = untilBuildParsed,
+        baselineLowerBound = 0,
+        attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = descriptorPath
+      )
+
+      verifyUntilBuildBaselineMagicNumbers(untilBuildParsed.baselineVersion, untilBuild, untilBuildParsed, descriptorPath)
       if (untilBuildParsed.productCode.isNotEmpty()) {
         registerProblem(ProductCodePrefixInBuild(descriptorPath))
       }
     }
   }
 
-  private fun ProblemRegistrar.verifyBaseLineVersion(
+  private fun ProblemRegistrar.verifyUntilBuildBaselineMagicNumbers(
     baseline: Int,
     untilBuildValue: String,
     untilBuild: IdeVersion?,
@@ -105,7 +148,7 @@ class PluginSinceUntilRangeVerifier {
   ) {
     if (baseline >= FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuildValue, untilBuild))
-    } else if (baseline >= 999) {
+    } else if (baseline == 999) {
       registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline.toString()))
     } else if (baseline >= SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND) {
       registerProblem(SuspiciousUntilBuild(untilBuildValue))
@@ -131,7 +174,7 @@ class PluginSinceUntilRangeVerifier {
   private fun ProblemRegistrar.verifySingleComponentUntilBuild(untilBuild: String, descriptorPath: String) {
     try {
       val untilBuildNumber = untilBuild.toInt()
-      verifyBaseLineVersion(untilBuildNumber, untilBuild, untilBuild = null, descriptorPath)
+      verifyUntilBuildBaselineMagicNumbers(untilBuildNumber, untilBuild, untilBuild = null, descriptorPath)
     } catch (e: NumberFormatException) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -107,6 +107,11 @@ class PluginSinceUntilRangeVerifier {
       return
     }
 
+    untilBuild.magicNumberSingleComponent()?.let { magicNumber ->
+      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, magicNumber))
+      return
+    }
+
     if (untilBuildParsed.isJustASingleComponent() || untilBuild.isZeroOnlySingleComponent()) {
       if (untilBuildParsed.baselineVersion == MAGIC_BASELINE_NUMBER) {
         registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
@@ -116,6 +121,14 @@ class PluginSinceUntilRangeVerifier {
       registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
     } else if (untilBuildParsed.isZeroOnly()) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
+    }
+
+    if (!untilBuild.isSpecialConstant() && untilBuildParsed.hasMagicBaseline()) {
+      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
+      if (untilBuildParsed.productCode.isNotEmpty()) {
+        registerProblem(ProductCodePrefixInBuild(descriptorPath))
+      }
+      return
     }
 
     verifyIdeBuildComponentsRanges(
@@ -142,7 +155,7 @@ class PluginSinceUntilRangeVerifier {
     val baseline = untilBuild.baselineVersion
     if (baseline >= FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuildValue, untilBuild))
-    } else if (baseline == MAGIC_BASELINE_NUMBER) {
+    } else if (baseline >= MAGIC_BASELINE_NUMBER) {
       registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline))
     } else if (baseline >= SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND) {
       registerProblem(SuspiciousUntilBuild(untilBuildValue))
@@ -165,9 +178,24 @@ class PluginSinceUntilRangeVerifier {
     return !contains('.') && isNotBlank() && all { it == '0' }
   }
 
+  private fun String.magicNumberSingleComponent(): Int? {
+    if (contains('.') || isBlank()) {
+      return null
+    }
+    return toIntOrNull()?.takeIf { it >= MAGIC_BASELINE_NUMBER }
+  }
+
+  private fun String.isSpecialConstant(): Boolean {
+    return this == BUILD_NUMBER || this == SNAPSHOT
+  }
+
   private fun IdeVersion.isJustASingleComponent(): Boolean {
     val meaningfulComponents = components.filter { it != 0 }
     return meaningfulComponents.size == 1
+  }
+
+  private fun IdeVersion.hasMagicBaseline(): Boolean {
+    return baselineVersion in MAGIC_BASELINE_NUMBER until FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR
   }
 
   private fun IdeVersion.isZeroOnly(): Boolean {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -4,16 +4,7 @@ import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.utils.CompatibilityUtils
 import com.jetbrains.plugin.structure.intellij.beans.IdeaVersionBean
 import com.jetbrains.plugin.structure.intellij.beans.PluginBean
-import com.jetbrains.plugin.structure.intellij.problems.IdeBuildComponentsOutOfRange
-import com.jetbrains.plugin.structure.intellij.problems.InvalidSinceBuild
-import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuild
-import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithJustBranch
-import com.jetbrains.plugin.structure.intellij.problems.InvalidUntilBuildWithMagicNumber
-import com.jetbrains.plugin.structure.intellij.problems.NonexistentReleaseInUntilBuild
-import com.jetbrains.plugin.structure.intellij.problems.ProductCodePrefixInBuild
-import com.jetbrains.plugin.structure.intellij.problems.SinceBuildCannotContainWildcard
-import com.jetbrains.plugin.structure.intellij.problems.SinceBuildNotSpecified
-import com.jetbrains.plugin.structure.intellij.problems.SuspiciousUntilBuild
+import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.version.IdeVersion
 import com.jetbrains.plugin.structure.intellij.version.IdeVersionImpl
 
@@ -116,13 +107,15 @@ class PluginSinceUntilRangeVerifier {
       return
     }
 
-    if (untilBuildParsed.isJustASingleComponent()) {
+    if (untilBuildParsed.isJustASingleComponent() || untilBuild.isZeroOnlySingleComponent()) {
       if (untilBuildParsed.baselineVersion == MAGIC_BASELINE_NUMBER) {
         registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
         return // fast fail for magic number, no additional checks needed
       }
 
       registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
+    } else if (untilBuildParsed.isZeroOnly()) {
+      registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
     }
 
     verifyIdeBuildComponentsRanges(
@@ -168,8 +161,16 @@ class PluginSinceUntilRangeVerifier {
     }
   }
 
+  private fun String.isZeroOnlySingleComponent(): Boolean {
+    return !contains('.') && isNotBlank() && all { it == '0' }
+  }
+
   private fun IdeVersion.isJustASingleComponent(): Boolean {
     val meaningfulComponents = components.filter { it != 0 }
     return meaningfulComponents.size == 1
+  }
+
+  private fun IdeVersion.isZeroOnly(): Boolean {
+    return components.all { it == 0 }
   }
 }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/verifiers/PluginSinceUntilRangeVerifier.kt
@@ -107,11 +107,6 @@ class PluginSinceUntilRangeVerifier {
       return
     }
 
-    untilBuild.magicNumberSingleComponent()?.let { magicNumber ->
-      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, magicNumber))
-      return
-    }
-
     if (untilBuildParsed.isJustASingleComponent() || untilBuild.isZeroOnlySingleComponent()) {
       if (untilBuildParsed.baselineVersion == MAGIC_BASELINE_NUMBER) {
         registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
@@ -121,14 +116,6 @@ class PluginSinceUntilRangeVerifier {
       registerProblem(InvalidUntilBuildWithJustBranch(descriptorPath, untilBuild))
     } else if (untilBuildParsed.isZeroOnly()) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuild))
-    }
-
-    if (!untilBuild.isSpecialConstant() && untilBuildParsed.hasMagicBaseline()) {
-      registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuild, untilBuildParsed.baselineVersion))
-      if (untilBuildParsed.productCode.isNotEmpty()) {
-        registerProblem(ProductCodePrefixInBuild(descriptorPath))
-      }
-      return
     }
 
     verifyIdeBuildComponentsRanges(
@@ -155,7 +142,7 @@ class PluginSinceUntilRangeVerifier {
     val baseline = untilBuild.baselineVersion
     if (baseline >= FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR) {
       registerProblem(InvalidUntilBuild(descriptorPath, untilBuildValue, untilBuild))
-    } else if (baseline >= MAGIC_BASELINE_NUMBER) {
+    } else if (baseline == MAGIC_BASELINE_NUMBER) {
       registerProblem(InvalidUntilBuildWithMagicNumber(descriptorPath, untilBuildValue, baseline))
     } else if (baseline >= SUSPICIOUS_UNTIL_BASELINE_LOWER_BOUND) {
       registerProblem(SuspiciousUntilBuild(untilBuildValue))
@@ -178,24 +165,9 @@ class PluginSinceUntilRangeVerifier {
     return !contains('.') && isNotBlank() && all { it == '0' }
   }
 
-  private fun String.magicNumberSingleComponent(): Int? {
-    if (contains('.') || isBlank()) {
-      return null
-    }
-    return toIntOrNull()?.takeIf { it >= MAGIC_BASELINE_NUMBER }
-  }
-
-  private fun String.isSpecialConstant(): Boolean {
-    return this == BUILD_NUMBER || this == SNAPSHOT
-  }
-
   private fun IdeVersion.isJustASingleComponent(): Boolean {
     val meaningfulComponents = components.filter { it != 0 }
     return meaningfulComponents.size == 1
-  }
-
-  private fun IdeVersion.hasMagicBaseline(): Boolean {
-    return baselineVersion in MAGIC_BASELINE_NUMBER until FIRST_YEARLY_BASED_RELEASE_NUMBER_YEAR
   }
 
   private fun IdeVersion.isZeroOnly(): Boolean {

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/IdeVersionImpl.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/version/IdeVersionImpl.kt
@@ -57,7 +57,7 @@ class IdeVersionImpl(
     private const val STAR = "*"
     private const val SNAPSHOT = "SNAPSHOT"
     private const val FALLBACK_VERSION = "999.SNAPSHOT"
-    private const val SNAPSHOT_VALUE = Integer.MAX_VALUE
+    const val SNAPSHOT_VALUE = Integer.MAX_VALUE
 
     @Throws(IllegalArgumentException::class)
     fun fromString(version: String): IdeVersionImpl {

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -427,9 +427,9 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
   fun `since build less then until `() {
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
-        ideaVersion = """<idea-version since-build="131.1" until-build="120.1"/>"""
+        ideaVersion = """<idea-version since-build="131.1" until-build="130.1"/>"""
       },
-      listOf(SinceBuildGreaterThanUntilBuild("plugin.xml", IdeVersion.createIdeVersion("131.1"), IdeVersion.createIdeVersion("120.1")))
+      listOf(SinceBuildGreaterThanUntilBuild("plugin.xml", IdeVersion.createIdeVersion("131.1"), IdeVersion.createIdeVersion("130.1")))
     )
   }
 
@@ -819,7 +819,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         IdeBuildComponentsOutOfRange(
           ideVersion = IdeVersion.createIdeVersion("2018.*"),
           failedComponent = 2018,
-          range = 0..999,
+          range = 130..999,
           attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
           descriptorPath = "plugin.xml"
         )
@@ -900,7 +900,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         IdeBuildComponentsOutOfRange(
           ideVersion = IdeVersion.createIdeVersion("1000.1"),
           failedComponent = 1000,
-          range = 0..999,
+          range = 130..999,
           attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
           descriptorPath = "plugin.xml"
         ),
@@ -923,7 +923,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         IdeBuildComponentsOutOfRange(
           ideVersion = IdeVersion.createIdeVersion("1000"),
           failedComponent = 1000,
-          range = 0..999,
+          range = 130..999,
           attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
           descriptorPath = "plugin.xml"
         ),
@@ -990,7 +990,13 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         perfectXmlBuilder.modify {
           ideaVersion = """<idea-version since-build="231.1" until-build="$zeroOnlyUntilBuild"/>"""
         },
-        listOf(InvalidUntilBuildWithJustBranch(PLUGIN_XML, zeroOnlyUntilBuild))
+        listOf(IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion(zeroOnlyUntilBuild),
+          failedComponent = 0,
+          range = 130..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ))
       )
     }
   }
@@ -1002,7 +1008,13 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         perfectXmlBuilder.modify {
           ideaVersion = """<idea-version since-build="231.1" until-build="$zeroOnlyUntilBuild"/>"""
         },
-        listOf(InvalidUntilBuild(PLUGIN_XML, zeroOnlyUntilBuild))
+        listOf(IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion(zeroOnlyUntilBuild),
+          failedComponent = 0,
+          range = 130..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ))
       )
     }
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -891,47 +891,19 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
 
 
   @Test
-  fun `until baseline component out of range`() {
+  fun `until baseline component contains magic number`() {
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="231.1" until-build="1000.1"/>"""
       },
-      expectedProblems = listOf(
-        IdeBuildComponentsOutOfRange(
-          ideVersion = IdeVersion.createIdeVersion("1000.1"),
-          failedComponent = 1000,
-          range = 0..999,
-          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
-          descriptorPath = "plugin.xml"
-        ),
-        SuspiciousUntilBuild(
-          untilBuild = "1000.1",
-          additionalMessage = ""
-        )
-      )
+      expectedProblems = listOf(InvalidUntilBuildWithMagicNumber(PLUGIN_XML, "1000.1", 1000))
     )
 
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="231.1" until-build="1000"/>"""
       },
-      expectedProblems = listOf(
-        InvalidUntilBuildWithJustBranch(
-          descriptorPath = "plugin.xml",
-          untilBuild = "1000"
-        ),
-        IdeBuildComponentsOutOfRange(
-          ideVersion = IdeVersion.createIdeVersion("1000"),
-          failedComponent = 1000,
-          range = 0..999,
-          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
-          descriptorPath = "plugin.xml"
-        ),
-        SuspiciousUntilBuild(
-          untilBuild = "1000",
-          additionalMessage = ""
-        )
-      )
+      expectedProblems = listOf(InvalidUntilBuildWithMagicNumber(PLUGIN_XML, "1000", 1000))
     )
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -843,13 +843,170 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
   }
 
   @Test
+  fun `since baseline component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="129.1"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("129.1"),
+        failedComponent = 129,
+        range = 130..999,
+        attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="1000.1"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("1000.1"),
+        failedComponent = 1000,
+        range = 130..999,
+        attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+  }
+
+  @Test
+  fun `since build component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.100000"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("231.100000"),
+        failedComponent = 100000,
+        range = 0..99999,
+        attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+  }
+
+
+  @Test
+  fun `since third component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1.10000"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("231.1.10000"),
+        failedComponent = 10000,
+        range = 0..9999,
+        attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+  }
+
+
+  @Test
+  fun `until baseline component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="1000.1"/>"""
+      },
+      expectedProblems = listOf(
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion("1000.1"),
+          failedComponent = 1000,
+          range = 0..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ),
+        SuspiciousUntilBuild(
+          untilBuild = "1000.1",
+          additionalMessage = ""
+        )
+      )
+    )
+
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="1000"/>"""
+      },
+      expectedProblems = listOf(
+        InvalidUntilBuildWithJustBranch(
+          descriptorPath = "plugin.xml",
+          untilBuild = "1000"
+        ),
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion("1000"),
+          failedComponent = 1000,
+          range = 0..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ),
+        SuspiciousUntilBuild(
+          untilBuild = "1000",
+          additionalMessage = ""
+        )
+      )
+    )
+  }
+
+  @Test
+  fun `until build component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="231.100000"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("231.100000"),
+        failedComponent = 100000,
+        range = 0..99999,
+        attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+  }
+
+
+  @Test
+  fun `until third component out of range`() {
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="231.1.10000"/>"""
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("231.1.10000"),
+        failedComponent = 10000,
+        range = 0..9999,
+        attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
+    )
+  }
+
+  @Test
+  fun `until build special constant`() {
+    `test valid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="__BUILD_NUMBER__"/>"""
+      }
+    )
+
+    `test valid plugin xml`(
+      perfectXmlBuilder.modify {
+        ideaVersion = """<idea-version since-build="231.1" until-build="SNAPSHOT"/>"""
+      }
+    )
+  }
+
+
+  @Test
   fun `until build is a 999`() {
     val suspiciousUntilBuild = "999"
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version until-build="$suspiciousUntilBuild" since-build="241" />"""
       }, listOf(
-            InvalidUntilBuildWithMagicNumber(PLUGIN_XML, suspiciousUntilBuild, "999"),
+            InvalidUntilBuildWithMagicNumber(PLUGIN_XML, suspiciousUntilBuild, 999),
         )
     )
   }
@@ -915,7 +1072,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
   @Test
   fun `until build is a 999 dot star`() {
     val suspiciousUntilBuild = "999.*"
-    val magicNumber = "999"
+    val magicNumber = 999
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version until-build="$suspiciousUntilBuild" since-build="241" />"""

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -891,19 +891,47 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
 
 
   @Test
-  fun `until baseline component contains magic number`() {
+  fun `until baseline component out of range`() {
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="231.1" until-build="1000.1"/>"""
       },
-      expectedProblems = listOf(InvalidUntilBuildWithMagicNumber(PLUGIN_XML, "1000.1", 1000))
+      expectedProblems = listOf(
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion("1000.1"),
+          failedComponent = 1000,
+          range = 0..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ),
+        SuspiciousUntilBuild(
+          untilBuild = "1000.1",
+          additionalMessage = ""
+        )
+      )
     )
 
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="231.1" until-build="1000"/>"""
       },
-      expectedProblems = listOf(InvalidUntilBuildWithMagicNumber(PLUGIN_XML, "1000", 1000))
+      expectedProblems = listOf(
+        InvalidUntilBuildWithJustBranch(
+          descriptorPath = "plugin.xml",
+          untilBuild = "1000"
+        ),
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion("1000"),
+          failedComponent = 1000,
+          range = 0..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        ),
+        SuspiciousUntilBuild(
+          untilBuild = "1000",
+          additionalMessage = ""
+        )
+      )
     )
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -22,6 +22,7 @@ import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
 import com.jetbrains.plugin.structure.base.utils.normalizeNewLines
 import com.jetbrains.plugin.structure.base.utils.simpleName
+import com.jetbrains.plugin.structure.intellij.beans.IdeaVersionBean
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.problems.*
 import com.jetbrains.plugin.structure.intellij.verifiers.PRODUCT_ID_RESTRICTED_WORDS
@@ -493,9 +494,15 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="$wildcardSinceBuild"/>"""
       },
-      listOf(
-        InvalidSinceBuild("plugin.xml", wildcardSinceBuild),
-        SinceBuildCannotContainWildcard("plugin.xml", IdeVersion.createIdeVersion(wildcardSinceBuild))
+      expectedProblems = listOf(
+        SinceBuildCannotContainWildcard("plugin.xml", IdeVersion.createIdeVersion(wildcardSinceBuild)),
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion(wildcardSinceBuild),
+          failedComponent = 129,
+          range = 130..999,
+          attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        )
       )
     )
   }
@@ -808,13 +815,30 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="2018.1"/>"""
-      }, listOf(ErroneousSinceBuild("plugin.xml", IdeVersion.createIdeVersion("2018.1")))
+      },
+      expectedProblems = listOf(IdeBuildComponentsOutOfRange(
+        ideVersion = IdeVersion.createIdeVersion("2018.1"),
+        failedComponent = 2018,
+        range = 130..999,
+        attributeName = IdeaVersionBean.SINCE_BUILD_ATTRIBUTE_NAME,
+        descriptorPath = "plugin.xml"
+      ))
     )
 
     `test invalid plugin xml`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="171.1" until-build="2018.*"/>"""
-      }, listOf(InvalidUntilBuild("plugin.xml", "2018.*", IdeVersion.createIdeVersion("2018.*")))
+      },
+      expectedProblems = listOf(
+        InvalidUntilBuild("plugin.xml", "2018.*", IdeVersion.createIdeVersion("2018.*")),
+        IdeBuildComponentsOutOfRange(
+          ideVersion = IdeVersion.createIdeVersion("2018.*"),
+          failedComponent = 2018,
+          range = 0..999,
+          attributeName = IdeaVersionBean.UNTIL_BUILD_ATTRIBUTE_NAME,
+          descriptorPath = "plugin.xml"
+        )
+      )
     )
   }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -1,22 +1,7 @@
 package com.jetbrains.plugin.structure.mocks
 
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
-import com.jetbrains.plugin.structure.base.problems.ContainsNewlines
-import com.jetbrains.plugin.structure.base.problems.DescriptionNotStartingWithLatinCharacters
-import com.jetbrains.plugin.structure.base.problems.HttpLinkInDescription
-import com.jetbrains.plugin.structure.base.problems.IncorrectZipOrJarFile
-import com.jetbrains.plugin.structure.base.problems.InvalidPluginName
-import com.jetbrains.plugin.structure.base.problems.MultiplePluginDescriptors
-import com.jetbrains.plugin.structure.base.problems.NotBoolean
-import com.jetbrains.plugin.structure.base.problems.NotNumber
-import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
-import com.jetbrains.plugin.structure.base.problems.PluginProblem
-import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
-import com.jetbrains.plugin.structure.base.problems.PropertyWithDefaultValue
-import com.jetbrains.plugin.structure.base.problems.TooLongPropertyValue
-import com.jetbrains.plugin.structure.base.problems.UnableToExtractZip
-import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
-import com.jetbrains.plugin.structure.base.problems.VendorCannotBeEmpty
+import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
@@ -996,6 +981,30 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
         ideaVersion = """<idea-version since-build="231.1" until-build="SNAPSHOT"/>"""
       }
     )
+  }
+
+  @Test
+  fun `until build zero-only single-component values are invalid`() {
+    listOf("0", "000").forEach { zeroOnlyUntilBuild ->
+      `test invalid plugin xml`(
+        perfectXmlBuilder.modify {
+          ideaVersion = """<idea-version since-build="231.1" until-build="$zeroOnlyUntilBuild"/>"""
+        },
+        listOf(InvalidUntilBuildWithJustBranch(PLUGIN_XML, zeroOnlyUntilBuild))
+      )
+    }
+  }
+
+  @Test
+  fun `until build zero-only multi-component values are invalid`() {
+    listOf("0.0", "0.0.0").forEach { zeroOnlyUntilBuild ->
+      `test invalid plugin xml`(
+        perfectXmlBuilder.modify {
+          ideaVersion = """<idea-version since-build="231.1" until-build="$zeroOnlyUntilBuild"/>"""
+        },
+        listOf(InvalidUntilBuild(PLUGIN_XML, zeroOnlyUntilBuild))
+      )
+    }
   }
 
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginV2Test.kt
@@ -109,7 +109,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
 
     assertEquals("Plugin description must be at least 40 characters long", plugin.description)
     assertEquals(IdeVersion.createIdeVersion("141.1009.5"), plugin.sinceBuild)
-    assertEquals(IdeVersion.createIdeVersion("141.9999999"), plugin.untilBuild)
+    assertEquals(IdeVersion.createIdeVersion("141.99999"), plugin.untilBuild)
 
     assertNull(plugin.changeNotes)
     assertFalse(plugin.useIdeClassLoader)
@@ -118,7 +118,7 @@ class MockPluginsV2Test(fileSystemType: FileSystemType) : IdePluginManagerTest(f
   }
 
   private fun checkIdeCompatibility(plugin: IdePlugin) {
-    //  <idea-version since-build="141.1009.5" until-build="141.9999999"/>
+    //  <idea-version since-build="141.1009.5" until-build="141.99999"/>
     assertTrue(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("141.1009.5")))
     assertTrue(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("141.99999")))
     assertFalse(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("142.0")))

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/MockPluginsTest.kt
@@ -662,7 +662,7 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
 
     assertEquals("Plugin description must be at least 40 characters long", plugin.description)
     assertEquals(IdeVersion.createIdeVersion("141.1009.5"), plugin.sinceBuild)
-    assertEquals(IdeVersion.createIdeVersion("141.9999999"), plugin.untilBuild)
+    assertEquals(IdeVersion.createIdeVersion("141.99999"), plugin.untilBuild)
 
     /*
     <change-notes> element will be included only if the plugin is NOT directory-based.
@@ -694,7 +694,7 @@ class MockPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(fil
   }
 
   private fun checkIdeCompatibility(plugin: IdePlugin) {
-    //  <idea-version since-build="141.1009.5" until-build="141.9999999"/>
+    //  <idea-version since-build="141.1009.5" until-build="141.99999"/>
     assertTrue(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("141.1009.5")))
     assertTrue(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("141.99999")))
     assertFalse(plugin.isCompatibleWithIde(IdeVersion.createIdeVersion("142.0")))

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin-v2/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <version>231.7515.9</version>
     <vendor email="vendor_email" url="https://www.jetbrains.com">JetBrains s.r.o.</vendor>
 
-    <idea-version since-build="141.1009.5" until-build="141.9999999"/>
+    <idea-version since-build="141.1009.5" until-build="141.99999"/>
 
     <xi:include href="../xiIncludeDir/ultimate-plugin.xml" xpointer="xpointer(/idea-plugin/*)">
         <xi:fallback/>

--- a/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
+++ b/intellij-plugin-structure/tests/src/test/resources/mock-plugin/META-INF/plugin.xml
@@ -7,7 +7,7 @@
     <version>1.0.0-beta-1038-IJ141-17</version>
     <vendor email="vendor_email" url="https://www.jetbrains.com">JetBrains s.r.o.</vendor>
 
-    <idea-version since-build="141.1009.5" until-build="141.9999999"/>
+    <idea-version since-build="141.1009.5" until-build="141.99999"/>
 
     <product-descriptor code="PABC" release-date="20180118" release-version="10" eap="true" optional="true"/>
 


### PR DESCRIPTION
JetBrains Marketplace converts the update's since / until values to long using `CompatibilityUtils` to simplify search. This means we need to validate that each meaningful component (the first three components of the IDE version) is within the specified bounds.

See [MP-7678](https://youtrack.jetbrains.com/issue/MP-7678).