### PR TITLE
Kotlin metadata bridge detection

### DIFF
--- a/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
+++ b/intellij-plugin-structure/structure-classes/src/main/java/com/jetbrains/plugin/structure/classes/utils/KtClassResolver.kt
@@ -27,8 +27,8 @@ class KtClassResolver {
   }
 
   private val ClassNode.ktClassNode: KtClassNode?
-    get() = findMetadataAnnotation(this)
-      ?.let { annotation -> getKtClassNode(this, annotation) }
+    get() = findMetadataAnnotation(this)?.let { annotation ->
+      getKtClassNode(this, annotation) }
 
   private fun getKtClassNode(classNode: ClassNode, metadataAnnotation: Metadata): KtClassNode? {
     return readMetadata(classNode, metadataAnnotation)?.let { metadata ->

--- a/intellij-plugin-verifier/verifier-core/build.gradle.kts
+++ b/intellij-plugin-verifier/verifier-core/build.gradle.kts
@@ -3,4 +3,5 @@ dependencies {
   implementation("org.jetbrains.intellij.plugins:structure-classes:$intellijStructureVersion")
 
   implementation(sharedLibs.caffeine)
+  implementation(libs.kotlinx.metadata)
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -8,9 +8,10 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.jetbrains.pluginverifier.results.location.MethodLocation
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
-import org.objectweb.asm.Opcodes
-import org.objectweb.asm.tree.AbstractInsnNode
-import org.objectweb.asm.tree.MethodInsnNode
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata
+import kotlinx.metadata.jvm.signature
+import org.objectweb.asm.tree.AnnotationNode
 
 object KotlinMethods {
   private const val CAPACITY = 100L
@@ -22,134 +23,89 @@ object KotlinMethods {
   /**
    * Identify a Kotlin default method.
    *
-   * A kotlin default method is a method that has a default implementation, but kotlin compiles
-   * in the inheritor an override that calls the default implementation (inner) class known as
-   * `DefaultImpls`.
+   * A kotlin default method is a method that has a default implementation, but Kotlin still emits
+   * a concrete method body for it in every implementing class that doesn't override it -- the JVM
+   * requires *some* body to exist, so the compiler synthesizes a bridge that forwards to the
+   * interface's real implementation. That bridge's bytecode references whatever types the default
+   * method's signature uses, so a naive bytecode scan would misattribute those references to the
+   * (non-existent) developer code in the implementing class.
    *
-   * Ignoring labels, line numbers, and kotlin intrinsics (to check nullness), there's only a
-   * handful of interesting bytecode that invoke the static method in `{TheInterfaceType}$DefaultImpls`
-   * loading first `this`, then loading parameters if any.
+   * This used to be detected by pattern-matching the bridge's bytecode shape, but that shape is a
+   * Kotlin-compiler implementation detail that has changed across versions (e.g. Kotlin 2.x's
+   * `-Xjvm-default=all-compatibility` switched from an `INVOKESTATIC` call into a `$DefaultImpls`
+   * inner class to an `INVOKESPECIAL` call directly on the interface's real default method) --
+   * and, worse, a developer-authored trivial override (`override fun foo() = super.foo()`) can
+   * compile to the exact same instructions as the synthesized bridge, so no bytecode shape can
+   * distinguish the two cases in general.
    *
-   * E.g. with
-   *
-   * ```
-   * // access flags 0x1
-   * public internalArgsReturningInternal(Linternal/defaultMethod/AnInternalType;Ljava/lang/String;)Linternal/defaultMethod/AnInternalType;
-   *    L0
-   *     ALOAD 1
-   *     LDC "anInternalType"
-   *     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
-   *     ALOAD 2
-   *     LDC "s"
-   *     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
-   *    L1
-   *     LINENUMBER 5 L1
-   *     ALOAD 0
-   *     ALOAD 1
-   *     ALOAD 2
-   *     INVOKESTATIC internal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI$DefaultImpls.internalArgsReturningInternal (Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI;Linternal/defaultMethod/AnInternalType;Ljava/lang/String;)Linternal/defaultMethod/AnInternalType;
-   *     ARETURN
-   *    L2
-   *     LOCALVARIABLE this Linternal/defaultMethod/InterfaceWithDefaultMethodUsingInternalAPI; L0 L2 0
-   *     LOCALVARIABLE anInternalType Linternal/defaultMethod/AnInternalType; L0 L2 1
-   *     LOCALVARIABLE s Ljava/lang/String; L0 L2 2
-   *     MAXSTACK = 3
-   *     MAXLOCALS = 3
-   * ```
-   *
-   * @see [`JvmDefault` annotation](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/src/kotlin/jvm/JvmDefault.kt)
+   * Instead, this reads the class's own `@kotlin.Metadata` annotation (the compiler's structured
+   * record of what the *source* actually declared, via `kotlinx-metadata-jvm`) and checks whether
+   * this method is present in the class's own declared functions. If it isn't, the compiler must
+   * have synthesized it -- regardless of which lowering strategy produced its bytecode.
    */
   fun Method.isKotlinDefaultMethod(): Boolean {
     val method: Method = this
-    return cache.get(method.location) { method.isKotlinMethodInvokingDefaultImpls() }
+    return cache.get(method.location) { method.isCompilerSynthesizedInterfaceBridge() }
   }
 
-  private fun Method.isKotlinMethodInvokingDefaultImpls(): Boolean {
-    // If this method doesn't have any bytecode, it will be skipped
-    val instructions = instructions
+  private fun Method.isCompilerSynthesizedInterfaceBridge(): Boolean {
+    // If this method doesn't have any bytecode (e.g. an abstract method), it can't be a bridge.
     if (instructions.isEmpty()) {
       return false
     }
 
-    // filter non-Kotlin classes
-    if (containingClassFile.annotations.none { it.desc == "Lkotlin/Metadata;" }) {
-      return false
+    val metadataAnnotation = containingClassFile.annotations
+      .firstOrNull { it.desc == "Lkotlin/Metadata;" }
+      ?: return false // filter non-Kotlin classes
+
+    val kmClass = metadataAnnotation.toKmClassOrNull() ?: return false
+
+    val isDeclaredByThisClass = kmClass.functions.any { function ->
+      val signature = function.signature
+      signature != null && signature.name == name && signature.descriptor == descriptor
     }
 
-    // Skip non-opcodes, and Kotlin intrinsics on arguments
-    val candidateOpcodes = mutableListOf<AbstractInsnNode>()
-    val instructionCount = instructions.size
-
-    var i = 0
-    while (i < instructionCount) {
-      val instruction = instructions[i]
-      if (instruction.opcode == -1) {
-        i++
-        continue
-      }
-      if (instruction.isKotlinIntrinsic()) {
-        i += 3 // Skip ALOAD, LDC, and INVOKESTATIC
-        continue
-      }
-      candidateOpcodes += instruction
-      i++
-    }
-
-    val expectedOpcodes = (
-      3 // ALOAD this + INVOKESTATIC + (RETURN or ARETURN)
-        + methodParameters.size // ALOAD for each parameter
-      )
-
-    if (candidateOpcodes.size != expectedOpcodes
-      || candidateOpcodes[0].opcode != Opcodes.ALOAD // ALOAD `this`
-      || candidateOpcodes.slice(1..methodParameters.size).any { it.opcode != Opcodes.ALOAD } // parameters
-      || candidateOpcodes[candidateOpcodes.lastIndex - 1].opcode != Opcodes.INVOKESTATIC
-      || candidateOpcodes.last().opcode !in intArrayOf(
-        Opcodes.RETURN,
-        Opcodes.ARETURN,
-        Opcodes.DRETURN,
-        Opcodes.FRETURN,
-        Opcodes.IRETURN,
-        Opcodes.LRETURN
-      )
-    ) {
-      return false
-    }
-
-    val methodInsnNode = candidateOpcodes[candidateOpcodes.lastIndex - 1] as MethodInsnNode
-    if (methodInsnNode.name != name || !methodInsnNode.owner.endsWith("\$DefaultImpls")) {
-      return false
-    }
-
-    val actualKotlinOwner = methodInsnNode.owner.substringBeforeLast("\$DefaultImpls")
-
-    // Walking the whole class hierarchy is not necessary because
-    // these methods always delegate to the immediate superinterface. E.g.
-    // ```
-    // interface A {
-    //    fun foo() {}
-    // }
-    //
-    // interface B : A
-    //
-    // class C : B
-    // ```
-    // `C.foo` will have a call to `B$DefaultImpls.foo`.
-    val isAParent = containingClassFile.interfaces.any {
-      it == actualKotlinOwner
-    }
-    if (!isAParent) {
-      return false
-    }
-
-    // The method is a kotlin default method
-    return true
+    // Kotlin's metadata only lists functions the source actually declared in this class. If this
+    // method isn't among them, it wasn't written by a developer -- the compiler synthesized it,
+    // most commonly as a compatibility bridge for an inherited-but-unoverridden default method.
+    return !isDeclaredByThisClass
   }
 
-  private fun AbstractInsnNode.isKotlinIntrinsic(): Boolean {
-    return opcode == Opcodes.ALOAD
-      && next?.opcode == Opcodes.LDC
-      && next?.next?.opcode == Opcodes.INVOKESTATIC
-      && (next?.next as MethodInsnNode).owner == "kotlin/jvm/internal/Intrinsics"
+  private fun AnnotationNode.toKmClassOrNull(): kotlinx.metadata.KmClass? {
+    val metadata = toMetadata()
+    if (metadata.metadataVersion.isEmpty()) {
+      return null
+    }
+    return try {
+      (KotlinClassMetadata.readLenient(metadata) as? KotlinClassMetadata.Class)?.kmClass
+    } catch (e: IllegalArgumentException) {
+      null
+    }
+  }
+
+  private fun AnnotationNode.toMetadata() = Metadata(
+    kind = int("k"),
+    metadataVersion = ints("mv"),
+    data1 = strings("d1"),
+    data2 = strings("d2"))
+
+  private fun AnnotationNode.int(key: String) = get<Int>(key)
+  private fun AnnotationNode.ints(key: String) = get<List<Int>?>(key)?.toIntArray()
+  private fun AnnotationNode.strings(key: String) = get<List<String>?>(key)?.toTypedArray()
+
+  private inline fun <reified T> AnnotationNode.get(key: String): T? {
+    return getAnnotationValue(key)?.let { value ->
+      if (value is T) value else null
+    }
+  }
+
+  private fun AnnotationNode.getAnnotationValue(key: String): Any? {
+    val values = values ?: return null
+    for (i in 0 until values.size step 2) {
+      if (values[i] == key) {
+        return values[i + 1]
+      }
+    }
+    return null
   }
 }

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -8,13 +8,20 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.jetbrains.pluginverifier.results.location.MethodLocation
 import com.jetbrains.pluginverifier.verifiers.resolution.Method
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.jvm.KotlinClassMetadata
 import kotlinx.metadata.jvm.Metadata
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
+import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.MethodInsnNode
 
 object KotlinMethods {
   private const val CAPACITY = 100L
+
+  private const val DEFAULT_IMPLS_SUFFIX = "\$DefaultImpls"
 
   private val cache: Cache<MethodLocation, Boolean> = Caffeine.newBuilder()
     .maximumSize(CAPACITY)
@@ -38,10 +45,21 @@ object KotlinMethods {
    * compile to the exact same instructions as the synthesized bridge, so no bytecode shape can
    * distinguish the two cases in general.
    *
-   * Instead, this reads the class's own `@kotlin.Metadata` annotation (the compiler's structured
-   * record of what the *source* actually declared, via `kotlinx-metadata-jvm`) and checks whether
-   * this method is present in the class's own declared functions. If it isn't, the compiler must
-   * have synthesized it -- regardless of which lowering strategy produced its bytecode.
+   * Neither signal is sufficient on its own, so this requires **both** to agree:
+   *
+   * 1. The class's own `@kotlin.Metadata` annotation (the compiler's structured record of what the
+   *    *source* actually declared, via `kotlinx-metadata-jvm`) does not list this method. This is
+   *    what rules out a developer-authored trivial override, which no bytecode shape can exclude.
+   * 2. The method's body actually forwards to an interface's default implementation. This is what
+   *    positively establishes that the method *is* a bridge, rather than merely being absent from
+   *    the metadata.
+   *
+   * Requiring (2) matters because "absent from metadata" covers far more than bridges: metadata
+   * tracks constructors and property accessors in [KmClass.constructors] and [KmClass.properties]
+   * rather than [KmClass.functions], and synthetic `name$default` overloads are not listed at all.
+   * Classifying any of those as a bridge would silently disable the argument-type, return-type and
+   * local-variable checks that [MethodArgumentTypesVerifier], [MethodReturnTypeVerifier] and
+   * [MethodLocalVarsVerifier] skip for default methods.
    */
   fun Method.isKotlinDefaultMethod(): Boolean {
     val method: Method = this
@@ -54,23 +72,60 @@ object KotlinMethods {
       return false
     }
 
+    // A constructor or a static initializer is never an interface default method.
+    if (isConstructor || isClassInitializer) {
+      return false
+    }
+
     val metadataAnnotation = containingClassFile.annotations
       .firstOrNull { it.desc == "Lkotlin/Metadata;" }
       ?: return false // filter non-Kotlin classes
 
     val kmClass = metadataAnnotation.toKmClassOrNull() ?: return false
 
-    val isDeclaredByThisClass = kmClass.functions
-      .mapNotNull { it.signature }
-      .any { it.name == name && it.descriptor == descriptor }
-
-    // Kotlin's metadata only lists functions the source actually declared in this class. If this
-    // method isn't among them, it wasn't written by a developer -- the compiler synthesized it,
-    // most commonly as a compatibility bridge for an inherited-but-unoverridden default method.
-    return !isDeclaredByThisClass
+    return !isDeclaredBy(kmClass) && forwardsToInterfaceDefaultImplementation()
   }
 
-  private fun AnnotationNode.toKmClassOrNull(): kotlinx.metadata.KmClass? {
+  /**
+   * Whether the Kotlin source of this class declared this method itself, in any member position:
+   * an ordinary function, a constructor, or a property accessor.
+   */
+  private fun Method.isDeclaredBy(kmClass: KmClass): Boolean {
+    val declaredSignatures = kmClass.functions.mapNotNull { it.signature } +
+      kmClass.constructors.mapNotNull { it.signature } +
+      kmClass.properties.flatMap { listOfNotNull(it.getterSignature, it.setterSignature) }
+
+    return declaredSignatures.any { it.name == name && it.descriptor == descriptor }
+  }
+
+  /**
+   * Whether this method's body hands the call off to an interface's own default implementation of
+   * the same method, which is what every Kotlin default-method lowering emits:
+   *
+   * * legacy and `-Xjvm-default=all-compatibility` lowering call the static holder,
+   *   `INVOKESTATIC SomeInterface$DefaultImpls.method(...)`;
+   * * newer compatibility lowering calls the interface method directly,
+   *   `INVOKESPECIAL SomeInterface.method(...)`.
+   *
+   * Forwarding to anything else -- a method on this same class (`name$default` overloads) or an
+   * `INVOKEINTERFACE` call through a delegate (`class Foo : Bar by delegate`) -- is not a default
+   * method bridge.
+   */
+  private fun Method.forwardsToInterfaceDefaultImplementation(): Boolean =
+    instructions.any { it is MethodInsnNode && it.forwardsTo(name) }
+
+  private fun MethodInsnNode.forwardsTo(bridgedMethodName: String): Boolean {
+    if (name != bridgedMethodName) {
+      return false
+    }
+    return when (opcode) {
+      Opcodes.INVOKESTATIC -> owner.endsWith(DEFAULT_IMPLS_SUFFIX)
+      Opcodes.INVOKESPECIAL -> itf
+      else -> false
+    }
+  }
+
+  private fun AnnotationNode.toKmClassOrNull(): KmClass? {
     val metadata = toMetadata()
     if (metadata.metadataVersion.isEmpty()) {
       return null

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -60,10 +60,9 @@ object KotlinMethods {
 
     val kmClass = metadataAnnotation.toKmClassOrNull() ?: return false
 
-    val isDeclaredByThisClass = kmClass.functions.any { function ->
-      val signature = function.signature
-      signature != null && signature.name == name && signature.descriptor == descriptor
-    }
+    val isDeclaredByThisClass = kmClass.functions
+      .mapNotNull { it.signature }
+      .any { it.name == name && it.descriptor == descriptor }
 
     // Kotlin's metadata only lists functions the source actually declared in this class. If this
     // method isn't among them, it wasn't written by a developer -- the compiler synthesized it,

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -48,7 +48,7 @@ object KotlinMethods {
     return cache.get(method.location) { method.isCompilerSynthesizedInterfaceBridge() }
   }
 
-  private fun Method.isCompilerSynthesizedInterfaceBridge(): Boolean {
+  internal fun Method.isCompilerSynthesizedInterfaceBridge(): Boolean {
     // If this method doesn't have any bytecode (e.g. an abstract method), it can't be a bridge.
     if (instructions.isEmpty()) {
       return false

--- a/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
+++ b/intellij-plugin-verifier/verifier-core/src/main/java/com/jetbrains/pluginverifier/verifiers/method/KotlinMethods.kt
@@ -19,7 +19,12 @@ import org.objectweb.asm.tree.AnnotationNode
 import org.objectweb.asm.tree.MethodInsnNode
 
 object KotlinMethods {
-  private const val CAPACITY = 100L
+  /**
+   * Sized to survive concurrent verification: [isKotlinDefaultMethod] is asked about every method
+   * by three verifiers, on as many threads as `intellij.plugin.verifier.concurrency.level` allows,
+   * so a cache of a hundred booleans evicts an entry before its second reader arrives.
+   */
+  private const val CAPACITY = 16_384L
 
   private const val DEFAULT_IMPLS_SUFFIX = "\$DefaultImpls"
 
@@ -77,13 +82,22 @@ object KotlinMethods {
       return false
     }
 
+    // Evaluate the bytecode signal first: it is a single instruction scan, and it is false for
+    // almost every method, whereas reading `@kotlin.Metadata` below deserializes the *whole*
+    // class's metadata. That deserialization costs ~16 us per call, and every method of every
+    // Kotlin class reaches this code (three verifiers ask about each method), so ordering the
+    // cheap test first keeps metadata parsing to the handful of genuine bridge candidates.
+    if (!forwardsToInterfaceDefaultImplementation()) {
+      return false
+    }
+
     val metadataAnnotation = containingClassFile.annotations
       .firstOrNull { it.desc == "Lkotlin/Metadata;" }
       ?: return false // filter non-Kotlin classes
 
     val kmClass = metadataAnnotation.toKmClassOrNull() ?: return false
 
-    return !isDeclaredBy(kmClass) && forwardsToInterfaceDefaultImplementation()
+    return !isDeclaredBy(kmClass)
   }
 
   /**

--- a/intellij-plugin-verifier/verifier-core/src/test/kotlin/com/jetbrains/pluginverifier/verifiers/method/KotlinMethodsNonFunctionMembersTest.kt
+++ b/intellij-plugin-verifier/verifier-core/src/test/kotlin/com/jetbrains/pluginverifier/verifiers/method/KotlinMethodsNonFunctionMembersTest.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.method
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isCompilerSynthesizedInterfaceBridge
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmConstructor
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmType
+import kotlinx.metadata.jvm.JvmMetadataVersion
+import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.setterSignature
+import kotlinx.metadata.jvm.signature
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.InsnNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.VarInsnNode
+
+/**
+ * Guards the "not a compiler-synthesized interface bridge" side of [KotlinMethods].
+ *
+ * `@kotlin.Metadata` lists a class's source-declared members in several separate collections:
+ * ordinary functions in [KmClass.functions], constructors in [KmClass.constructors] and property
+ * accessors in [KmClass.properties]. Treating "absent from [KmClass.functions]" as proof that the
+ * compiler synthesized a method therefore misclassifies constructors, property accessors, and
+ * synthetic default-argument overloads.
+ *
+ * Misclassification is not cosmetic: [MethodArgumentTypesVerifier], [MethodReturnTypeVerifier] and
+ * [MethodLocalVarsVerifier] all skip a method that is reported as a bridge, so a false positive
+ * silently drops those API usage checks.
+ */
+class KotlinMethodsNonFunctionMembersTest {
+
+  @Test
+  fun `source declared constructor is not a synthesized interface bridge`() {
+    val descriptor = "(L$INTERNAL_TYPE;)V"
+    val method = classFileWithMetadata(
+      methodNode = constructor(descriptor),
+      declaredConstructors = listOf(JvmMethodSignature("<init>", descriptor))
+    ).methods.single()
+
+    assertFalse(
+      "An ordinary Kotlin constructor must not be reported as a compiler-synthesized bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  @Test
+  fun `source declared property getter is not a synthesized interface bridge`() {
+    val method = classFileWithMetadata(
+      methodNode = propertyGetter(),
+      declaredProperties = listOf(PROPERTY_NAME)
+    ).methods.single()
+
+    assertFalse(
+      "An ordinary Kotlin property getter must not be reported as a compiler-synthesized bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  @Test
+  fun `source declared property setter is not a synthesized interface bridge`() {
+    val method = classFileWithMetadata(
+      methodNode = propertySetter(),
+      declaredProperties = listOf(PROPERTY_NAME)
+    ).methods.single()
+
+    assertFalse(
+      "An ordinary Kotlin property setter must not be reported as a compiler-synthesized bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  /**
+   * A function with default parameter values gets a synthetic `name$default` companion method that
+   * metadata does not list. It is compiler-generated, but it is not an interface-default bridge: it
+   * forwards to the real function on the *same* class, so its signature types still belong to code
+   * the developer wrote and must keep being verified.
+   */
+  @Test
+  fun `synthetic default arguments overload is not a synthesized interface bridge`() {
+    val method = classFileWithMetadata(
+      methodNode = defaultArgumentsOverload(),
+      declaredFunctions = listOf(JvmMethodSignature(FUNCTION_NAME, "(L$INTERNAL_TYPE;)V"))
+    ).methods.single()
+
+    assertFalse(
+      "A synthetic \$default overload must not be reported as a compiler-synthesized bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  /**
+   * The core of the fix: being absent from metadata is not on its own evidence of an interface
+   * bridge. Without a body that forwards to an interface's default implementation, a method must not
+   * be classified as one.
+   */
+  @Test
+  fun `method absent from metadata that forwards nowhere is not a synthesized interface bridge`() {
+    val method = classFileWithMetadata(
+      methodNode = nonForwardingMethod(),
+      declaredFunctions = emptyList()
+    ).methods.single()
+
+    assertFalse(
+      "A method that does not forward to an interface default must not be reported as a bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  /**
+   * Kotlin interface delegation (`class C : I by delegate`) also synthesizes forwarding methods, but
+   * they forward through the delegate with `invokeinterface` rather than to an interface's own
+   * default implementation, so they are not default-method bridges.
+   */
+  @Test
+  fun `interface delegation forwarder is not a synthesized interface bridge`() {
+    val method = classFileWithMetadata(
+      methodNode = delegatingForwarder(),
+      declaredFunctions = emptyList(),
+      interfaces = listOf(TEST_INTERFACE_NAME)
+    ).methods.single()
+
+    assertFalse(
+      "A delegation forwarder must not be reported as a compiler-synthesized bridge",
+      method.isCompilerSynthesizedInterfaceBridge()
+    )
+  }
+
+  private fun constructor(descriptor: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, "<init>", descriptor, null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(MethodInsnNode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false))
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun propertyGetter(): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, GETTER_NAME, "()L$INTERNAL_TYPE;", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(InsnNode(Opcodes.ARETURN))
+    }
+
+  private fun propertySetter(): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, SETTER_NAME, "(L$INTERNAL_TYPE;)V", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun defaultArgumentsOverload(): MethodNode =
+    MethodNode(
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC or Opcodes.ACC_SYNTHETIC,
+      "$FUNCTION_NAME\$default",
+      "(L$TEST_CLASS_NAME;L$INTERNAL_TYPE;ILjava/lang/Object;)V",
+      null,
+      null
+    ).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+      instructions.add(
+        MethodInsnNode(Opcodes.INVOKEVIRTUAL, TEST_CLASS_NAME, FUNCTION_NAME, "(L$INTERNAL_TYPE;)V", false)
+      )
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun nonForwardingMethod(): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, FUNCTION_NAME, "(L$INTERNAL_TYPE;)V", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+      instructions.add(InsnNode(Opcodes.POP))
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun delegatingForwarder(): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, FUNCTION_NAME, "(L$INTERNAL_TYPE;)V", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 1))
+      instructions.add(
+        MethodInsnNode(Opcodes.INVOKEINTERFACE, TEST_INTERFACE_NAME, FUNCTION_NAME, "(L$INTERNAL_TYPE;)V", true)
+      )
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  private fun classFileWithMetadata(
+    methodNode: MethodNode,
+    declaredFunctions: List<JvmMethodSignature> = emptyList(),
+    declaredConstructors: List<JvmMethodSignature> = emptyList(),
+    declaredProperties: List<String> = emptyList(),
+    interfaces: List<String> = emptyList()
+  ): ClassFileAsm {
+    val classNode = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC or Opcodes.ACC_SUPER
+      name = TEST_CLASS_NAME
+      superName = "java/lang/Object"
+      this.interfaces = interfaces.toMutableList()
+      methods = mutableListOf(methodNode)
+      visibleAnnotations = mutableListOf(
+        kotlinMetadata(declaredFunctions, declaredConstructors, declaredProperties)
+      )
+    }
+    return ClassFileAsm(classNode, origin)
+  }
+
+  private fun kotlinMetadata(
+    declaredFunctions: List<JvmMethodSignature>,
+    declaredConstructors: List<JvmMethodSignature>,
+    declaredProperties: List<String>
+  ): AnnotationNode {
+    val metadata = KotlinClassMetadata.Class(
+      KmClass().apply {
+        name = TEST_CLASS_NAME
+        functions += declaredFunctions.map { signature ->
+          KmFunction(signature.name).apply {
+            this.signature = signature
+            returnType = KmType().apply { classifier = KmClassifier.Class("kotlin/Unit") }
+          }
+        }
+        constructors += declaredConstructors.map { signature ->
+          KmConstructor().apply { this.signature = signature }
+        }
+        properties += declaredProperties.map { propertyName ->
+          KmProperty(propertyName).apply {
+            returnType = KmType().apply { classifier = KmClassifier.Class(INTERNAL_TYPE) }
+            getterSignature = JvmMethodSignature(GETTER_NAME, "()L$INTERNAL_TYPE;")
+            setterSignature = JvmMethodSignature(SETTER_NAME, "(L$INTERNAL_TYPE;)V")
+          }
+        }
+      },
+      JvmMetadataVersion.LATEST_STABLE_SUPPORTED,
+      0
+    ).write()
+
+    return AnnotationNode("Lkotlin/Metadata;").apply {
+      values = mutableListOf(
+        "k", metadata.kind,
+        "mv", metadata.metadataVersion.toList(),
+        "d1", metadata.data1.toList(),
+        "d2", metadata.data2.toList()
+      )
+    }
+  }
+
+  private companion object {
+    const val TEST_CLASS_NAME = "com/jetbrains/pluginverifier/tests/KotlinPluginService"
+    const val TEST_INTERFACE_NAME = "com/jetbrains/pluginverifier/tests/KotlinDefaultInterface"
+    const val INTERNAL_TYPE = "com/intellij/internal/SomeInternalPlatformType"
+
+    const val FUNCTION_NAME = "useInternalType"
+    const val PROPERTY_NAME = "thing"
+    const val GETTER_NAME = "getThing"
+    const val SETTER_NAME = "setThing"
+
+    val origin = object : FileOrigin {
+      override val parent = null
+    }
+  }
+}

--- a/intellij-plugin-verifier/verifier-core/src/test/kotlin/com/jetbrains/pluginverifier/verifiers/method/KotlinMethodsTest.kt
+++ b/intellij-plugin-verifier/verifier-core/src/test/kotlin/com/jetbrains/pluginverifier/verifiers/method/KotlinMethodsTest.kt
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2000-2026 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+ */
+
+package com.jetbrains.pluginverifier.verifiers.method
+
+import com.jetbrains.plugin.structure.classes.resolvers.FileOrigin
+import com.jetbrains.pluginverifier.verifiers.method.KotlinMethods.isCompilerSynthesizedInterfaceBridge
+import com.jetbrains.pluginverifier.verifiers.resolution.ClassFileAsm
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.KmType
+import kotlinx.metadata.jvm.JvmMetadataVersion
+import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.signature
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.*
+
+class KotlinMethodsTest {
+
+  @Test
+  fun `Kotlin 1_3 default behavior - compiler synthesized DefaultImpls bridge is detected`() {
+    val method = classFileWithMetadata(
+      methodNode = legacyDefaultImplsBridge("defaultMethod"),
+      declaredFunctions = emptyList()
+    ).methods.single()
+
+    assertTrue(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `Kotlin 1_3 inherited default behavior - compiler synthesized DefaultImpls bridge is detected`() {
+    val method = classFileWithMetadata(
+      methodNode = legacyDefaultImplsBridge("defaultMethod"),
+      declaredFunctions = emptyList(),
+      interfaces = listOf(TEST_CHILD_INTERFACE_NAME)
+    ).methods.single()
+
+    assertTrue(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `jvm-default enable compatibility - compiler synthesized interface default bridge is detected`() {
+    val method = classFileWithMetadata(
+      methodNode = jvmDefaultBridge("defaultMethod"),
+      declaredFunctions = emptyList()
+    ).methods.single()
+
+    assertTrue(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `jvm-default enable compatibility inherited default - compiler synthesized interface default bridge is detected`() {
+    val method = classFileWithMetadata(
+      methodNode = jvmDefaultBridge("defaultMethod"),
+      declaredFunctions = emptyList(),
+      interfaces = listOf(TEST_CHILD_INTERFACE_NAME)
+    ).methods.single()
+
+    assertTrue(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `jvm-default no-compatibility - declared interface default method is not a synthesized bridge`() {
+    val methodName = "defaultMethod"
+    val method = classFileWithMetadata(
+      methodNode = interfaceDefaultMethod(methodName),
+      declaredFunctions = listOf(JvmMethodSignature(methodName, "()V")),
+      classAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT,
+    ).methods.single()
+
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `inherited default explicitly overridden in source is not detected as compiler synthesized bridge`() {
+    val methodName = "defaultMethod"
+    val method = classFileWithMetadata(
+      methodNode = jvmDefaultBridge(methodName),
+      declaredFunctions = listOf(JvmMethodSignature(methodName, "()V")),
+      interfaces = listOf(TEST_CHILD_INTERFACE_NAME)
+    ).methods.single()
+
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `legacy JvmDefault annotated interface method is not detected as compiler synthesized bridge`() {
+    val methodName = "defaultMethod"
+    val method = classFileWithMetadata(
+      methodNode = legacyJvmDefaultAnnotatedInterfaceMethod(methodName),
+      declaredFunctions = listOf(JvmMethodSignature(methodName, "()V")),
+      classAccess = Opcodes.ACC_PUBLIC or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT,
+    ).methods.single()
+
+    assertTrue(method.annotations.any { it.desc == "Lkotlin/jvm/JvmDefault;" })
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `developer declared override is not detected as compiler synthesized bridge`() {
+    val methodName = "defaultMethod"
+    val method = classFileWithMetadata(
+      methodNode = jvmDefaultBridge(methodName),
+      declaredFunctions = listOf(JvmMethodSignature(methodName, "()V"))
+    ).methods.single()
+
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `abstract Kotlin method is not detected as compiler synthesized bridge`() {
+    val methodName = "abstractMethod"
+    val method = classFileWithMetadata(
+      methodNode = abstractMethod(methodName),
+      declaredFunctions = emptyList()
+    ).methods.single()
+
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  @Test
+  fun `non Kotlin method is not detected as compiler synthesized bridge`() {
+    val classFile = classFile(plainMethod("javaMethod"))
+    val method = classFile.methods.single()
+
+    assertFalse(method.isCompilerSynthesizedInterfaceBridge())
+  }
+
+  /**
+   * Builds a JVM class that looks like a Kotlin class to [KotlinMethods]:
+   * it contains exactly [methodNode], and its `@kotlin.Metadata` lists exactly [declaredFunctions].
+   *
+   * This lets the tests model the important Kotlin source distinction:
+   * a method listed in metadata is something the source class declared, while a concrete method that
+   * exists in bytecode but is missing from metadata is something the compiler synthesized.
+   *
+   * For example, the referenced interface in these samples looks like this:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   fun defaultMethod() {
+   *     // default implementation
+   *   }
+   * }
+   * ```
+   *
+   * This models a source-declared override:
+   *
+   * ```
+   * class KotlinDefaultMethodOwner : KotlinDefaultInterface {
+   *   override fun defaultMethod() = super.defaultMethod()
+   * }
+   * ```
+   *
+   * by passing a concrete `defaultMethod` [MethodNode] and
+   * `declaredFunctions = listOf(JvmMethodSignature("defaultMethod", "()V"))`.
+   *
+   * The synthesized bridge case uses the same concrete [MethodNode], but passes
+   * `declaredFunctions = emptyList()` to model Kotlin source that did not declare the override:
+   *
+   * ```
+   * class KotlinDefaultMethodOwner : KotlinDefaultInterface
+   * ```
+   */
+  private fun classFileWithMetadata(
+    methodNode: MethodNode,
+    declaredFunctions: List<JvmMethodSignature>,
+    classAccess: Int = Opcodes.ACC_PUBLIC or Opcodes.ACC_SUPER,
+    interfaces: List<String> = emptyList()
+  ): ClassFileAsm = classFile(methodNode, interfaces).also { classFile ->
+    classFile.asmNode.access = classAccess
+    classFile.asmNode.visibleAnnotations = mutableListOf(kotlinMetadata(declaredFunctions))
+  }
+
+  /**
+   * Builds the minimal ASM-backed [ClassFileAsm] wrapper used by the production verifier code.
+   *
+   * In source terms this is a simple class such as:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   fun defaultMethod() {
+   *     // default implementation
+   *   }
+   * }
+   *
+   * class KotlinDefaultMethodOwner : KotlinDefaultChildInterface {
+   *   // methodNode goes here
+   * }
+   * ```
+   *
+   * If [interfaces] contains `KotlinDefaultChildInterface`, the generated bytecode corresponds to
+   * that `: KotlinDefaultChildInterface` clause. If [interfaces] is empty, the generated bytecode
+   * corresponds to:
+   *
+   * ```
+   * class KotlinDefaultMethodOwner {
+   *   // methodNode goes here
+   * }
+   * ```
+   *
+   * The optional [interfaces] list is only there to make inherited-default scenarios visible in the
+   * class shape. The detector itself does not walk those interfaces; it classifies the concrete
+   * [MethodNode] that the Kotlin compiler has already emitted into this class.
+   */
+  private fun classFile(methodNode: MethodNode, interfaces: List<String> = emptyList()): ClassFileAsm {
+    val classNode = ClassNode(Opcodes.ASM9).apply {
+      version = Opcodes.V1_8
+      access = Opcodes.ACC_PUBLIC or Opcodes.ACC_SUPER
+      name = TEST_CLASS_NAME
+      superName = "java/lang/Object"
+      this.interfaces = interfaces.toMutableList()
+      methods = mutableListOf(methodNode)
+    }
+    return ClassFileAsm(classNode, origin)
+  }
+
+  /**
+   * Models old Kotlin default-interface lowering, roughly:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   fun defaultMethod() { ... }
+   * }
+   *
+   * class KotlinDefaultMethodOwner : KotlinDefaultInterface
+   * ```
+   *
+   * Old Kotlin compilers emitted a concrete method into the implementing class that forwards to the
+   * static helper `KotlinDefaultInterface$DefaultImpls.defaultMethod(this)`.
+   *
+   * In Java-like pseudocode, the emitted owner class method looks like this:
+   *
+   * ```
+   * public final class KotlinDefaultMethodOwner implements KotlinDefaultInterface {
+   *   public void defaultMethod() {
+   *     KotlinDefaultInterface.DefaultImpls.defaultMethod(this);
+   *   }
+   * }
+   * ```
+   *
+   * The Kotlin source did not declare `defaultMethod()` in `KotlinDefaultMethodOwner`, so the test
+   * omits this method from the owner's `@kotlin.Metadata` function list.
+   */
+  private fun legacyDefaultImplsBridge(methodName: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, methodName, "()V", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(
+        MethodInsnNode(
+          Opcodes.INVOKESTATIC,
+          "$TEST_INTERFACE_NAME\$DefaultImpls",
+          methodName,
+          "(L$TEST_INTERFACE_NAME;)V",
+          false
+        )
+      )
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  /**
+   * Models newer compatibility lowering for an inherited interface default method, roughly:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   fun defaultMethod() { ... }
+   * }
+   *
+   * class KotlinDefaultMethodOwner : KotlinDefaultInterface
+   * ```
+   *
+   * In compatibility mode the compiler can emit an implementing-class method whose body forwards
+   * directly to the interface default via `invokespecial KotlinDefaultInterface.defaultMethod()`.
+   * A developer-written `override fun defaultMethod() = super.defaultMethod()` may have the same
+   * bytecode, so metadata is what distinguishes source-declared overrides from synthesized bridges.
+   */
+  private fun jvmDefaultBridge(methodName: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, methodName, "()V", null, null).apply {
+      instructions.add(VarInsnNode(Opcodes.ALOAD, 0))
+      instructions.add(
+        MethodInsnNode(
+          Opcodes.INVOKESPECIAL,
+          TEST_INTERFACE_NAME,
+          methodName,
+          "()V",
+          true
+        )
+      )
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  /**
+   * Models `-jvm-default=no-compatibility`, where the default implementation is the interface
+   * method itself:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   fun defaultMethod() { ... }
+   * }
+   * ```
+   *
+   * There is no synthetic implementing-class bridge in this row, so the detector should not classify
+   * this declared interface method as synthesized.
+   */
+  private fun interfaceDefaultMethod(methodName: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, methodName, "()V", null, null).apply {
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  /**
+   * Models the legacy experimental source form:
+   *
+   * ```
+   * interface KotlinDefaultInterface {
+   *   @JvmDefault
+   *   fun defaultMethod() { ... }
+   * }
+   * ```
+   *
+   * Unlike `@JvmDefaultWithCompatibility` and `@JvmDefaultWithoutCompatibility`, this old annotation
+   * can be runtime-visible in bytecode. It still marks a source-declared interface method, not a
+   * compiler-synthesized bridge in an implementing class.
+   */
+  private fun legacyJvmDefaultAnnotatedInterfaceMethod(methodName: String): MethodNode =
+    interfaceDefaultMethod(methodName).apply {
+      visibleAnnotations = mutableListOf(AnnotationNode("Lkotlin/jvm/JvmDefault;"))
+    }
+
+  /**
+   * Models an ordinary Java method:
+   *
+   * ```
+   * class KotlinDefaultMethodOwner {
+   *   public void javaMethod() {}
+   * }
+   * ```
+   *
+   * With no `@kotlin.Metadata` on the containing class, Kotlin-specific bridge detection must stay
+   * off.
+   */
+  private fun plainMethod(methodName: String): MethodNode =
+    MethodNode(Opcodes.ACC_PUBLIC, methodName, "()V", null, null).apply {
+      instructions.add(InsnNode(Opcodes.RETURN))
+    }
+
+  /**
+   * Models a Kotlin abstract declaration:
+   *
+   * ```
+   * abstract class KotlinDefaultMethodOwner {
+   *   abstract fun abstractMethod()
+   * }
+   * ```
+   *
+   * Abstract methods have no bytecode body, so they cannot be synthesized forwarding bridges.
+   */
+  private fun abstractMethod(methodName: String): MethodNode =
+    MethodNode(
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT,
+      methodName,
+      "()V",
+      null,
+      null
+    )
+
+  /**
+   * Creates the `@kotlin.Metadata` annotation that Kotlin would attach to the containing class.
+   *
+   * The only part relevant to these tests is the function list. If a JVM method signature appears
+   * here, it means the Kotlin source declared that function in this class. If a concrete method is
+   * present in bytecode but absent from this list, [KotlinMethods.isCompilerSynthesizedInterfaceBridge]
+   * treats it as compiler-generated.
+   */
+  private fun kotlinMetadata(declaredFunctions: List<JvmMethodSignature>): AnnotationNode {
+    val metadata = KotlinClassMetadata.Class(
+      KmClass().apply {
+        name = TEST_CLASS_NAME
+        functions += declaredFunctions.map { signature ->
+          KmFunction(signature.name).apply {
+            this.signature = signature
+            returnType = KmType().apply {
+              classifier = KmClassifier.Class("kotlin/Unit")
+            }
+          }
+        }
+      },
+      JvmMetadataVersion.LATEST_STABLE_SUPPORTED,
+      0
+    ).write()
+
+    return AnnotationNode("Lkotlin/Metadata;").apply {
+      values = mutableListOf(
+        "k", metadata.kind,
+        "mv", metadata.metadataVersion.toList(),
+        "d1", metadata.data1.toList(),
+        "d2", metadata.data2.toList()
+      )
+    }
+  }
+
+  private companion object {
+    const val TEST_CLASS_NAME = "com/jetbrains/pluginverifier/tests/KotlinDefaultMethodOwner"
+    const val TEST_INTERFACE_NAME = "com/jetbrains/pluginverifier/tests/KotlinDefaultInterface"
+    const val TEST_CHILD_INTERFACE_NAME = "com/jetbrains/pluginverifier/tests/KotlinDefaultChildInterface"
+
+    val origin = object : FileOrigin {
+      override val parent = null
+    }
+  }
+}


### PR DESCRIPTION
Separated from #1555 , a hard-requirement for kotlin version bump, but it has some performance and semantics impact.

Also relevant for https://github.com/JetBrains/intellij-plugin-verifier/pull/1560