### PR TITLE
Use compact set for resolved dependency edges

### DIFF
--- a/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
+++ b/intellij-plugin-verifier/verifier-intellij/src/main/java/com/jetbrains/pluginverifier/dependencies/ResolvedDependenciesGraph.kt
@@ -108,13 +108,13 @@ fun DependenciesGraph.toResolved(batchContext: PluginVerifierBatchContext? = nul
     ResolvedDependencyNode(node.id.dedup(), node.version.dedup(), aliases, isProductModule).dedup()
   }
 
-  val resolvedEdges = edges.mapTo(hashSetOf()) { edge ->
+  val resolvedEdges = java.util.Set.copyOf(edges.map { edge ->
     ResolvedDependencyEdge(
       nodeMap.getValue(edge.from),
       nodeMap.getValue(edge.to),
       ResolvedPluginDependency(edge.dependency.id.dedup(), edge.dependency.isOptional, edge.dependency.isModule).dedup()
     ).dedup()
-  }.dedup()
+  }).dedup()
 
   val resolvedMissingDeps = missingDependencies.entries.associate { (node, missing) ->
     nodeMap.getValue(node) to missing.mapTo(hashSetOf()) { md ->


### PR DESCRIPTION
Currently, we deduplicate the dependency edges themselves across verification results, but each result still keeps its own large `HashSet` containing those shared edges. 

In the OOM heap this accounts for several GB mostly in `HashMap` nodes/tables. 

This PR switches the retained edge set to the JDK compact immutable representation without changing the graph API or contents.