### PR TITLE
Escape XML markup in randomly generated invalid plugin names in tests

### DIFF
--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/base/utils/XmlStrings.kt
@@ -52,3 +52,14 @@ internal fun getRandomInvalidXmlBasedPluginName(length: Int): String {
 internal fun String.normalizeNewLines(): String = replace("\r\n", "\n").replace("\r", "\n")
 
 private fun Int.range() = IntRange(this, this)
+
+/**
+ * Escape the characters that are not allowed to appear literally in XML character data.
+ *
+ * A randomly generated plugin name may contain `<`, which would corrupt the descriptor and make the parser
+ * report a malformed-XML problem instead of the expected invalid-name problem.
+ *
+ * Carriage returns are deliberately left unescaped, so that they keep being normalized by the XML parser
+ * according to [normalizeNewLines].
+ */
+internal fun String.escapeXmlCharacterData(): String = replace("&", "&amp;").replace("<", "&lt;")

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/mocks/InvalidPluginsTest.kt
@@ -4,6 +4,7 @@ import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.problems.*
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildDirectory
 import com.jetbrains.plugin.structure.base.utils.contentBuilder.buildZipFile
+import com.jetbrains.plugin.structure.base.utils.escapeXmlCharacterData
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
 import com.jetbrains.plugin.structure.base.utils.normalizeNewLines
 import com.jetbrains.plugin.structure.base.utils.simpleName
@@ -209,11 +210,22 @@ class InvalidPluginsTest(fileSystemType: FileSystemType) : IdePluginManagerTest(
       val pluginName = "bla ${getRandomInvalidXmlBasedPluginName(i)}bla"
       `test invalid plugin xml`(
         perfectXmlBuilder.modify {
-          name = "<name>$pluginName</name>"
+          name = "<name>${pluginName.escapeXmlCharacterData()}</name>"
         },
         listOf(InvalidPluginName("plugin.xml", pluginName.normalizeNewLines()))
       )
     }
+  }
+
+  @Test
+  fun `plugin name contains an XML markup character`() {
+    val pluginName = "bla <bla"
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        name = "<name>${pluginName.escapeXmlCharacterData()}</name>"
+      },
+      listOf(InvalidPluginName("plugin.xml", pluginName))
+    )
   }
 
   @Test

--- a/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
+++ b/intellij-plugin-structure/tests/src/test/kotlin/com/jetbrains/plugin/structure/teamcity/mock/TeamcityInvalidPluginsTest.kt
@@ -5,6 +5,7 @@ import com.jetbrains.plugin.structure.base.problems.PluginDescriptorIsNotFound
 import com.jetbrains.plugin.structure.base.problems.PluginProblem
 import com.jetbrains.plugin.structure.base.problems.PropertyNotSpecified
 import com.jetbrains.plugin.structure.base.problems.UnexpectedDescriptorElements
+import com.jetbrains.plugin.structure.base.utils.escapeXmlCharacterData
 import com.jetbrains.plugin.structure.base.utils.getRandomInvalidXmlBasedPluginName
 import com.jetbrains.plugin.structure.base.utils.normalizeNewLines
 import com.jetbrains.plugin.structure.base.utils.simpleName
@@ -121,11 +122,22 @@ class TeamcityInvalidPluginsTest(fileSystemType: FileSystemType) : BasePluginMan
       }
       `test invalid plugin xml`(
         perfectXmlBuilder.modify {
-          displayName = "<display-name>$name</display-name>"
+          displayName = "<display-name>${name.escapeXmlCharacterData()}</display-name>"
         },
         listOf(expectedProblems)
       )
     }
+  }
+
+  @Test
+  fun `plugin display name contains an XML markup character`() {
+    val name = "\n\u8CDF\u0ACD<\n\n"
+    `test invalid plugin xml`(
+      perfectXmlBuilder.modify {
+        displayName = "<display-name>${name.escapeXmlCharacterData()}</display-name>"
+      },
+      listOf(InvalidPluginName("teamcity-plugin.xml", name.normalizeNewLines()))
+    )
   }
 
   @Test


### PR DESCRIPTION
Escape XML markup in randomly generated invalid plugin names in tests. 
Focusing on random XML `<` being generated.