### PR TITLE
Optimize memory usage by moving the resolved edge index to pretty-printer

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
@@ -66,17 +66,12 @@ data class ResolvedDependenciesGraph(
   val edges: Set<ResolvedDependencyEdge>,
   val missingDependencies: Map<ResolvedDependencyNode, Set<ResolvedMissingDependency>>
 ) {
-  // Adjacency index: getEdgesFrom is invoked once per node when pretty-printing the graph,
-  // and a linear scan over all edges each time makes that traversal O(V*E).
-  private val edgesFromNode: Map<ResolvedDependencyNode, List<ResolvedDependencyEdge>> by lazy {
-    edges.groupBy { it.from }
-  }
-
   fun getDirectMissingDependencies(): Set<ResolvedMissingDependency> =
     missingDependencies.getOrDefault(verifiedPlugin, emptySet())
 
+  @Deprecated("Build an index from 'edges' when repeated lookups are needed")
   fun getEdgesFrom(node: ResolvedDependencyNode): List<ResolvedDependencyEdge> =
-    edgesFromNode[node].orEmpty()
+    edges.filter { it.from == node }
 }
 
 /**

--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/presentation/ResolvedDependenciesGraphPrettyPrinter.kt
@@ -26,6 +26,7 @@ import com.jetbrains.pluginverifier.dependencies.ResolvedDependencyNode
 class ResolvedDependenciesGraphPrettyPrinter(private val graph: ResolvedDependenciesGraph) {
 
   private val visitedNodes = hashSetOf<ResolvedDependencyNode>()
+  private val edgesFromNode = graph.edges.groupBy { it.from }
 
   fun prettyPresentation(): String {
     val result = StringBuilder()
@@ -41,7 +42,7 @@ class ResolvedDependenciesGraphPrettyPrinter(private val graph: ResolvedDependen
       .getOrDefault(currentNode, emptySet())
       .sortedBy { it.dependency.id }
 
-    val directEdges = graph.getEdgesFrom(currentNode)
+    val directEdges = edgesFromNode[currentNode].orEmpty()
       .sortedWith(
         compareBy<ResolvedDependencyEdge> { if (it.dependency.isOptional) 1 else -1 }
           .thenBy { if (it.dependency.isModule) 1 else -1 }


### PR DESCRIPTION
Adjacency index used for dependency graph printingis currently lazily stored in every `ResolvedDependenciesGraph`. Once the dependency report is printed, thousands of results retain those indexes until the whole `check-trunk-api` batch finishes. 

This PR moves the index to the existing pretty-printer instead, so it only lives while the graph is being rendered.