### PR TITLE
Cache ZIPs and JARs in the `ContentModuleScanner` to improve perfomance

### DIFF
--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/loaders/LibDirectoryPluginLoader.kt
@@ -133,8 +133,8 @@ internal class LibDirectoryPluginLoader(
   }
 
   /**
-   * Returns those [files] of the `lib` directory that can provide [descriptorPath]: JARs indexed as containing
-   * such a descriptor, along with every directory, as directories are not indexed.
+   * Returns those [files] of the `lib` directory that can provide [descriptorPath]: archives indexed as
+   * containing such a descriptor, along with every directory, as directories are not indexed.
    *
    * All [files] are returned for a [descriptorPath] the index cannot answer for, see [getIndexableDescriptorName].
    * The order of [files] is retained, so that an ambiguous descriptor is reported with the same pair of files
@@ -143,8 +143,8 @@ internal class LibDirectoryPluginLoader(
   private fun getDescriptorProviders(libDirectoryParent: Path, descriptorPath: String, files: List<Path>): List<Path> {
     val descriptorName = getIndexableDescriptorName(descriptorPath) ?: return files
     val index = descriptorIndexes.computeIfAbsent(libDirectoryParent) { contentModuleScanner.getDescriptorIndex(it) }
-    val jars: Set<Path> = index[descriptorName]?.toHashSet() ?: emptySet()
-    return files.filter { it in jars || it.isDirectory }
+    val archives: Set<Path> = index[descriptorName]?.toHashSet() ?: emptySet()
+    return files.filter { it in archives || it.isDirectory }
   }
 
   /**

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -2,6 +2,9 @@ package com.jetbrains.plugin.structure.intellij.plugin.module
 
 import com.jetbrains.plugin.structure.base.utils.exists
 import com.jetbrains.plugin.structure.base.utils.hasExtension
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.isZip
+import com.jetbrains.plugin.structure.base.utils.listFiles
 import com.jetbrains.plugin.structure.base.utils.listJars
 import com.jetbrains.plugin.structure.intellij.plugin.LIB_DIRECTORY
 import com.jetbrains.plugin.structure.intellij.plugin.descriptors.createIdeaPluginXmlDetector
@@ -27,8 +30,9 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
   private val ideaPluginXmlDetector = createIdeaPluginXmlDetector()
 
   fun getContentModules(pluginArtifact: Path) : ContentModules {
-    val jarPaths = getLibJarPaths(pluginArtifact)
+    val libDir = pluginArtifact.getLibDirectory()
       ?: return ContentModules(pluginArtifact, emptyList())
+    val jarPaths = libDir.listJars() + libDir.resolve(MODULES_DIR).listJars()
     val contentModules = jarPaths.flatMap { jarPath ->
       getJarContentModules(jarPath)
     }
@@ -37,27 +41,29 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
   }
 
   /**
-   * Maps a plugin descriptor file name to the JARs of [pluginArtifact] that contain such a descriptor.
+   * Maps a plugin descriptor file name to the archives of [pluginArtifact] that contain such a descriptor.
    *
    * Keys are bare file names: a descriptor is either `META-INF/plugin.xml` or a Plugin Model V2 module
-   * descriptor in a JAR root, hence its file name identifies it within a single plugin artifact.
-   * This allows a plugin loader to open only those JARs that can provide a requested descriptor
-   * instead of every JAR of the plugin.
+   * descriptor in an archive root, hence its file name identifies it within a single plugin artifact.
+   * This allows a plugin loader to open only those archives that can provide a requested descriptor
+   * instead of every archive of the plugin.
+   *
+   * Both JARs and ZIPs are indexed, as a plugin loader searches a descriptor in either of them.
    */
   fun getDescriptorIndex(pluginArtifact: Path): Map<String, List<Path>> {
-    val jarPaths = getLibJarPaths(pluginArtifact) ?: return emptyMap()
-    return jarPaths
-      .flatMap { jarPath -> getJarDescriptorNames(jarPath).map { descriptorName -> descriptorName to jarPath } }
-      .groupBy({ (descriptorName, _) -> descriptorName }, { (_, jarPath) -> jarPath })
+    val libDir = pluginArtifact.getLibDirectory() ?: return emptyMap()
+    val archivePaths = libDir.listArchives() + libDir.resolve(MODULES_DIR).listArchives()
+    return archivePaths
+      .flatMap { archivePath -> getJarDescriptorNames(archivePath).map { descriptorName -> descriptorName to archivePath } }
+      .groupBy({ (descriptorName, _) -> descriptorName }, { (_, archivePath) -> archivePath })
   }
 
-  private fun getLibJarPaths(pluginArtifact: Path): List<Path>? {
-    val libDir = pluginArtifact.resolve(LIB_DIRECTORY)
-    if (!libDir.exists()) {
-      return null
-    }
-    return libDir.listJars() + libDir.resolve(MODULES_DIR).listJars()
-  }
+  private fun Path.getLibDirectory(): Path? = resolve(LIB_DIRECTORY).takeIf { it.exists() }
+
+  /**
+   * Lists the archives of this directory that a plugin loader can search for a descriptor.
+   */
+  private fun Path.listArchives(): List<Path> = listFiles().filter { it.isJar() || it.isZip() }
 
   private fun getJarContentModules(jarPath: Path): List<ContentModule> = withPluginJar(jarPath) { jar ->
     jar.resolveDescriptors { it.isDescriptor() }

--- a/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
+++ b/intellij-plugin-structure/structure-intellij/src/main/java/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScanner.kt
@@ -49,11 +49,14 @@ class ContentModuleScanner(private val fileSystemProvider: JarFileSystemProvider
    * instead of every archive of the plugin.
    *
    * Both JARs and ZIPs are indexed, as a plugin loader searches a descriptor in either of them.
+   *
+   * Only the `lib` directory itself is indexed, not its `modules` subdirectory: a plugin loader picks a
+   * descriptor provider among the direct children of `lib`, so an archive nested deeper can never be chosen
+   * from this index and indexing it would only open it for nothing.
    */
   fun getDescriptorIndex(pluginArtifact: Path): Map<String, List<Path>> {
     val libDir = pluginArtifact.getLibDirectory() ?: return emptyMap()
-    val archivePaths = libDir.listArchives() + libDir.resolve(MODULES_DIR).listArchives()
-    return archivePaths
+    return libDir.listArchives()
       .flatMap { archivePath -> getJarDescriptorNames(archivePath).map { descriptorName -> descriptorName to archivePath } }
       .groupBy({ (descriptorName, _) -> descriptorName }, { (_, archivePath) -> archivePath })
   }

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ContentModuleDescriptorResolutionTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/ContentModuleDescriptorResolutionTest.kt
@@ -64,6 +64,40 @@ class ContentModuleDescriptorResolutionTest {
   }
 
   @Test
+  fun `content module descriptor available in a ZIP of the lib directory is resolved`() {
+    /*
+    A `lib` directory archive is searched for a descriptor whether it is a JAR or a ZIP, so the descriptor
+    index must cover both. Indexing JARs alone silently left such a content module unresolved.
+    Note that a ZIP is still absent from the resolved classpath, which is derived from JARs only.
+    */
+    val pluginPath = buildPlugin("zip-provider", moduleNames = listOf("example.module"), moduleJarNames = listOf("modules.zip"), auxiliaryJarCount = 3)
+
+    val plugin = createPlugin(pluginPath)
+
+    assertEquals("example.module", plugin.modulesDescriptors.single().name)
+  }
+
+  @Test
+  fun `content module descriptor available in both a JAR and a ZIP is reported as ambiguous and is not resolved`() {
+    val pluginPath = buildPlugin(
+      "mixed-archive-providers",
+      moduleNames = listOf("example.module"),
+      moduleJarNames = listOf("modules-a.jar", "modules-b.zip"),
+      auxiliaryJarCount = 3
+    )
+
+    val creationResult = createManager(SingletonCachingJarFileSystemProvider).createPlugin(pluginPath, false)
+    assertTrue("Expected a successfully created plugin but got $creationResult", creationResult is PluginCreationSuccess)
+    creationResult as PluginCreationSuccess
+
+    assertTrue("Expected an unresolved module but got ${creationResult.plugin.modulesDescriptors}", creationResult.plugin.modulesDescriptors.isEmpty())
+
+    val ambiguityWarnings = creationResult.warnings.filter { it.message.contains("Found multiple plugin descriptors") }
+    assertEquals("Expected a single ambiguity warning but got ${creationResult.warnings}", 1, ambiguityWarnings.size)
+    assertTrue(ambiguityWarnings.single().message.contains("example.module"))
+  }
+
+  @Test
   fun `content module descriptors are not searched for in every JAR of the plugin`() {
     val moduleNames = (1..10).map { "example.module$it" }
 

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/intellij/plugin/module/ContentModuleScannerTest.kt
@@ -94,6 +94,37 @@ class ContentModuleScannerTest {
   }
 
   @Test
+  fun `descriptor index covers ZIP archives of the lib directory`() {
+    val root = temporaryFolder.root.toPath()
+
+    val pluginPath = buildDirectory(temporaryFolder.newFolder("zipped").toPath()) {
+      dir("lib") {
+        zip("main.jar") {
+          dir("META-INF") {
+            file("plugin.xml", "<idea-plugin />")
+          }
+        }
+        zip("modules.zip") {
+          file("intellij.zipped.xml", "<idea-plugin />")
+        }
+      }
+    }
+
+    val descriptorIndex = ContentModuleScanner(jarFileSystemProvider).getDescriptorIndex(pluginPath)
+
+    val indexedPaths = descriptorIndex.mapValues { (_, archivePaths) ->
+      archivePaths.map { root.relativize(it).invariantSeparatorsPathString }.sorted()
+    }
+    assertEquals(
+      mapOf(
+        "plugin.xml" to listOf("zipped/lib/main.jar"),
+        "intellij.zipped.xml" to listOf("zipped/lib/modules.zip")
+      ),
+      indexedPaths
+    )
+  }
+
+  @Test
   fun `no content modules are found in a corrupted artifact`() {
     val pluginPath = buildDirectory(temporaryFolder.newFolder("corrupted").toPath()) {
       dir("lib") {


### PR DESCRIPTION
This PR https://github.com/JetBrains/intellij-plugin-verifier/pull/1567 had an additional comment about a potential issue.

This PR is the fix of that issue.