### PR TITLE
Treat wildcard `since-build` as an unacceptable warning

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/problems/InvalidDescriptorErrors.kt
@@ -145,7 +145,7 @@ class SinceBuildCannotContainWildcard(
   detailedMessage = "The <since-build> parameter ($sinceBuild) must not contain a wildcard (dot-star suffix) '.*')."
 ) {
   override val level
-    get() = Level.WARNING
+    get() = Level.UNACCEPTABLE_WARNING
 
   override val hint = ProblemSolutionHint(
     example = "<since-build>241</vendor>",

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -450,7 +450,7 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
   @Test
   fun `since build contains wildcard `() {
     val specifiedVersion = "131.*"
-    `test plugin xml warnings`(
+    `test plugin xml unacceptable warnings`(
       perfectXmlBuilder.modify {
         ideaVersion = """<idea-version since-build="$specifiedVersion" until-build="233.*"/>"""
       },


### PR DESCRIPTION
Some plugin authors on Marketplace expect since-builds like `233.*` work as "in all 233.* IDEs" but it is incorrect. We want to detect and prohibit such until-builds.

This PR changes `SinceBuildCannotContainWildcard` problem's level from `WARNING` to `UNACCEPTABLE_WARNING`. Not `ERROR` because we want to still be able to parse the plugin and get `PluginCreationSuccess`.

* See [MP-6542](https://youtrack.jetbrains.com/issue/MP-6542).
* See [IntelliJ Platform SDK Docs - Build Number Ranges](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#valid-values)